### PR TITLE
feat: expose maestro noise models + multi-observable QEM

### DIFF
--- a/divi/backends/_maestro_simulator.py
+++ b/divi/backends/_maestro_simulator.py
@@ -462,7 +462,8 @@ class MaestroSimulator(CircuitRunner):
                             maestro_circuit,
                             observables=pauli_string,
                             noise_model=self.noise_config["noise_model"],
-                            noise_realizations=self.noise_config["noise_realizations"] or 1,
+                            noise_realizations=self.noise_config["noise_realizations"],
+                            seed=self.noise_config["noise_seed"],
                             config=sim_config,
                         )
                 ops = pauli_string.split(";")

--- a/divi/backends/_maestro_simulator.py
+++ b/divi/backends/_maestro_simulator.py
@@ -58,6 +58,31 @@ def _strip_measurements(qasm: str) -> str:
     return re.sub(r"measure\s+q\[\d+\]\s*->\s*\w+\[\d+\]\s*;\n?", "", qasm)
 
 
+def _resolve_noise_realizations(
+    realizations: int | None, *, sampling: bool
+) -> int | None:
+    """Validate ``noise_realizations`` and resolve the backend dispatch.
+
+    Returns ``None`` to signal "use the analytical backend" (expval only),
+    or a positive ``int`` to forward to a Monte-Carlo entry point.
+
+    Sampling has no analytical equivalent, so ``None`` collapses to ``1``
+    (a single noise realization).  Maestro's native default for
+    ``noisy_execute`` is 64; divi deliberately uses 1 to avoid silently
+    multiplying the shot budget.
+
+    Zero or negative values raise ``ValueError`` — they have no meaningful
+    MC interpretation and ``None`` already covers the analytical path.
+    """
+    if realizations is None:
+        return 1 if sampling else None
+    if realizations < 1:
+        raise ValueError(
+            f"noise_realizations must be None or a positive integer, got {realizations}."
+        )
+    return realizations
+
+
 @dataclass(frozen=True)
 class MaestroConfig:
     """Configuration object for :class:`MaestroSimulator`.
@@ -115,6 +140,58 @@ class MaestroConfig:
     ``simulation_type`` is set explicitly.  Divi-specific; not forwarded to
     ``maestro.SimulatorConfig``."""
 
+    noise_model: "maestro.NoiseModel | None" = None
+    """Maestro ``NoiseModel`` object.  ``None`` (default) disables noise —
+    circuits run via ``simple_execute`` (sampling) or ``simple_estimate``
+    (expval).  When set, dispatch routes to ``noisy_execute`` /
+    ``noisy_estimate`` / ``noisy_estimate_montecarlo`` depending on
+    :attr:`noise_realizations`.  Divi-specific; not forwarded to
+    ``maestro.SimulatorConfig`` — Maestro keeps noise models separate from
+    simulator config and accepts them positionally on the noisy entry points."""
+
+    noise_seed: int = 42
+    """Seed for Pauli-error sampling.  Consulted whenever execution routes
+    through one of Maestro's stochastic noisy entry points
+    (``noisy_execute`` or ``noisy_estimate_montecarlo``); the analytical
+    ``noisy_estimate`` path ignores it.  Each circuit in a
+    :meth:`MaestroSimulator.submit_circuits` batch is seeded with
+    ``noise_seed + i`` (where ``i`` is the circuit's index in the input
+    mapping) so circuits in the same batch get independent error patterns.
+
+    Reproducibility scope: the seed pins the **Pauli error patterns**
+    sampled from the noise model.  Expectation-value runs
+    (``noisy_estimate_montecarlo``) are fully reproducible because the
+    inner loop is analytical.  Noisy *sampling* runs (``noisy_execute``)
+    are only partially reproducible: the same Pauli errors are injected,
+    but the shot-count outcomes still vary across runs because Maestro's
+    measurement sampler initialises its own RNG from system entropy on
+    every call.
+
+    Divi-specific; not forwarded to ``maestro.SimulatorConfig``."""
+
+    noise_realizations: int | None = None
+    """Number of Monte-Carlo noise realizations.  ``None`` (default) selects
+    the analytical noisy backend when available:
+
+    * **Expval** — ``maestro.noisy_estimate``, which applies exact Pauli
+      damping coefficients to noiseless expectation values.  Deterministic.
+    * **Sampling** — no analytical equivalent; falls back to one realization
+      (``noisy_execute`` with ``noise_realizations=1``).
+
+    A positive ``int`` ``N`` selects Monte-Carlo backends:
+
+    * **Expval** — ``maestro.noisy_estimate_montecarlo``, which runs ``N``
+      independent Pauli-injection passes and averages the expectation values.
+    * **Sampling** — ``maestro.noisy_execute``, which divides ``shots``
+      across ``min(shots, N)`` batches, each with a freshly sampled noise
+      pattern.  Total shot count is always ``shots``; if ``N > shots`` the
+      effective realization count is capped at ``shots``.
+
+    Note that ``noise_realizations=1`` is **not** equivalent to ``None``
+    for expval — the former is one random Pauli sampling, the latter is
+    the exact analytical average.  Divi-specific; not forwarded to
+    ``maestro.SimulatorConfig``."""
+
     def override(self, other: "MaestroConfig") -> "MaestroConfig":
         """Return a new config overriding fields with non-default values from ``other``.
 
@@ -127,6 +204,11 @@ class MaestroConfig:
 
         for f in fields(MaestroConfig):
             other_value = getattr(other, f.name)
+            # Relies on != with the default sentinel.  Safe for scalar fields and
+            # for noise_model because None is the default — any non-None object
+            # evaluates != None as True.  If two non-None NoiseModel instances ever
+            # need to be distinguished by value equality this logic would need
+            # an identity check (``is not``) instead.
             if other_value != defaults[f.name]:
                 merged[f.name] = other_value
 
@@ -202,14 +284,14 @@ class MaestroSimulator(CircuitRunner):
     PauliPropagator), intelligent auto-routing, GPU acceleration, and native observable
     estimation.
 
-    All maestro-level configuration is carried in a :class:`MaestroConfig` object
-    rather than as loose keyword arguments, matching the
+    All maestro-level configuration — including noise — is carried in a
+    :class:`MaestroConfig` object rather than as loose keyword arguments,
+    matching the
     :class:`~divi.backends.ExecutionConfig` / :class:`~divi.backends.QoroService`
-    pattern.
-
-    Noise is handled separately from the rest of the configuration to respect the
-    existing architecture of MaestroConfig in Maestro, which decouples noise models
-    from simulators (running multiple noise models in one simulator allowed).
+    pattern.  Pass a ``maestro.NoiseModel`` via :attr:`MaestroConfig.noise_model`
+    (and tune :attr:`MaestroConfig.noise_seed` and
+    :attr:`MaestroConfig.noise_realizations`) to route execution through
+    Maestro's noisy entry points.
 
     .. note::
 
@@ -220,8 +302,8 @@ class MaestroSimulator(CircuitRunner):
     Args:
         shots: Number of measurement shots. Defaults to 5000.
         config: :class:`MaestroConfig` controlling simulator backend, simulation
-            method, bond dimension, and related knobs.  Defaults to
-            ``MaestroConfig()``.
+            method, bond dimension, noise model, and related knobs.  Defaults
+            to ``MaestroConfig()``.
         track_depth: Record circuit depth per submission. Defaults to False.
     """
 
@@ -230,9 +312,6 @@ class MaestroSimulator(CircuitRunner):
         shots: int = 5000,
         config: MaestroConfig | None = None,
         track_depth: bool = False,
-        noise_model: maestro.NoiseModel | None = None,
-        noise_seed: int | None = 42,
-        noise_realizations: int | None = None,
     ):
         if maestro is None:
             raise ImportError(
@@ -241,7 +320,6 @@ class MaestroSimulator(CircuitRunner):
 
         super().__init__(shots=shots, track_depth=track_depth)
         self.config: MaestroConfig = config if config is not None else MaestroConfig()
-        self.noise_config = {"noise_model": noise_model, "noise_seed": noise_seed, "noise_realizations": noise_realizations}
 
         # Per-instance circuit fan-out pool, lazy-initialized on first
         # ``submit_circuits`` call.  Maestro's C++ entrypoints release the
@@ -264,7 +342,7 @@ class MaestroSimulator(CircuitRunner):
         """Maestro executes circuits synchronously."""
         return False
 
-    def set_seed(self, seed: int) -> None:
+    def set_seed(self, seed: int) -> None:  # noqa: ARG002 — CircuitRunner interface
         """No-op — maestro does not yet expose seeding from C++."""
 
     def _get_executor(self) -> ThreadPoolExecutor:
@@ -410,19 +488,24 @@ class MaestroSimulator(CircuitRunner):
                     if per_circuit_shots is not None
                     else self.shots
                 )
-                if self.noise_config["noise_model"] is None:
+                if self.config.noise_model is None:
                     raw = maestro.simple_execute(qasm, config=sim_config, shots=shots)
                 else:
-                    # unlike simple_estimate, the noisy functions take in a maestro Circuit object
+                    # Noisy functions require a parsed maestro Circuit, not a raw QASM string.
                     circuit_parser = maestro.QasmToCirc()
                     maestro_circuit = circuit_parser.parse_and_translate(qasm)
+                    realizations = _resolve_noise_realizations(
+                        self.config.noise_realizations, sampling=True
+                    )
                     raw = maestro.noisy_execute(
                         maestro_circuit,
-                        self.noise_config["noise_model"],
+                        self.config.noise_model,
                         config=sim_config,
                         shots=shots,
-                        noise_realizations=self.noise_config["noise_realizations"] or 1,
-                        seed=self.noise_config["noise_seed"],
+                        noise_realizations=realizations,
+                        # Derive a per-circuit seed so circuits in a batch don't
+                        # all receive the same Pauli error pattern.
+                        seed=self.config.noise_seed + i,
                     )
                 counts = {bs[::-1]: n for bs, n in raw["counts"].items()}
                 return {"label": label, "results": counts}
@@ -440,30 +523,37 @@ class MaestroSimulator(CircuitRunner):
                 pauli_string = self._get_ham_ops_for_circuit(
                     i, ham_ops, circuit_ham_map
                 )
-                if self.noise_config["noise_model"] is None:
+                if self.config.noise_model is None:
                     raw = maestro.simple_estimate(
                         _strip_measurements(qasm),
                         observables=pauli_string,
                         config=sim_config,
                     )
                 else:
-                    # unlike simple_estimate, the noisy functions take in a maestro Circuit object
+                    # Noisy functions require a parsed maestro Circuit, not a raw QASM string.
                     circuit_parser = maestro.QasmToCirc()
-                    maestro_circuit = circuit_parser.parse_and_translate(_strip_measurements(qasm))
-                    if self.noise_config["noise_realizations"] in [None, 0]:
+                    maestro_circuit = circuit_parser.parse_and_translate(
+                        _strip_measurements(qasm)
+                    )
+                    realizations = _resolve_noise_realizations(
+                        self.config.noise_realizations, sampling=False
+                    )
+                    if realizations is None:
                         raw = maestro.noisy_estimate(
                             maestro_circuit,
                             observables=pauli_string,
-                            noise_model=self.noise_config["noise_model"],
+                            noise_model=self.config.noise_model,
                             config=sim_config,
                         )
                     else:
                         raw = maestro.noisy_estimate_montecarlo(
                             maestro_circuit,
                             observables=pauli_string,
-                            noise_model=self.noise_config["noise_model"],
-                            noise_realizations=self.noise_config["noise_realizations"],
-                            seed=self.noise_config["noise_seed"],
+                            noise_model=self.config.noise_model,
+                            noise_realizations=realizations,
+                            # Derive a per-circuit seed so circuits in a batch don't
+                            # all receive the same Pauli error pattern.
+                            seed=self.config.noise_seed + i,
                             config=sim_config,
                         )
                 ops = pauli_string.split(";")

--- a/divi/backends/_maestro_simulator.py
+++ b/divi/backends/_maestro_simulator.py
@@ -413,12 +413,15 @@ class MaestroSimulator(CircuitRunner):
                 if self.noise_config["noise_model"] is None:
                     raw = maestro.simple_execute(qasm, config=sim_config, shots=shots)
                 else:
+                    # unlike simple_estimate, the noisy functions take in a maestro Circuit object
+                    circuit_parser = maestro.QasmToCirc()
+                    maestro_circuit = circuit_parser.parse_and_translate(qasm)
                     raw = maestro.noisy_execute(
-                        qasm,
+                        maestro_circuit,
                         self.noise_config["noise_model"],
                         config=sim_config,
                         shots=shots,
-                        noise_realizations=self.noise_config["noise_realizations"],
+                        noise_realizations=self.noise_config["noise_realizations"] or 1,
                         seed=self.noise_config["noise_seed"],
                     )
                 counts = {bs[::-1]: n for bs, n in raw["counts"].items()}
@@ -444,19 +447,22 @@ class MaestroSimulator(CircuitRunner):
                         config=sim_config,
                     )
                 else:
+                    # unlike simple_estimate, the noisy functions take in a maestro Circuit object
+                    circuit_parser = maestro.QasmToCirc()
+                    maestro_circuit = circuit_parser.parse_and_translate(_strip_measurements(qasm))
                     if self.noise_config["noise_realizations"] in [None, 0]:
                         raw = maestro.noisy_estimate(
-                            _strip_measurements(qasm),
-                            self.noise_config["noise_model"],
+                            maestro_circuit,
                             observables=pauli_string,
+                            noise_model=self.noise_config["noise_model"],
                             config=sim_config,
                         )
                     else:
                         raw = maestro.noisy_estimate_montecarlo(
-                            _strip_measurements(qasm),
-                            self.noise_config["noise_model"],
-                            noise_realizations=self.noise_config["noise_realizations"],
+                            maestro_circuit,
                             observables=pauli_string,
+                            noise_model=self.noise_config["noise_model"],
+                            noise_realizations=self.noise_config["noise_realizations"] or 1,
                             config=sim_config,
                         )
                 ops = pauli_string.split(";")

--- a/divi/backends/_maestro_simulator.py
+++ b/divi/backends/_maestro_simulator.py
@@ -115,18 +115,6 @@ class MaestroConfig:
     ``simulation_type`` is set explicitly.  Divi-specific; not forwarded to
     ``maestro.SimulatorConfig``."""
 
-    noise_model: maestro.NoiseModel | None = None
-    """ Maestro NoiseModel object. Configured before passing to MaestroConfig"""
-
-    noise_seed: int | None = 42
-    """ Seed for the random noise model. Only active when :attr:`noise_model` is not `None` """
-
-    noise_realizations: int | None = None
-    """ Number of realizations to use for noise model. Only active when :attr:`noise_model` is not `None` 
-    - If `None`, no noise is actually used, instead a damping factor is computed and applied to get the expected average under the noise model
-    - If `int`, it randomly inserts Pauli gates and computes expectation values `int` times, then averages over the instances
-    ==> NB: behaviour(`None`) != behaviour(int: 1) !!! rather, behaviour(`None`) = behaviour(`int: n -> /infinity)"""
-
     def override(self, other: "MaestroConfig") -> "MaestroConfig":
         """Return a new config overriding fields with non-default values from ``other``.
 
@@ -219,6 +207,10 @@ class MaestroSimulator(CircuitRunner):
     :class:`~divi.backends.ExecutionConfig` / :class:`~divi.backends.QoroService`
     pattern.
 
+    Noise is handled separately from the rest of the configuration to respect the
+    existing architecture of MaestroConfig in Maestro, which decouples noise models
+    from simulators (running multiple noise models in one simulator allowed).
+
     .. note::
 
         Maestro's C++ extension must be loaded before other C++ libraries
@@ -238,6 +230,9 @@ class MaestroSimulator(CircuitRunner):
         shots: int = 5000,
         config: MaestroConfig | None = None,
         track_depth: bool = False,
+        noise_model: maestro.NoiseModel | None = None,
+        noise_seed: int | None = 42,
+        noise_realizations: int | None = None,
     ):
         if maestro is None:
             raise ImportError(
@@ -246,6 +241,7 @@ class MaestroSimulator(CircuitRunner):
 
         super().__init__(shots=shots, track_depth=track_depth)
         self.config: MaestroConfig = config if config is not None else MaestroConfig()
+        self.noise_config = {"noise_model": noise_model, "noise_seed": noise_seed, "noise_realizations": noise_realizations}
 
         # Per-instance circuit fan-out pool, lazy-initialized on first
         # ``submit_circuits`` call.  Maestro's C++ entrypoints release the
@@ -414,10 +410,17 @@ class MaestroSimulator(CircuitRunner):
                     if per_circuit_shots is not None
                     else self.shots
                 )
-                if self.config.noise_model is None:
+                if self.noise_config["noise_model"] is None:
                     raw = maestro.simple_execute(qasm, config=sim_config, shots=shots)
                 else:
-                    raw = maestro.noisy_execute(qasm, self.config.noise_model, config=sim_config, shots=shots, noise_realizations=self.config.noise_realizations, seed=self.config.seed)
+                    raw = maestro.noisy_execute(
+                        qasm,
+                        self.noise_config["noise_model"],
+                        config=sim_config,
+                        shots=shots,
+                        noise_realizations=self.noise_config["noise_realizations"],
+                        seed=self.noise_config["noise_seed"],
+                    )
                 counts = {bs[::-1]: n for bs, n in raw["counts"].items()}
                 return {"label": label, "results": counts}
 
@@ -434,24 +437,25 @@ class MaestroSimulator(CircuitRunner):
                 pauli_string = self._get_ham_ops_for_circuit(
                     i, ham_ops, circuit_ham_map
                 )
-                if self.config.noise_model is None:
+                if self.noise_config["noise_model"] is None:
                     raw = maestro.simple_estimate(
                         _strip_measurements(qasm),
                         observables=pauli_string,
                         config=sim_config,
                     )
-                if self.config.noise_model is not None:
-                    if self.config.noise_realizations is None:
+                else:
+                    if self.noise_config["noise_realizations"] in [None, 0]:
                         raw = maestro.noisy_estimate(
                             _strip_measurements(qasm),
-                            self.config.noise_model,
+                            self.noise_config["noise_model"],
                             observables=pauli_string,
                             config=sim_config,
                         )
                     else:
                         raw = maestro.noisy_estimate_montecarlo(
                             _strip_measurements(qasm),
-                            self.config.noise_model,
+                            self.noise_config["noise_model"],
+                            noise_realizations=self.noise_config["noise_realizations"],
                             observables=pauli_string,
                             config=sim_config,
                         )

--- a/divi/backends/_maestro_simulator.py
+++ b/divi/backends/_maestro_simulator.py
@@ -401,7 +401,13 @@ class MaestroSimulator(CircuitRunner):
         ham_ops: str,
         circuit_ham_map: list[list[int]] | None,
     ) -> str:
-        """Resolve which observable string applies to a given circuit index."""
+        """Resolve which observable string applies to a given circuit index.
+
+        When ``circuit_ham_map`` is provided but no range covers
+        ``circuit_index``, falls back to the full ``ham_ops`` string —
+        callers may submit auxiliary circuits outside the per-group ranges
+        and expect them to be evaluated against every observable.
+        """
         if circuit_ham_map is None:
             return ham_ops
 

--- a/divi/backends/_maestro_simulator.py
+++ b/divi/backends/_maestro_simulator.py
@@ -115,6 +115,18 @@ class MaestroConfig:
     ``simulation_type`` is set explicitly.  Divi-specific; not forwarded to
     ``maestro.SimulatorConfig``."""
 
+    noise_model: maestro.NoiseModel | None = None
+    """ Maestro NoiseModel object. Configured before passing to MaestroConfig"""
+
+    noise_seed: int | None = 42
+    """ Seed for the random noise model. Only active when :attr:`noise_model` is not `None` """
+
+    noise_realizations: int | None = None
+    """ Number of realizations to use for noise model. Only active when :attr:`noise_model` is not `None` 
+    - If `None`, no noise is actually used, instead a damping factor is computed and applied to get the expected average under the noise model
+    - If `int`, it randomly inserts Pauli gates and computes expectation values `int` times, then averages over the instances
+    ==> NB: behaviour(`None`) != behaviour(int: 1) !!! rather, behaviour(`None`) = behaviour(`int: n -> /infinity)"""
+
     def override(self, other: "MaestroConfig") -> "MaestroConfig":
         """Return a new config overriding fields with non-default values from ``other``.
 
@@ -402,7 +414,10 @@ class MaestroSimulator(CircuitRunner):
                     if per_circuit_shots is not None
                     else self.shots
                 )
-                raw = maestro.simple_execute(qasm, config=sim_config, shots=shots)
+                if self.config.noise_model is None:
+                    raw = maestro.simple_execute(qasm, config=sim_config, shots=shots)
+                else:
+                    raw = maestro.noisy_execute(qasm, self.config.noise_model, config=sim_config, shots=shots, noise_realizations=self.config.noise_realizations, seed=self.config.seed)
                 counts = {bs[::-1]: n for bs, n in raw["counts"].items()}
                 return {"label": label, "results": counts}
 
@@ -419,11 +434,27 @@ class MaestroSimulator(CircuitRunner):
                 pauli_string = self._get_ham_ops_for_circuit(
                     i, ham_ops, circuit_ham_map
                 )
-                raw = maestro.simple_estimate(
-                    _strip_measurements(qasm),
-                    observables=pauli_string,
-                    config=sim_config,
-                )
+                if self.config.noise_model is None:
+                    raw = maestro.simple_estimate(
+                        _strip_measurements(qasm),
+                        observables=pauli_string,
+                        config=sim_config,
+                    )
+                if self.config.noise_model is not None:
+                    if self.config.noise_realizations is None:
+                        raw = maestro.noisy_estimate(
+                            _strip_measurements(qasm),
+                            self.config.noise_model,
+                            observables=pauli_string,
+                            config=sim_config,
+                        )
+                    else:
+                        raw = maestro.noisy_estimate_montecarlo(
+                            _strip_measurements(qasm),
+                            self.config.noise_model,
+                            observables=pauli_string,
+                            config=sim_config,
+                        )
                 ops = pauli_string.split(";")
                 expvals = dict(zip(ops, raw["expectation_values"]))
                 return {"label": label, "results": expvals}

--- a/divi/circuits/_conversions.py
+++ b/divi/circuits/_conversions.py
@@ -372,6 +372,7 @@ def qscript_to_meta(
     qscript: QuantumScript,
     precision: int = 8,
     parameter_order: tuple[Parameter, ...] | None = None,
+    was_multi_obs: bool | None = None,
 ):
     """Shared helper: convert a PennyLane ``QuantumScript`` to a ``MetaCircuit``.
 
@@ -385,12 +386,10 @@ def qscript_to_meta(
         qscript: PennyLane ``QuantumScript``.  Accepts:
 
             * a single ``probs``/``counts`` measurement;
-            * a single ``expval`` measurement (sets ``observable`` to a
-              :class:`~qiskit.quantum_info.SparsePauliOp`);
-            * multiple ``expval`` measurements — sets ``observable`` to a
-              ``tuple[SparsePauliOp, ...]``, one entry per measurement
-              (used by error-mitigation protocols that share work across
-              observables).
+            * one or more ``expval`` measurements — sets ``observable`` to
+              a ``tuple[SparsePauliOp, ...]``, one entry per measurement.
+              Mixing ``expval`` with ``probs``/``counts`` in one
+              ``QuantumScript`` is not supported.
         precision: ``MetaCircuit.precision`` for numeric gate parameters.
         parameter_order: Explicit parameter ordering for the resulting
             ``MetaCircuit``.  Use when the qscript's first-appearance order
@@ -398,6 +397,14 @@ def qscript_to_meta(
             gates in a different order than the flat weight array).
             When ``None``, ordering is inferred from the qscript
             (first appearance).
+        was_multi_obs: Optional override for the resulting MetaCircuit's
+            ``_was_multi_obs`` flag.  When ``None`` (default), inferred
+            from the script: more than one ``expval`` measurement → ``True``,
+            otherwise ``False``.  Pass ``True`` when the higher-level
+            caller knows the user opted into the multi-observable API
+            (e.g. ``observable=[O]`` in
+            :class:`~divi.qprog.algorithms.TimeEvolution`) even when only
+            one expval ends up in the script.
     """
     measurements = list(qscript.measurements)
 
@@ -405,16 +412,13 @@ def qscript_to_meta(
 
     params = parameter_order if parameter_order is not None else inferred_params
 
-    observable: SparsePauliOp | tuple[SparsePauliOp, ...] | None = None
+    observable: tuple[SparsePauliOp, ...] | None = None
     measured_wires = None
 
     expval_measurements = [
         m for m in measurements if isinstance(m, qp.measurements.ExpectationMP)
     ]
-    if len(expval_measurements) >= 2:
-        # Multi-observable path: every measurement must be an expval with an
-        # operator attached.  Mixing expval with probs/counts in one
-        # QuantumScript is not supported.
+    if expval_measurements:
         if len(expval_measurements) != len(measurements):
             raise ValueError(
                 "qscript_to_meta: mixing `expval` with `probs`/`counts` "
@@ -428,16 +432,14 @@ def qscript_to_meta(
                 )
             ops.append(observable_to_sparse_pauli_op(m.obs, qscript.wires))
         observable = tuple(ops)
-    elif len(expval_measurements) == 1:
-        m = expval_measurements[0]
-        if m.obs is None:
-            raise ValueError("ExpectationMP without an observable is not supported.")
-        observable = observable_to_sparse_pauli_op(m.obs, qscript.wires)
     elif measurements:
         first = measurements[0]
         if isinstance(first, (qp.measurements.ProbabilityMP, qp.measurements.CountsMP)):
             target_wires = first.wires if len(first.wires) else qscript.wires
             measured_wires = tuple(qscript.wires.index(w) for w in target_wires)
+
+    if was_multi_obs is None:
+        was_multi_obs = len(expval_measurements) > 1
 
     return MetaCircuit(
         circuit_bodies=(((), dag),),
@@ -445,6 +447,7 @@ def qscript_to_meta(
         observable=observable,
         measured_wires=measured_wires,
         precision=precision,
+        _was_multi_obs=was_multi_obs,
     )
 
 

--- a/divi/circuits/_conversions.py
+++ b/divi/circuits/_conversions.py
@@ -382,8 +382,15 @@ def qscript_to_meta(
     from the qscript's single measurement.
 
     Args:
-        qscript: PennyLane ``QuantumScript`` with exactly one measurement
-            (``expval``, ``probs``, or ``counts``).
+        qscript: PennyLane ``QuantumScript``.  Accepts:
+
+            * a single ``probs``/``counts`` measurement;
+            * a single ``expval`` measurement (sets ``observable`` to a
+              :class:`~qiskit.quantum_info.SparsePauliOp`);
+            * multiple ``expval`` measurements — sets ``observable`` to a
+              ``tuple[SparsePauliOp, ...]``, one entry per measurement
+              (used by error-mitigation protocols that share work across
+              observables).
         precision: ``MetaCircuit.precision`` for numeric gate parameters.
         parameter_order: Explicit parameter ordering for the resulting
             ``MetaCircuit``.  Use when the qscript's first-appearance order
@@ -392,24 +399,42 @@ def qscript_to_meta(
             When ``None``, ordering is inferred from the qscript
             (first appearance).
     """
-    measurement = qscript.measurements[0] if qscript.measurements else None
+    measurements = list(qscript.measurements)
 
     dag, inferred_params, _ = _qscript_to_dag(qscript)
 
     params = parameter_order if parameter_order is not None else inferred_params
 
-    observable = None
+    observable: SparsePauliOp | tuple[SparsePauliOp, ...] | None = None
     measured_wires = None
-    if isinstance(measurement, qp.measurements.ExpectationMP):
-        if measurement.obs is None:
+
+    expval_measurements = [
+        m for m in measurements if isinstance(m, qp.measurements.ExpectationMP)
+    ]
+    if len(expval_measurements) >= 2:
+        # Multi-observable path: every measurement must be an expval.
+        # Mixing expval with probs/counts in one qscript is not supported.
+        if len(expval_measurements) != len(measurements):
+            raise ValueError(
+                "qscript_to_meta: mixing `expval` with `probs`/`counts` "
+                "measurements in a single QuantumScript is not supported."
+            )
+        observable = tuple(
+            observable_to_sparse_pauli_op(m.obs, qscript.wires)
+            for m in expval_measurements
+        )
+    elif len(expval_measurements) == 1:
+        m = expval_measurements[0]
+        if m.obs is None:
             raise ValueError("ExpectationMP without an observable is not supported.")
-        observable = observable_to_sparse_pauli_op(measurement.obs, qscript.wires)
-    elif isinstance(
-        measurement,
-        (qp.measurements.ProbabilityMP, qp.measurements.CountsMP),
-    ):
-        target_wires = measurement.wires if len(measurement.wires) else qscript.wires
-        measured_wires = tuple(qscript.wires.index(w) for w in target_wires)
+        observable = observable_to_sparse_pauli_op(m.obs, qscript.wires)
+    elif measurements:
+        first = measurements[0]
+        if isinstance(
+            first, (qp.measurements.ProbabilityMP, qp.measurements.CountsMP)
+        ):
+            target_wires = first.wires if len(first.wires) else qscript.wires
+            measured_wires = tuple(qscript.wires.index(w) for w in target_wires)
 
     return MetaCircuit(
         circuit_bodies=(((), dag),),

--- a/divi/circuits/_conversions.py
+++ b/divi/circuits/_conversions.py
@@ -412,17 +412,22 @@ def qscript_to_meta(
         m for m in measurements if isinstance(m, qp.measurements.ExpectationMP)
     ]
     if len(expval_measurements) >= 2:
-        # Multi-observable path: every measurement must be an expval.
-        # Mixing expval with probs/counts in one qscript is not supported.
+        # Multi-observable path: every measurement must be an expval with an
+        # operator attached.  Mixing expval with probs/counts in one
+        # QuantumScript is not supported.
         if len(expval_measurements) != len(measurements):
             raise ValueError(
                 "qscript_to_meta: mixing `expval` with `probs`/`counts` "
                 "measurements in a single QuantumScript is not supported."
             )
-        observable = tuple(
-            observable_to_sparse_pauli_op(m.obs, qscript.wires)
-            for m in expval_measurements
-        )
+        ops: list[SparsePauliOp] = []
+        for m in expval_measurements:
+            if m.obs is None:
+                raise ValueError(
+                    "ExpectationMP without an observable is not supported."
+                )
+            ops.append(observable_to_sparse_pauli_op(m.obs, qscript.wires))
+        observable = tuple(ops)
     elif len(expval_measurements) == 1:
         m = expval_measurements[0]
         if m.obs is None:
@@ -430,9 +435,7 @@ def qscript_to_meta(
         observable = observable_to_sparse_pauli_op(m.obs, qscript.wires)
     elif measurements:
         first = measurements[0]
-        if isinstance(
-            first, (qp.measurements.ProbabilityMP, qp.measurements.CountsMP)
-        ):
+        if isinstance(first, (qp.measurements.ProbabilityMP, qp.measurements.CountsMP)):
             target_wires = first.wires if len(first.wires) else qscript.wires
             measured_wires = tuple(qscript.wires.index(w) for w in target_wires)
 

--- a/divi/circuits/_core.py
+++ b/divi/circuits/_core.py
@@ -40,8 +40,17 @@ class MetaCircuit:
     Order matches the flat parameter-values array fed by
     :class:`~divi.pipeline.stages.ParameterBindingStage`."""
 
-    observable: SparsePauliOp | None = None
-    """Observable for expectation-value measurements. ``None`` for probs/counts."""
+    observable: SparsePauliOp | tuple[SparsePauliOp, ...] | None = None
+    """Observable(s) for expectation-value measurements.
+
+    * ``None`` — probs/counts measurement (uses :attr:`measured_wires` instead).
+    * Single :class:`~qiskit.quantum_info.SparsePauliOp` — one mitigated
+      expectation value (the standard case).
+    * ``tuple[SparsePauliOp, ...]`` — one mitigated expectation value per
+      entry. Stages that share work across observables (e.g. QuEPP path-DAG
+      dedup, QWC measurement-batching across the union) branch on this case.
+
+    Use :func:`isinstance(meta.observable, tuple)` to dispatch."""
 
     measured_wires: tuple[int, ...] | None = None
     """Qubit indices to measure for probs/counts measurements. ``None`` for expval."""

--- a/divi/circuits/_core.py
+++ b/divi/circuits/_core.py
@@ -48,9 +48,7 @@ class MetaCircuit:
       expectation value (the standard case).
     * ``tuple[SparsePauliOp, ...]`` — one mitigated expectation value per
       entry. Stages that share work across observables (e.g. QuEPP path-DAG
-      dedup, QWC measurement-batching across the union) branch on this case.
-
-    Use :func:`isinstance(meta.observable, tuple)` to dispatch."""
+      dedup, QWC measurement-batching across the union) branch on this case."""
 
     measured_wires: tuple[int, ...] | None = None
     """Qubit indices to measure for probs/counts measurements. ``None`` for expval."""

--- a/divi/circuits/_core.py
+++ b/divi/circuits/_core.py
@@ -6,11 +6,66 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 
+import numpy as np
 from qiskit.circuit import Parameter
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.quantum_info import SparsePauliOp
 
 from divi.circuits._types import QASMTag
+
+
+def flatten_observable_tuple(
+    observable: tuple[SparsePauliOp, ...],
+) -> tuple[SparsePauliOp, list[list[int]]]:
+    """Flatten a tuple of observables into a single union ``SparsePauliOp``.
+
+    Pauli labels that appear in multiple observables (or repeat within one)
+    collapse to a single union slot keyed on their little-endian label.
+    The union's coefficient on a slot is the sum of every owning
+    observable's *absolute* coefficient on that Pauli.
+
+    Args:
+        observable: Non-empty tuple of Hermitian ``SparsePauliOp``.
+
+    Returns:
+        ``(union, per_obs_term_indices)``:
+
+        * ``union`` — a ``SparsePauliOp`` whose Pauli terms are the unique
+          Paulis across all observables, with absolute-summed coefficients.
+        * ``per_obs_term_indices`` — for each observable in tuple-order, a
+          list whose ``k``-th entry is the union slot index of that
+          observable's ``k``-th Pauli term.
+    """
+    if not observable:
+        raise ValueError("flatten_observable_tuple requires at least one observable.")
+
+    label_to_slot: dict[str, int] = {}
+    union_labels: list[str] = []
+    union_coeffs_real: list[float] = []
+    per_obs_term_indices: list[list[int]] = []
+
+    for obs in observable:
+        coeffs = np.abs(np.real(obs.coeffs)).astype(np.float64)
+        indices: list[int] = []
+        for label, c in zip(obs.paulis.to_labels(), coeffs):
+            slot = label_to_slot.get(label)
+            if slot is None:
+                slot = len(union_labels)
+                label_to_slot[label] = slot
+                union_labels.append(label)
+                union_coeffs_real.append(float(c))
+            else:
+                union_coeffs_real[slot] += float(c)
+            indices.append(slot)
+        per_obs_term_indices.append(indices)
+
+    if not union_labels:
+        raise ValueError(
+            "flatten_observable_tuple: every observable in the tuple is empty."
+        )
+
+    union = SparsePauliOp.from_list(list(zip(union_labels, union_coeffs_real)))
+    return union, per_obs_term_indices
 
 
 @dataclass(frozen=True)
@@ -44,11 +99,10 @@ class MetaCircuit:
     """Observable(s) for expectation-value measurements.
 
     * ``None`` — probs/counts measurement (uses :attr:`measured_wires` instead).
-    * Single :class:`~qiskit.quantum_info.SparsePauliOp` — one mitigated
-      expectation value (the standard case).
-    * ``tuple[SparsePauliOp, ...]`` — one mitigated expectation value per
-      entry. Stages that share work across observables (e.g. QuEPP path-DAG
-      dedup, QWC measurement-batching across the union) branch on this case."""
+    * ``SparsePauliOp`` — accepted as input; ``__post_init__`` wraps it
+      in a length-1 tuple.
+    * ``tuple[SparsePauliOp, ...]`` — canonical stored form; one mitigated
+      expectation value per entry."""
 
     measured_wires: tuple[int, ...] | None = None
     """Qubit indices to measure for probs/counts measurements. ``None`` for expval."""
@@ -71,10 +125,21 @@ class MetaCircuit:
     precision: int = 8
     """Number of decimal places for numeric parameter values in QASM conversion."""
 
+    _was_multi_obs: bool = False
+    """Caller-set flag: ``True`` when the user explicitly opted into the
+    multi-observable API (e.g. ``observable=[O]`` or
+    ``observable=(O1, O2)``).  Drives result-shape squeeze policy at the
+    :class:`~divi.pipeline.PipelineResult` boundary — ``False`` allows
+    a length-1 expval list to be unwrapped to a scalar."""
+
     def __post_init__(self):
         """Minimal shape validation — caller owns correctness of the DAGs."""
         if not self.circuit_bodies:
             raise ValueError("MetaCircuit requires at least one circuit body.")
+
+        # Wrap a bare SparsePauliOp in a 1-tuple to match the canonical shape.
+        if isinstance(self.observable, SparsePauliOp):
+            object.__setattr__(self, "observable", (self.observable,))
 
     @property
     def n_qubits(self) -> int:

--- a/divi/circuits/qem.py
+++ b/divi/circuits/qem.py
@@ -6,10 +6,11 @@ import copy
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
-from typing import Any, Literal, Protocol, cast, runtime_checkable
+from typing import Any, Literal, Protocol, runtime_checkable
 
 import numpy as np
 from qiskit.dagcircuit import DAGCircuit
+from qiskit.quantum_info import SparsePauliOp
 
 from divi.circuits._qem_passes import (
     GlobalFoldPass,
@@ -43,20 +44,15 @@ class QEMProtocol(ABC):
     expand/reduce lifecycle:
 
     * ``expand`` — given a Qiskit :class:`~qiskit.dagcircuit.DAGCircuit`
-      and the observable(s) being measured, return the DAGs to execute on
-      quantum hardware and a ``QEMContext`` (or list thereof) carrying any
-      classically-computed side-channel data needed during postprocessing.
-    * ``reduce`` — given the context(s) from ``expand`` and the quantum
-      results, produce the mitigated expectation value(s).
+      and the observable tuple being measured, return the DAGs to execute
+      on quantum hardware and a ``QEMContext`` carrying any classically-
+      computed side-channel data needed during postprocessing.
+    * ``reduce`` — given the context from ``expand`` and the quantum
+      results, produce a ``list[float]`` of per-observable mitigated
+      expectation values.
 
-    Both methods accept either a single observable / single context (the
-    standard case, returns scalar) or a tuple of observables / list of
-    contexts (one mitigated value per observable, returns list).  Each
-    context carries a ``"dag_indices"`` field giving the positions in the
-    merged DAG tuple that belong to that context — :meth:`reduce` uses this
-    to slice ``quantum_results`` before applying its protocol-specific
-    logic, so single-observable code paths and per-observable code paths
-    share the same arithmetic.
+    The observable flows through as a ``tuple[SparsePauliOp, ...]`` and is
+    forwarded unchanged to whichever stage needs its structure.
     """
 
     @property
@@ -68,9 +64,9 @@ class QEMProtocol(ABC):
     def expand(
         self,
         dag: DAGCircuit,
-        observable: Any | tuple[Any, ...] | None = None,
-    ) -> tuple[tuple[DAGCircuit, ...], QEMContext | list[QEMContext]]:
-        """Generate DAGs and classical context(s) for error mitigation.
+        observable: tuple[SparsePauliOp, ...] | None = None,
+    ) -> tuple[tuple[DAGCircuit, ...], QEMContext]:
+        """Generate DAGs and classical context for error mitigation.
 
         The input ``dag`` is consumed by this method: implementations may
         mutate it, and callers must not retain it expecting the original
@@ -80,28 +76,15 @@ class QEMProtocol(ABC):
 
         Args:
             dag: Circuit to mitigate.
-            observable: One of:
-
-                * ``None`` or a single :class:`~qiskit.quantum_info.SparsePauliOp` —
-                  standard single-observable path.  Returns
-                  ``(merged_dags, ctx)`` with ``ctx["dag_indices"] =
-                  list(range(len(merged_dags)))`` (the trivial identity range).
-                * ``tuple[SparsePauliOp, ...]`` — multi-observable path.
-                  Returns ``(merged_dags, list[ctx])``, one ctx per
-                  observable.  Each ctx's ``"dag_indices"`` selects the
-                  positions in ``merged_dags`` that belong to that observable.
-                  Indices may overlap across contexts when DAGs are shared
-                  (e.g. the target circuit in QuEPP).
-
-        Implementations without specialised multi-observable handling can
-        delegate the tuple case to :meth:`_expand_per_observable_loop`.
+            observable: ``tuple[SparsePauliOp, ...]`` (one entry per
+                expectation value being measured), or ``None``.
         """
 
     def dry_expand(
         self,
         dag: DAGCircuit,
-        observable: Any | None = None,
-    ) -> tuple[tuple[DAGCircuit, ...], QEMContext | list[QEMContext]]:
+        observable: tuple[SparsePauliOp, ...] | None = None,
+    ) -> tuple[tuple[DAGCircuit, ...], QEMContext]:
         """Analytic counterpart to :meth:`expand` used by dry-run pipelines.
 
         Must emit the **same number of DAGs** as :meth:`expand` would on the
@@ -122,97 +105,19 @@ class QEMProtocol(ABC):
     @abstractmethod
     def reduce(
         self,
-        quantum_results: Sequence[float],
-        context: QEMContext | list[QEMContext],
-    ) -> float | list[float]:
-        """Combine quantum results with classical context(s) into mitigated value(s).
-
-        When ``context`` is a list (one entry per observable), returns a
-        ``list[float]`` of the same length.  Otherwise returns a single
-        ``float``.
-
-        Implementations should use ``context["dag_indices"]`` (when present)
-        to select the relevant positions in ``quantum_results`` before
-        applying protocol-specific arithmetic; this keeps single-observable
-        and per-observable code paths uniform.
-        """
-
-    # ----------------------------------------------------------------- #
-    # Reusable helpers for the multi-observable path
-    # ----------------------------------------------------------------- #
-
-    def _expand_per_observable_loop(
-        self,
-        dag: DAGCircuit,
-        observables: Sequence[Any],
-    ) -> tuple[tuple[DAGCircuit, ...], list[QEMContext]]:
-        """Default multi-observable expansion: loop :meth:`expand` per observable.
-
-        Deepcopies ``dag`` for every call but the last (matching
-        :meth:`expand`'s mutation contract), concatenates the resulting DAG
-        tuples, and overwrites each context's ``"dag_indices"`` so it points
-        at the right slice of the merged tuple.  Subclasses that can share
-        work across observables (path-DAG dedup, shared target execution)
-        should override this method instead.
-        """
-        n = len(observables)
-        if n == 0:
-            raise ValueError("Expansion requires at least one observable in the tuple.")
-
-        merged_dags: list[DAGCircuit] = []
-        contexts: list[QEMContext] = []
-        for i, obs in enumerate(observables):
-            input_dag = dag if i == n - 1 else copy.deepcopy(dag)
-            obs_dags, ctx = self.expand(input_dag, obs)
-            if isinstance(ctx, list):
-                raise TypeError(
-                    "_expand_per_observable_loop expected a single context "
-                    "from each per-observable expand call; got a list. "
-                    "Override this helper if your protocol nests tuples."
-                )
-            ctx = dict(ctx)
-            start = len(merged_dags)
-            merged_dags.extend(obs_dags)
-            ctx["dag_indices"] = list(range(start, len(merged_dags)))
-            contexts.append(ctx)
-        return tuple(merged_dags), contexts
-
-    def _reduce_for_list_context(
-        self,
         quantum_results: Sequence[Any],
-        contexts: list[QEMContext],
+        context: QEMContext,
     ) -> list[float]:
-        """Default multi-observable :meth:`reduce` dispatch helper.
+        """Combine quantum results with classical context into mitigated values.
 
-        Distinguishes two shapes of ``quantum_results``:
+        Returns a ``list[float]`` of per-observable mitigated values.
+        ``quantum_results`` is ordered along the QEM axis; each entry is
+        itself a ``list[float]`` of per-observable expectation values from
+        :class:`~divi.pipeline.stages.MeasurementStage`.
 
-        * **Per-DAG rows of per-observable values** (length-N lists, where
-          N matches ``len(contexts)``) — emitted by ``MeasurementStage``
-          when the meta carries a tuple ``observable``.  Each observable's
-          mitigated value comes from extracting its column.
-        * **Scalar rows** — typically only seen by tests that bypass
-          ``MeasurementStage``.  Each context sees the full results.
+        Implementations may use ``context["dag_indices"]`` (when present)
+        to select the relevant positions in ``quantum_results``.
         """
-        if quantum_results and isinstance(quantum_results[0], (list, tuple)):
-            n = len(contexts)
-            sample_len = len(quantum_results[0])
-            if sample_len != n:
-                raise RuntimeError(
-                    f"Expected {n} per-observable values per DAG, got "
-                    f"{sample_len}.  Multi-observable contexts and "
-                    f"MeasurementStage rows are out of sync."
-                )
-            # Each inner ``reduce`` is passed a single QEMContext, not a list,
-            # so it returns ``float`` — but the public signature is wider, so
-            # we narrow with ``cast``.
-            return [
-                cast(
-                    float,
-                    self.reduce([row[i] for row in quantum_results], contexts[i]),
-                )
-                for i in range(n)
-            ]
-        return [cast(float, self.reduce(quantum_results, c)) for c in contexts]
 
     def post_reduce(self, contexts: Sequence[QEMContext]) -> None:
         """Hook called after all per-group ``reduce`` calls in an evaluation.
@@ -232,19 +137,15 @@ class _NoMitigation(QEMProtocol):
     def expand(
         self,
         dag: DAGCircuit,
-        observable: Any | tuple[Any, ...] | None = None,
-    ) -> tuple[tuple[DAGCircuit, ...], QEMContext | list[QEMContext]]:
-        if isinstance(observable, tuple):
-            return self._expand_per_observable_loop(dag, observable)
+        observable: tuple[SparsePauliOp, ...] | None = None,
+    ) -> tuple[tuple[DAGCircuit, ...], QEMContext]:
         return (dag,), {"dag_indices": [0]}
 
     def reduce(
         self,
-        quantum_results: Sequence[float],
-        context: QEMContext | list[QEMContext],
-    ) -> float | list[float]:
-        if isinstance(context, list):
-            return self._reduce_for_list_context(quantum_results, context)
+        quantum_results: Sequence[Any],
+        context: QEMContext,
+    ) -> list[float]:
         indices = context.get("dag_indices")
         selected = (
             [quantum_results[i] for i in indices]
@@ -255,7 +156,10 @@ class _NoMitigation(QEMProtocol):
             raise RuntimeError("NoMitigation received an empty results sequence.")
         if len(selected) > 1:
             raise RuntimeError("NoMitigation class received multiple partial results.")
-        return selected[0]
+        only = selected[0]
+        if isinstance(only, list):
+            return [float(v) for v in only]
+        return [float(only)]
 
 
 # ---------------------------------------------------------------------------
@@ -507,14 +411,8 @@ class ZNE(QEMProtocol):
     def expand(
         self,
         dag: DAGCircuit,
-        observable: Any | tuple[Any, ...] | None = None,
-    ) -> tuple[tuple[DAGCircuit, ...], QEMContext | list[QEMContext]]:
-        if isinstance(observable, tuple):
-            # Folding is observable-independent, so the loop helper produces
-            # N copies of the same folded DAGs.  Correct, not optimal — a
-            # ZNE-specific override could share the folded set.
-            return self._expand_per_observable_loop(dag, observable)
-
+        observable: tuple[SparsePauliOp, ...] | None = None,
+    ) -> tuple[tuple[DAGCircuit, ...], QEMContext]:
         # Expand takes ownership of `dag` (see QEMProtocol.expand).  For
         # S scale factors we need S distinct folded outputs; the input
         # can absorb one of them, so we deepcopy S-1 times instead of S.
@@ -545,11 +443,15 @@ class ZNE(QEMProtocol):
 
     def reduce(
         self,
-        quantum_results: Sequence[float],
-        context: QEMContext | list[QEMContext],
-    ) -> float | list[float]:
-        if isinstance(context, list):
-            return self._reduce_for_list_context(quantum_results, context)
+        quantum_results: Sequence[Any],
+        context: QEMContext,
+    ) -> list[float]:
+        """Extrapolate per-observable expectation values to ``s=0``.
+
+        Each entry of ``quantum_results`` is a ``list[float]`` of per-
+        observable expectation values from one scale factor.  Extrapolation
+        runs independently per observable.
+        """
         indices = context.get("dag_indices")
         selected = (
             [quantum_results[i] for i in indices]
@@ -557,4 +459,14 @@ class ZNE(QEMProtocol):
             else list(quantum_results)
         )
         scales = context.get("effective_scales", self._scale_factors)
-        return self._extrapolator.extrapolate(scales, selected)
+
+        if not selected:
+            raise RuntimeError("ZNE received an empty results sequence.")
+
+        if not isinstance(selected[0], (list, tuple)):
+            selected = [[v] for v in selected]
+        n_obs = len(selected[0])
+        return [
+            float(self._extrapolator.extrapolate(scales, [row[i] for row in selected]))
+            for i in range(n_obs)
+        ]

--- a/divi/circuits/qem.py
+++ b/divi/circuits/qem.py
@@ -6,7 +6,7 @@ import copy
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
-from typing import Any, Literal, Protocol, runtime_checkable
+from typing import Any, Literal, Protocol, cast, runtime_checkable
 
 import numpy as np
 from qiskit.dagcircuit import DAGCircuit
@@ -101,7 +101,7 @@ class QEMProtocol(ABC):
         self,
         dag: DAGCircuit,
         observable: Any | None = None,
-    ) -> tuple[tuple[DAGCircuit, ...], QEMContext]:
+    ) -> tuple[tuple[DAGCircuit, ...], QEMContext | list[QEMContext]]:
         """Analytic counterpart to :meth:`expand` used by dry-run pipelines.
 
         Must emit the **same number of DAGs** as :meth:`expand` would on the
@@ -157,9 +157,7 @@ class QEMProtocol(ABC):
         """
         n = len(observables)
         if n == 0:
-            raise ValueError(
-                "Expansion requires at least one observable in the tuple."
-            )
+            raise ValueError("Expansion requires at least one observable in the tuple.")
 
         merged_dags: list[DAGCircuit] = []
         contexts: list[QEMContext] = []
@@ -204,11 +202,17 @@ class QEMProtocol(ABC):
                     f"{sample_len}.  Multi-observable contexts and "
                     f"MeasurementStage rows are out of sync."
                 )
+            # Each inner ``reduce`` is passed a single QEMContext, not a list,
+            # so it returns ``float`` — but the public signature is wider, so
+            # we narrow with ``cast``.
             return [
-                self.reduce([row[i] for row in quantum_results], contexts[i])
+                cast(
+                    float,
+                    self.reduce([row[i] for row in quantum_results], contexts[i]),
+                )
                 for i in range(n)
             ]
-        return [self.reduce(quantum_results, c) for c in contexts]
+        return [cast(float, self.reduce(quantum_results, c)) for c in contexts]
 
     def post_reduce(self, contexts: Sequence[QEMContext]) -> None:
         """Hook called after all per-group ``reduce`` calls in an evaluation.

--- a/divi/circuits/qem.py
+++ b/divi/circuits/qem.py
@@ -43,11 +43,20 @@ class QEMProtocol(ABC):
     expand/reduce lifecycle:
 
     * ``expand`` — given a Qiskit :class:`~qiskit.dagcircuit.DAGCircuit`
-      (and optionally the observable being measured), return the DAGs to
-      execute on quantum hardware and a ``QEMContext`` carrying any
+      and the observable(s) being measured, return the DAGs to execute on
+      quantum hardware and a ``QEMContext`` (or list thereof) carrying any
       classically-computed side-channel data needed during postprocessing.
-    * ``reduce`` — given the context from ``expand`` and the quantum
-      results, produce a single mitigated expectation value.
+    * ``reduce`` — given the context(s) from ``expand`` and the quantum
+      results, produce the mitigated expectation value(s).
+
+    Both methods accept either a single observable / single context (the
+    standard case, returns scalar) or a tuple of observables / list of
+    contexts (one mitigated value per observable, returns list).  Each
+    context carries a ``"dag_indices"`` field giving the positions in the
+    merged DAG tuple that belong to that context — :meth:`reduce` uses this
+    to slice ``quantum_results`` before applying its protocol-specific
+    logic, so single-observable code paths and per-observable code paths
+    share the same arithmetic.
     """
 
     @property
@@ -59,15 +68,33 @@ class QEMProtocol(ABC):
     def expand(
         self,
         dag: DAGCircuit,
-        observable: Any | None = None,
-    ) -> tuple[tuple[DAGCircuit, ...], QEMContext]:
-        """Generate DAGs and classical context for error mitigation.
+        observable: Any | tuple[Any, ...] | None = None,
+    ) -> tuple[tuple[DAGCircuit, ...], QEMContext | list[QEMContext]]:
+        """Generate DAGs and classical context(s) for error mitigation.
 
         The input ``dag`` is consumed by this method: implementations may
         mutate it, and callers must not retain it expecting the original
         state.  This matches the broader pipeline convention for
         ``consumes_dag_bodies`` stages (see
         :class:`~divi.pipeline.abc.BundleStage`).
+
+        Args:
+            dag: Circuit to mitigate.
+            observable: One of:
+
+                * ``None`` or a single :class:`~qiskit.quantum_info.SparsePauliOp` —
+                  standard single-observable path.  Returns
+                  ``(merged_dags, ctx)`` with ``ctx["dag_indices"] =
+                  list(range(len(merged_dags)))`` (the trivial identity range).
+                * ``tuple[SparsePauliOp, ...]`` — multi-observable path.
+                  Returns ``(merged_dags, list[ctx])``, one ctx per
+                  observable.  Each ctx's ``"dag_indices"`` selects the
+                  positions in ``merged_dags`` that belong to that observable.
+                  Indices may overlap across contexts when DAGs are shared
+                  (e.g. the target circuit in QuEPP).
+
+        Implementations without specialised multi-observable handling can
+        delegate the tuple case to :meth:`_expand_per_observable_loop`.
         """
 
     def dry_expand(
@@ -96,9 +123,92 @@ class QEMProtocol(ABC):
     def reduce(
         self,
         quantum_results: Sequence[float],
-        context: QEMContext,
-    ) -> float:
-        """Combine quantum results with classical context into a mitigated value."""
+        context: QEMContext | list[QEMContext],
+    ) -> float | list[float]:
+        """Combine quantum results with classical context(s) into mitigated value(s).
+
+        When ``context`` is a list (one entry per observable), returns a
+        ``list[float]`` of the same length.  Otherwise returns a single
+        ``float``.
+
+        Implementations should use ``context["dag_indices"]`` (when present)
+        to select the relevant positions in ``quantum_results`` before
+        applying protocol-specific arithmetic; this keeps single-observable
+        and per-observable code paths uniform.
+        """
+
+    # ----------------------------------------------------------------- #
+    # Reusable helpers for the multi-observable path
+    # ----------------------------------------------------------------- #
+
+    def _expand_per_observable_loop(
+        self,
+        dag: DAGCircuit,
+        observables: Sequence[Any],
+    ) -> tuple[tuple[DAGCircuit, ...], list[QEMContext]]:
+        """Default multi-observable expansion: loop :meth:`expand` per observable.
+
+        Deepcopies ``dag`` for every call but the last (matching
+        :meth:`expand`'s mutation contract), concatenates the resulting DAG
+        tuples, and overwrites each context's ``"dag_indices"`` so it points
+        at the right slice of the merged tuple.  Subclasses that can share
+        work across observables (path-DAG dedup, shared target execution)
+        should override this method instead.
+        """
+        n = len(observables)
+        if n == 0:
+            raise ValueError(
+                "Expansion requires at least one observable in the tuple."
+            )
+
+        merged_dags: list[DAGCircuit] = []
+        contexts: list[QEMContext] = []
+        for i, obs in enumerate(observables):
+            input_dag = dag if i == n - 1 else copy.deepcopy(dag)
+            obs_dags, ctx = self.expand(input_dag, obs)
+            if isinstance(ctx, list):
+                raise TypeError(
+                    "_expand_per_observable_loop expected a single context "
+                    "from each per-observable expand call; got a list. "
+                    "Override this helper if your protocol nests tuples."
+                )
+            ctx = dict(ctx)
+            start = len(merged_dags)
+            merged_dags.extend(obs_dags)
+            ctx["dag_indices"] = list(range(start, len(merged_dags)))
+            contexts.append(ctx)
+        return tuple(merged_dags), contexts
+
+    def _reduce_for_list_context(
+        self,
+        quantum_results: Sequence[Any],
+        contexts: list[QEMContext],
+    ) -> list[float]:
+        """Default multi-observable :meth:`reduce` dispatch helper.
+
+        Distinguishes two shapes of ``quantum_results``:
+
+        * **Per-DAG rows of per-observable values** (length-N lists, where
+          N matches ``len(contexts)``) — emitted by ``MeasurementStage``
+          when the meta carries a tuple ``observable``.  Each observable's
+          mitigated value comes from extracting its column.
+        * **Scalar rows** — typically only seen by tests that bypass
+          ``MeasurementStage``.  Each context sees the full results.
+        """
+        if quantum_results and isinstance(quantum_results[0], (list, tuple)):
+            n = len(contexts)
+            sample_len = len(quantum_results[0])
+            if sample_len != n:
+                raise RuntimeError(
+                    f"Expected {n} per-observable values per DAG, got "
+                    f"{sample_len}.  Multi-observable contexts and "
+                    f"MeasurementStage rows are out of sync."
+                )
+            return [
+                self.reduce([row[i] for row in quantum_results], contexts[i])
+                for i in range(n)
+            ]
+        return [self.reduce(quantum_results, c) for c in contexts]
 
     def post_reduce(self, contexts: Sequence[QEMContext]) -> None:
         """Hook called after all per-group ``reduce`` calls in an evaluation.
@@ -116,16 +226,32 @@ class _NoMitigation(QEMProtocol):
         return "NoMitigation"
 
     def expand(
-        self, dag: DAGCircuit, observable: Any | None = None
-    ) -> tuple[tuple[DAGCircuit, ...], QEMContext]:
-        return (dag,), {}
+        self,
+        dag: DAGCircuit,
+        observable: Any | tuple[Any, ...] | None = None,
+    ) -> tuple[tuple[DAGCircuit, ...], QEMContext | list[QEMContext]]:
+        if isinstance(observable, tuple):
+            return self._expand_per_observable_loop(dag, observable)
+        return (dag,), {"dag_indices": [0]}
 
-    def reduce(self, quantum_results: Sequence[float], context: QEMContext) -> float:
-        if len(quantum_results) == 0:
+    def reduce(
+        self,
+        quantum_results: Sequence[float],
+        context: QEMContext | list[QEMContext],
+    ) -> float | list[float]:
+        if isinstance(context, list):
+            return self._reduce_for_list_context(quantum_results, context)
+        indices = context.get("dag_indices")
+        selected = (
+            [quantum_results[i] for i in indices]
+            if indices is not None
+            else list(quantum_results)
+        )
+        if len(selected) == 0:
             raise RuntimeError("NoMitigation received an empty results sequence.")
-        if len(quantum_results) > 1:
+        if len(selected) > 1:
             raise RuntimeError("NoMitigation class received multiple partial results.")
-        return quantum_results[0]
+        return selected[0]
 
 
 # ---------------------------------------------------------------------------
@@ -375,8 +501,16 @@ class ZNE(QEMProtocol):
         return self._folding_fn
 
     def expand(
-        self, dag: DAGCircuit, observable: Any | None = None
-    ) -> tuple[tuple[DAGCircuit, ...], QEMContext]:
+        self,
+        dag: DAGCircuit,
+        observable: Any | tuple[Any, ...] | None = None,
+    ) -> tuple[tuple[DAGCircuit, ...], QEMContext | list[QEMContext]]:
+        if isinstance(observable, tuple):
+            # Folding is observable-independent, so the loop helper produces
+            # N copies of the same folded DAGs.  Correct, not optimal — a
+            # ZNE-specific override could share the folded set.
+            return self._expand_per_observable_loop(dag, observable)
+
         # Expand takes ownership of `dag` (see QEMProtocol.expand).  For
         # S scale factors we need S distinct folded outputs; the input
         # can absorb one of them, so we deepcopy S-1 times instead of S.
@@ -400,8 +534,23 @@ class ZNE(QEMProtocol):
                 stacklevel=2,
             )
 
-        return folded_dags, {"effective_scales": effective_scales}
+        return folded_dags, {
+            "effective_scales": effective_scales,
+            "dag_indices": list(range(len(folded_dags))),
+        }
 
-    def reduce(self, quantum_results: Sequence[float], context: QEMContext) -> float:
+    def reduce(
+        self,
+        quantum_results: Sequence[float],
+        context: QEMContext | list[QEMContext],
+    ) -> float | list[float]:
+        if isinstance(context, list):
+            return self._reduce_for_list_context(quantum_results, context)
+        indices = context.get("dag_indices")
+        selected = (
+            [quantum_results[i] for i in indices]
+            if indices is not None
+            else list(quantum_results)
+        )
         scales = context.get("effective_scales", self._scale_factors)
-        return self._extrapolator.extrapolate(scales, list(quantum_results))
+        return self._extrapolator.extrapolate(scales, selected)

--- a/divi/circuits/quepp.py
+++ b/divi/circuits/quepp.py
@@ -919,7 +919,7 @@ class QuEPP(QEMProtocol):
         validated = self._validate_observable(observable)
         prep = self._preprocess(dag, validated)
         paths = self._select_paths(prep)
-        self._warn_on_truncation_ratio(prep)
+        self._warn_on_truncation_ratio(len(prep.rotations))
         return prep, paths, validated
 
     def expand(
@@ -992,9 +992,7 @@ class QuEPP(QEMProtocol):
         coincident path DAGs.
         """
         if len(observables) == 0:
-            raise ValueError(
-                "QuEPP requires at least one observable in the tuple."
-            )
+            raise ValueError("QuEPP requires at least one observable in the tuple.")
         for obs in observables:
             self._validate_observable(obs)
 
@@ -1062,9 +1060,7 @@ class QuEPP(QEMProtocol):
             obs_path_dags = [
                 merged_path_dags[branch_to_dag_idx[p.branches]] for p in paths
             ]
-            classical_values = _simulate_clifford_ensemble(
-                obs_path_dags, obs, n_qubits
-            )
+            classical_values = _simulate_clifford_ensemble(obs_path_dags, obs, n_qubits)
             weights = [p.weight for p in paths]
 
             ctx: QEMContext = {
@@ -1080,7 +1076,7 @@ class QuEPP(QEMProtocol):
             }
             if symbolic:
                 ctx["symbolic"] = True
-                ctx["weight_symbols"] = sorted(all_params, key=lambda p: p.name)
+                ctx["weight_symbols"] = sorted(all_params or [], key=lambda p: p.name)
             contexts.append(ctx)
 
         return merged_dags, contexts

--- a/divi/circuits/quepp.py
+++ b/divi/circuits/quepp.py
@@ -283,8 +283,8 @@ class _PauliPath:
 
 @dataclass(frozen=True)
 class _PreprocResult:
-    """Bundle of quantities shared across :meth:`QuEPP._preprocess`,
-    :meth:`QuEPP._select_paths`, and :meth:`QuEPP._build_ensemble`."""
+    """Bundle of quantities shared across :meth:`QuEPP._preprocess` and
+    :meth:`QuEPP._select_paths`."""
 
     working: QuantumCircuit
     n_qubits: int
@@ -906,97 +906,21 @@ class QuEPP(QEMProtocol):
     def name(self) -> str:
         return "quepp"
 
-    def _prepare_paths(
-        self, dag: DAGCircuit, observable: SparsePauliOp | None
-    ) -> tuple["_PreprocResult", list["_PauliPath"], SparsePauliOp]:
-        """Shared setup for :meth:`expand` / :meth:`dry_expand`.
-
-        Runs the cheap prefix (validation, preprocessing, path selection,
-        truncation warning) — everything except the expensive Clifford
-        simulation + per-path DAG cloning. Both real and dry paths build
-        on the returned ``(prep, paths, validated_observable)`` tuple.
-        """
-        validated = self._validate_observable(observable)
-        prep = self._preprocess(dag, validated)
-        paths = self._select_paths(prep)
-        self._warn_on_truncation_ratio(len(prep.rotations))
-        return prep, paths, validated
-
     def expand(
         self,
         dag: DAGCircuit,
-        observable: SparsePauliOp | tuple[SparsePauliOp, ...] | None = None,
-    ) -> tuple[tuple[DAGCircuit, ...], QEMContext | list[QEMContext]]:
-        if isinstance(observable, tuple):
-            return self._expand_for_observables(dag, observable)
-        prep, paths, validated = self._prepare_paths(dag, observable)
-        return self._build_ensemble(dag, prep, paths, validated)
-
-    def dry_expand(
-        self,
-        dag: DAGCircuit,
-        observable: SparsePauliOp | tuple[SparsePauliOp, ...] | None = None,
+        observable: tuple[SparsePauliOp, ...] | None = None,
     ) -> tuple[tuple[DAGCircuit, ...], QEMContext]:
-        """Analytic path: emit ``1 + n_paths`` placeholder DAGs, no Clifford sim.
+        """Build path DAGs and per-observable classical context.
 
-        Reuses :meth:`_prepare_paths` to get the exact path count (source
-        of truth for the fan-out), then skips the per-path
-        ``_build_path_dag`` surgery and the full Clifford ensemble
-        simulation — the two dominant costs of :meth:`expand` — and reuses
-        the input ``dag`` as a shared placeholder for every emitted slot.
-        Context keys read by :class:`~divi.pipeline.stages.QEMStage`'s
-        introspect hook (``n_rotations``, ``n_paths``, ``symbolic``) are
-        populated so dry-run reports render correctly.
+        Preprocessing and Clifford tableau construction run once; path
+        enumeration and classical simulation run per observable.  Paths
+        sharing a ``branches`` tuple produce the same Clifford circuit
+        and are deduped across observables.
         """
-        # Multi-observable dry-run accounting is not yet implemented;
-        # use the first observable's path count as a conservative proxy.
-        if isinstance(observable, tuple):
-            observable = observable[0] if observable else None
-        prep, paths, _ = self._prepare_paths(dag, observable)
-        n_paths = len(paths)
-        # Placeholder DAG per slot — dry stages don't submit / simulate.
-        all_dags = (dag,) * (1 + n_paths)
-        context: QEMContext = {
-            "classical_values": None,
-            "weights": None,
-            "target_idx": 0,
-            "ensemble_start": 1,
-            "n_rotations": len(prep.rotations),
-            "n_paths": n_paths,
-        }
-        if prep.symbolic:
-            context["symbolic"] = True
-            context["weight_symbols"] = []
-        return all_dags, context
+        observables = self._validate_observable_tuple(observable)
 
-    def _expand_for_observables(
-        self,
-        dag: DAGCircuit,
-        observables: tuple[SparsePauliOp, ...],
-    ) -> tuple[tuple[DAGCircuit, ...], list[QEMContext]]:
-        """Multi-observable expansion that shares the target DAG and dedupes
-        path DAGs across observables.
-
-        The target circuit is observable-independent and is emitted once at
-        index 0 of ``merged_dags``.  Path DAGs are determined by
-        ``(working_dag, rotation_positions, branches)`` — paths from
-        different observables that share a ``branches`` tuple produce the
-        same DAG and are deduplicated.  Each per-observable context records
-        ``"dag_indices"`` listing the positions in ``merged_dags`` that make
-        up its target+ensemble (with target at the slice's index 0 and the
-        observable's ensemble at indices 1..k).
-
-        Path enumeration and η are per-observable per the QuEPP paper
-        (arXiv:2603.14485, Eq. 1, Sec. III) — the only sharing here is the
-        observable-independent preprocessing, the target circuit, and
-        coincident path DAGs.
-        """
-        if len(observables) == 0:
-            raise ValueError("QuEPP requires at least one observable in the tuple.")
-        for obs in observables:
-            self._validate_observable(obs)
-
-        # ----- Observable-independent preprocessing (done ONCE) ---------- #
+        # ----- Observable-independent preprocessing ---------------------- #
         target_qc = dag_to_circuit(dag)
         n_qubits = target_qc.num_qubits
         decomposed = _decompose_controlled_rotations(target_qc)
@@ -1017,8 +941,6 @@ class QuEPP(QEMProtocol):
                 symbolic=symbolic,
             )
             obs_paths_list.append(self._select_paths(prep))
-        # Truncation-ratio warning depends only on the rotation count and
-        # K_T, both observable-independent — emit at most once.
         self._warn_on_truncation_ratio(len(rotations))
 
         # ----- Path-DAG dedup across observables ------------------------- #
@@ -1034,10 +956,9 @@ class QuEPP(QEMProtocol):
                         _build_path_dag(working_dag, rotation_positions, p.branches)
                     )
 
-        # merged_dags: shared target at index 0, deduped path DAGs at 1..M
         merged_dags = (dag,) + tuple(merged_path_dags)
 
-        # ----- Per-observable contexts ----------------------------------- #
+        # ----- Per-observable per-path classical sim + weights ----------- #
         all_params: set[Parameter] | None = None
         if symbolic:
             all_params = set().union(
@@ -1048,51 +969,119 @@ class QuEPP(QEMProtocol):
                 )
             )
 
-        contexts: list[QEMContext] = []
+        per_obs: list[dict] = []
         for obs, paths in zip(observables, obs_paths_list):
-            # Position in merged_dags for each of this observable's paths
-            # (offset by +1 because index 0 is the shared target).
+            # +1 offset because merged_dags[0] is the shared target.
             path_positions = [branch_to_dag_idx[p.branches] + 1 for p in paths]
             dag_indices = [0] + path_positions
 
-            # Classical simulation uses each obs's own terms; pull the
-            # already-built (deduped) path DAGs in this obs's path order.
             obs_path_dags = [
                 merged_path_dags[branch_to_dag_idx[p.branches]] for p in paths
             ]
             classical_values = _simulate_clifford_ensemble(obs_path_dags, obs, n_qubits)
             weights = [p.weight for p in paths]
+            per_obs.append(
+                {
+                    "classical_values": classical_values,
+                    "weights": (
+                        np.array(weights, dtype=object)
+                        if symbolic
+                        else np.array(weights)
+                    ),
+                    "n_paths": len(paths),
+                    "dag_indices": dag_indices,
+                }
+            )
 
-            ctx: QEMContext = {
-                "classical_values": classical_values,
-                "weights": (
-                    np.array(weights, dtype=object) if symbolic else np.array(weights)
-                ),
-                "target_idx": 0,
-                "ensemble_start": 1,
-                "n_rotations": len(rotations),
-                "n_paths": len(paths),
-                "dag_indices": dag_indices,
-            }
-            if symbolic:
-                ctx["symbolic"] = True
-                ctx["weight_symbols"] = sorted(all_params or [], key=lambda p: p.name)
-            contexts.append(ctx)
+        context: QEMContext = {
+            "per_obs": per_obs,
+            "target_idx": 0,
+            "ensemble_start": 1,
+            "n_rotations": len(rotations),
+            "n_paths": len(merged_path_dags),
+        }
+        if symbolic:
+            context["symbolic"] = True
+            context["weight_symbols"] = sorted(
+                all_params if all_params is not None else [],
+                key=lambda p: p.name,
+            )
+        return merged_dags, context
 
-        return merged_dags, contexts
+    def dry_expand(
+        self,
+        dag: DAGCircuit,
+        observable: tuple[SparsePauliOp, ...] | None = None,
+    ) -> tuple[tuple[DAGCircuit, ...], QEMContext]:
+        """Analytic path: emit ``1 + n_paths`` placeholder DAGs, no Clifford sim.
+
+        Runs the same preprocessing + per-observable path enumeration as
+        :meth:`expand` to get an accurate fan-out factor, then skips the
+        per-path DAG surgery and Clifford ensemble simulation — the two
+        dominant costs — and reuses the input ``dag`` as a placeholder for
+        every emitted slot.  ``n_paths`` reflects the deduplicated count
+        across all observables.
+        """
+        observables = self._validate_observable_tuple(observable)
+
+        target_qc = dag_to_circuit(dag)
+        n_qubits = target_qc.num_qubits
+        decomposed = _decompose_controlled_rotations(target_qc)
+        symbolic = _has_symbolic_angles(decomposed)
+        working = _normalize_circuit(decomposed)
+        rotations = _extract_rotation_gates(working)
+        tableaus = _build_clifford_tableaus(working, rotations)
+
+        unique_branches: set[tuple[int, ...]] = set()
+        for obs in observables:
+            prep = _PreprocResult(
+                working=working,
+                n_qubits=n_qubits,
+                rotations=rotations,
+                tableaus=tableaus,
+                obs_terms=_obs_to_stim_terms(obs, n_qubits),
+                symbolic=symbolic,
+            )
+            for p in self._select_paths(prep):
+                unique_branches.add(p.branches)
+        self._warn_on_truncation_ratio(len(rotations))
+
+        n_paths = len(unique_branches)
+        all_dags = (dag,) * (1 + n_paths)
+        context: QEMContext = {
+            "per_obs": None,
+            "target_idx": 0,
+            "ensemble_start": 1,
+            "n_rotations": len(rotations),
+            "n_paths": n_paths,
+        }
+        if symbolic:
+            context["symbolic"] = True
+            context["weight_symbols"] = []
+        return all_dags, context
 
     @staticmethod
-    def _validate_observable(observable: SparsePauliOp | None) -> SparsePauliOp:
+    def _validate_observable_tuple(
+        observable: SparsePauliOp | tuple[SparsePauliOp, ...] | None,
+    ) -> tuple[SparsePauliOp, ...]:
         if observable is None:
             raise ValueError(
-                "QuEPP requires an observable (SparsePauliOp) for classical "
-                "Clifford simulation."
+                "QuEPP requires at least one observable (SparsePauliOp) for "
+                "classical Clifford simulation."
             )
-        if not isinstance(observable, SparsePauliOp):
-            raise TypeError(
-                f"QuEPP.expand expected a SparsePauliOp observable, got "
-                f"{type(observable).__name__}."
+        if isinstance(observable, SparsePauliOp):
+            observable = (observable,)
+        if not observable:
+            raise ValueError(
+                "QuEPP requires at least one observable (SparsePauliOp) for "
+                "classical Clifford simulation."
             )
+        for obs in observable:
+            if not isinstance(obs, SparsePauliOp):
+                raise TypeError(
+                    f"QuEPP.expand observable tuple entries must be "
+                    f"SparsePauliOp; got {type(obs).__name__}."
+                )
         return observable
 
     @staticmethod
@@ -1161,63 +1150,6 @@ class QuEPP(QEMProtocol):
                 stacklevel=3,
             )
 
-    def _build_ensemble(
-        self,
-        dag: DAGCircuit,
-        prep: "_PreprocResult",
-        paths: list[_PauliPath],
-        observable: SparsePauliOp,
-    ) -> tuple[tuple[DAGCircuit, ...], QEMContext]:
-        """Build Clifford path DAGs, simulate them, and assemble the context.
-
-        Returns the original (non-normalised) target DAG together with the
-        Clifford path DAGs.  The target runs on hardware; path circuits are
-        only used for classical stim simulation and the η rescaling, never
-        transmitted to the backend — but the pipeline treats them uniformly
-        as DAGs, so we emit them as such.
-        """
-        # inst_idx == topological position (both enumerate qc.data order),
-        # so _build_path_dag can do O(K) node surgery per path.
-        working_dag = circuit_to_dag(prep.working)
-        rotation_positions = [(rot.inst_idx, rot) for rot in prep.rotations]
-
-        path_dags = [
-            _build_path_dag(working_dag, rotation_positions, p.branches) for p in paths
-        ]
-        classical_values = _simulate_clifford_ensemble(
-            path_dags, observable, prep.n_qubits
-        )
-        weights = [p.weight for p in paths]
-
-        all_dags = (dag,) + tuple(path_dags)
-        symbolic = prep.symbolic
-        context: QEMContext = {
-            "classical_values": classical_values,
-            "weights": (
-                np.array(weights, dtype=object) if symbolic else np.array(weights)
-            ),
-            "target_idx": 0,
-            "ensemble_start": 1,
-            "n_rotations": len(prep.rotations),
-            "n_paths": len(paths),
-            # Identity range — present on every context so that ``reduce``
-            # uses the same slicing path in both single- and multi-observable
-            # mode (see ``_expand_for_observables`` for the non-trivial case).
-            "dag_indices": list(range(len(all_dags))),
-        }
-        if symbolic:
-            all_params: set[Parameter] = set().union(
-                *(
-                    rot.angle.parameters
-                    for rot in prep.rotations
-                    if _is_parametric(rot.angle)
-                )
-            )
-            context["symbolic"] = True
-            context["weight_symbols"] = sorted(all_params, key=lambda p: p.name)
-
-        return all_dags, context
-
     @staticmethod
     def compute_eta(
         classical_values: np.ndarray,
@@ -1233,71 +1165,103 @@ class QuEPP(QEMProtocol):
 
     @staticmethod
     def evaluate_symbolic_weights(
-        context: QEMContext,
+        per_obs_entry: dict,
         symbols: Sequence[Parameter],
         param_values: np.ndarray,
     ) -> None:
         """Substitute concrete parameter values into symbolic weight expressions.
 
-        *symbols* are the Qiskit :class:`~qiskit.circuit.Parameter`
-        objects referenced by the weight expressions.  *param_values* are
-        the corresponding numeric values (same positional order).
+        Operates on a single ``per_obs`` slot.  *symbols* are the Qiskit
+        :class:`~qiskit.circuit.Parameter` objects referenced by the
+        weight expressions; *param_values* are their numeric values in
+        the same positional order.
         """
+        if "per_obs" in per_obs_entry:
+            raise TypeError(
+                "evaluate_symbolic_weights expects a per_obs entry "
+                "(context['per_obs'][i]), not the full QuEPP context."
+            )
         binding = {p: float(v) for p, v in zip(symbols, param_values)}
-        context["weights"] = np.array(
+        per_obs_entry["weights"] = np.array(
             [
                 (
                     float(w.bind({p: binding[p] for p in w.parameters}))
                     if isinstance(w, ParameterExpression)
                     else float(w)
                 )
-                for w in context["weights"]
+                for w in per_obs_entry["weights"]
             ]
         )
-        context["symbolic"] = False
 
     def reduce(
         self,
         quantum_results: Sequence[float],
-        context: QEMContext | list[QEMContext],
-    ) -> float | list[float]:
-        if isinstance(context, list):
-            return self._reduce_for_list_context(quantum_results, context)
-        d = context
-        if d.get("symbolic"):
+        context: QEMContext,
+    ) -> list[float]:
+        """Combine quantum results with per-observable classical context(s)
+        into a list of mitigated expectation values.
+
+        The context's ``per_obs`` list carries one entry per observable;
+        each entry has its own ``dag_indices`` slicing
+        ``quantum_results``, its own ``classical_values`` and ``weights``,
+        and produces one mitigated value via the QuEPP η formula.
+        """
+        if context.get("symbolic"):
             raise ValueError(
                 "QuEPP weights are still symbolic — parameter values were "
                 "never substituted. Add ParameterBindingStage to the "
                 "pipeline or use QuEPP(bind_before_mitigation=True)."
             )
-        # Slice by ``dag_indices`` so target_idx/ensemble_start are
-        # interpreted relative to this observable's view of the merged DAG
-        # tuple.  Falls back to the full results for legacy contexts.
-        indices = d.get("dag_indices")
-        if indices is not None:
-            quantum_results = [quantum_results[i] for i in indices]
-        target_noisy = quantum_results[d["target_idx"]]
-        ensemble_noisy = np.array(quantum_results[d["ensemble_start"] :], dtype=float)
-        classical_values = d["classical_values"]
-        weights = d["weights"]
+        per_obs: list[dict] | None = context.get("per_obs")
+        if per_obs is None:
+            raise RuntimeError(
+                "QuEPP.reduce: context has no per_obs entries (was this a "
+                "dry-run context?)."
+            )
+        target_idx = context["target_idx"]
+        ensemble_start = context["ensemble_start"]
+        n_rotations = context["n_rotations"]
 
-        if d["n_rotations"] == 0:
-            return float(weights @ classical_values)
+        out: list[float] = []
+        for obs_idx, entry in enumerate(per_obs):
+            indices = entry["dag_indices"]
+            obs_results: list[float] = []
+            for i in indices:
+                row = quantum_results[i]
+                if isinstance(row, (list, tuple)):
+                    obs_results.append(float(row[obs_idx]))
+                else:
+                    obs_results.append(float(row))
 
-        classical_est = float(weights @ classical_values)
-        noisy_est = float(weights @ ensemble_noisy)
+            target_noisy = obs_results[target_idx]
+            ensemble_noisy = np.array(obs_results[ensemble_start:], dtype=float)
+            classical_values = entry["classical_values"]
+            weights = entry["weights"]
 
-        eta = self.compute_eta(classical_values, ensemble_noisy)
-        if eta is None:
-            valid = np.abs(classical_values) > 1e-12
-            if np.any(valid):
-                context["_signal_destroyed"] = True
-            return float(target_noisy)
+            if n_rotations == 0:
+                out.append(float(weights @ classical_values))
+                continue
 
-        return classical_est + (target_noisy - noisy_est) / eta
+            classical_est = float(weights @ classical_values)
+            noisy_est = float(weights @ ensemble_noisy)
+
+            eta = self.compute_eta(classical_values, ensemble_noisy)
+            if eta is None:
+                valid = np.abs(classical_values) > 1e-12
+                if np.any(valid):
+                    entry["_signal_destroyed"] = True
+                out.append(float(target_noisy))
+                continue
+
+            out.append(classical_est + (target_noisy - noisy_est) / eta)
+
+        return out
 
     def post_reduce(self, contexts: Sequence[QEMContext]) -> None:
-        destroyed = sum(1 for c in contexts if c.get("_signal_destroyed"))
+        destroyed = 0
+        for ctx in contexts:
+            per_obs = ctx.get("per_obs") or []
+            destroyed += sum(1 for entry in per_obs if entry.get("_signal_destroyed"))
         if destroyed:
             warnings.warn(
                 "QuEPP: signal destroyed — η fell below the safety threshold "

--- a/divi/circuits/quepp.py
+++ b/divi/circuits/quepp.py
@@ -925,15 +925,17 @@ class QuEPP(QEMProtocol):
     def expand(
         self,
         dag: DAGCircuit,
-        observable: SparsePauliOp | None = None,
-    ) -> tuple[tuple[DAGCircuit, ...], QEMContext]:
+        observable: SparsePauliOp | tuple[SparsePauliOp, ...] | None = None,
+    ) -> tuple[tuple[DAGCircuit, ...], QEMContext | list[QEMContext]]:
+        if isinstance(observable, tuple):
+            return self._expand_for_observables(dag, observable)
         prep, paths, validated = self._prepare_paths(dag, observable)
         return self._build_ensemble(dag, prep, paths, validated)
 
     def dry_expand(
         self,
         dag: DAGCircuit,
-        observable: SparsePauliOp | None = None,
+        observable: SparsePauliOp | tuple[SparsePauliOp, ...] | None = None,
     ) -> tuple[tuple[DAGCircuit, ...], QEMContext]:
         """Analytic path: emit ``1 + n_paths`` placeholder DAGs, no Clifford sim.
 
@@ -946,6 +948,10 @@ class QuEPP(QEMProtocol):
         introspect hook (``n_rotations``, ``n_paths``, ``symbolic``) are
         populated so dry-run reports render correctly.
         """
+        # Multi-observable dry-run accounting is not yet implemented;
+        # use the first observable's path count as a conservative proxy.
+        if isinstance(observable, tuple):
+            observable = observable[0] if observable else None
         prep, paths, _ = self._prepare_paths(dag, observable)
         n_paths = len(paths)
         # Placeholder DAG per slot — dry stages don't submit / simulate.
@@ -962,6 +968,122 @@ class QuEPP(QEMProtocol):
             context["symbolic"] = True
             context["weight_symbols"] = []
         return all_dags, context
+
+    def _expand_for_observables(
+        self,
+        dag: DAGCircuit,
+        observables: tuple[SparsePauliOp, ...],
+    ) -> tuple[tuple[DAGCircuit, ...], list[QEMContext]]:
+        """Multi-observable expansion that shares the target DAG and dedupes
+        path DAGs across observables.
+
+        The target circuit is observable-independent and is emitted once at
+        index 0 of ``merged_dags``.  Path DAGs are determined by
+        ``(working_dag, rotation_positions, branches)`` — paths from
+        different observables that share a ``branches`` tuple produce the
+        same DAG and are deduplicated.  Each per-observable context records
+        ``"dag_indices"`` listing the positions in ``merged_dags`` that make
+        up its target+ensemble (with target at the slice's index 0 and the
+        observable's ensemble at indices 1..k).
+
+        Path enumeration and η are per-observable per the QuEPP paper
+        (arXiv:2603.14485, Eq. 1, Sec. III) — the only sharing here is the
+        observable-independent preprocessing, the target circuit, and
+        coincident path DAGs.
+        """
+        if len(observables) == 0:
+            raise ValueError(
+                "QuEPP requires at least one observable in the tuple."
+            )
+        for obs in observables:
+            self._validate_observable(obs)
+
+        # ----- Observable-independent preprocessing (done ONCE) ---------- #
+        target_qc = dag_to_circuit(dag)
+        n_qubits = target_qc.num_qubits
+        decomposed = _decompose_controlled_rotations(target_qc)
+        symbolic = _has_symbolic_angles(decomposed)
+        working = _normalize_circuit(decomposed)
+        rotations = _extract_rotation_gates(working)
+        tableaus = _build_clifford_tableaus(working, rotations)
+
+        # ----- Per-observable path enumeration --------------------------- #
+        obs_paths_list: list[list[_PauliPath]] = []
+        for obs in observables:
+            prep = _PreprocResult(
+                working=working,
+                n_qubits=n_qubits,
+                rotations=rotations,
+                tableaus=tableaus,
+                obs_terms=_obs_to_stim_terms(obs, n_qubits),
+                symbolic=symbolic,
+            )
+            obs_paths_list.append(self._select_paths(prep))
+        # Truncation-ratio warning depends only on the rotation count and
+        # K_T, both observable-independent — emit at most once.
+        self._warn_on_truncation_ratio(prep)
+
+        # ----- Path-DAG dedup across observables ------------------------- #
+        working_dag = circuit_to_dag(working)
+        rotation_positions = [(rot.inst_idx, rot) for rot in rotations]
+        branch_to_dag_idx: dict[tuple[int, ...], int] = {}
+        merged_path_dags: list[DAGCircuit] = []
+        for paths in obs_paths_list:
+            for p in paths:
+                if p.branches not in branch_to_dag_idx:
+                    branch_to_dag_idx[p.branches] = len(merged_path_dags)
+                    merged_path_dags.append(
+                        _build_path_dag(working_dag, rotation_positions, p.branches)
+                    )
+
+        # merged_dags: shared target at index 0, deduped path DAGs at 1..M
+        merged_dags = (dag,) + tuple(merged_path_dags)
+
+        # ----- Per-observable contexts ----------------------------------- #
+        all_params: set[Parameter] | None = None
+        if symbolic:
+            all_params = set().union(
+                *(
+                    rot.angle.parameters
+                    for rot in rotations
+                    if _is_parametric(rot.angle)
+                )
+            )
+
+        contexts: list[QEMContext] = []
+        for obs, paths in zip(observables, obs_paths_list):
+            # Position in merged_dags for each of this observable's paths
+            # (offset by +1 because index 0 is the shared target).
+            path_positions = [branch_to_dag_idx[p.branches] + 1 for p in paths]
+            dag_indices = [0] + path_positions
+
+            # Classical simulation uses each obs's own terms; pull the
+            # already-built (deduped) path DAGs in this obs's path order.
+            obs_path_dags = [
+                merged_path_dags[branch_to_dag_idx[p.branches]] for p in paths
+            ]
+            classical_values = _simulate_clifford_ensemble(
+                obs_path_dags, obs, n_qubits
+            )
+            weights = [p.weight for p in paths]
+
+            ctx: QEMContext = {
+                "classical_values": classical_values,
+                "weights": (
+                    np.array(weights, dtype=object) if symbolic else np.array(weights)
+                ),
+                "target_idx": 0,
+                "ensemble_start": 1,
+                "n_rotations": len(rotations),
+                "n_paths": len(paths),
+                "dag_indices": dag_indices,
+            }
+            if symbolic:
+                ctx["symbolic"] = True
+                ctx["weight_symbols"] = sorted(all_params, key=lambda p: p.name)
+            contexts.append(ctx)
+
+        return merged_dags, contexts
 
     @staticmethod
     def _validate_observable(observable: SparsePauliOp | None) -> SparsePauliOp:
@@ -1083,6 +1205,10 @@ class QuEPP(QEMProtocol):
             "ensemble_start": 1,
             "n_rotations": len(prep.rotations),
             "n_paths": len(paths),
+            # Identity range — present on every context so that ``reduce``
+            # uses the same slicing path in both single- and multi-observable
+            # mode (see ``_expand_for_observables`` for the non-trivial case).
+            "dag_indices": list(range(len(all_dags))),
         }
         if symbolic:
             all_params: set[Parameter] = set().union(
@@ -1138,8 +1264,10 @@ class QuEPP(QEMProtocol):
     def reduce(
         self,
         quantum_results: Sequence[float],
-        context: QEMContext,
-    ) -> float:
+        context: QEMContext | list[QEMContext],
+    ) -> float | list[float]:
+        if isinstance(context, list):
+            return self._reduce_for_list_context(quantum_results, context)
         d = context
         if d.get("symbolic"):
             raise ValueError(
@@ -1147,6 +1275,12 @@ class QuEPP(QEMProtocol):
                 "never substituted. Add ParameterBindingStage to the "
                 "pipeline or use QuEPP(bind_before_mitigation=True)."
             )
+        # Slice by ``dag_indices`` so target_idx/ensemble_start are
+        # interpreted relative to this observable's view of the merged DAG
+        # tuple.  Falls back to the full results for legacy contexts.
+        indices = d.get("dag_indices")
+        if indices is not None:
+            quantum_results = [quantum_results[i] for i in indices]
         target_noisy = quantum_results[d["target_idx"]]
         ensemble_noisy = np.array(quantum_results[d["ensemble_start"] :], dtype=float)
         classical_values = d["classical_values"]

--- a/divi/circuits/quepp.py
+++ b/divi/circuits/quepp.py
@@ -1021,7 +1021,7 @@ class QuEPP(QEMProtocol):
             obs_paths_list.append(self._select_paths(prep))
         # Truncation-ratio warning depends only on the rotation count and
         # K_T, both observable-independent — emit at most once.
-        self._warn_on_truncation_ratio(prep)
+        self._warn_on_truncation_ratio(len(rotations))
 
         # ----- Path-DAG dedup across observables ------------------------- #
         working_dag = circuit_to_dag(working)
@@ -1154,8 +1154,7 @@ class QuEPP(QEMProtocol):
             coefficient_threshold=coeff_threshold,
         )
 
-    def _warn_on_truncation_ratio(self, prep: "_PreprocResult") -> None:
-        n_rotations = len(prep.rotations)
+    def _warn_on_truncation_ratio(self, n_rotations: int) -> None:
         if n_rotations > 0 and self._K_T / n_rotations > 0.33:
             warnings.warn(
                 f"QuEPP: truncation order K={self._K_T} replaces a large "

--- a/divi/circuits/quepp.py
+++ b/divi/circuits/quepp.py
@@ -942,6 +942,9 @@ class QuEPP(QEMProtocol):
             )
             obs_paths_list.append(self._select_paths(prep))
         self._warn_on_truncation_ratio(len(rotations))
+        self._warn_no_diagonal_paths(
+            len(rotations), [len(paths) for paths in obs_paths_list]
+        )
 
         # ----- Path-DAG dedup across observables ------------------------- #
         working_dag = circuit_to_dag(working)
@@ -1033,6 +1036,7 @@ class QuEPP(QEMProtocol):
         tableaus = _build_clifford_tableaus(working, rotations)
 
         unique_branches: set[tuple[int, ...]] = set()
+        n_paths_per_obs: list[int] = []
         for obs in observables:
             prep = _PreprocResult(
                 working=working,
@@ -1042,9 +1046,12 @@ class QuEPP(QEMProtocol):
                 obs_terms=_obs_to_stim_terms(obs, n_qubits),
                 symbolic=symbolic,
             )
-            for p in self._select_paths(prep):
+            paths = self._select_paths(prep)
+            n_paths_per_obs.append(len(paths))
+            for p in paths:
                 unique_branches.add(p.branches)
         self._warn_on_truncation_ratio(len(rotations))
+        self._warn_no_diagonal_paths(len(rotations), n_paths_per_obs)
 
         n_paths = len(unique_branches)
         all_dags = (dag,) * (1 + n_paths)
@@ -1149,6 +1156,44 @@ class QuEPP(QEMProtocol):
                 f"truncation_order or using a deeper circuit.",
                 stacklevel=3,
             )
+
+    def _warn_no_diagonal_paths(
+        self, n_rotations: int, n_paths_per_obs: list[int]
+    ) -> None:
+        """Warn when one or more observables produce zero diagonal Pauli paths.
+
+        The Heisenberg-DFS enumerator only accepts paths whose final
+        back-propagated Pauli is diagonal (composed of ``I`` and ``Z``);
+        when the circuit's Clifford structure routes an observable into
+        a strictly non-diagonal basis (e.g. a final ``H`` rotates ``Z``
+        to ``X``), no path survives and ``classical_values`` is empty.
+        :meth:`reduce` then takes the ``eta is None`` branch and returns
+        the raw noisy target unchanged — so mitigation is a no-op even
+        though it was configured.  Surface this so the user does not
+        silently consume noisy results believing they were mitigated.
+
+        Emits a single warning listing every offending observable index,
+        so a multi-observable job with 50 failing observables produces
+        one diagnostic, not 50.
+        """
+        # All-Clifford circuits trivially have no rotations; mitigation
+        # is structurally a no-op and warning would be noise.
+        if n_rotations == 0:
+            return
+        zero_indices = [i for i, n in enumerate(n_paths_per_obs) if n == 0]
+        if not zero_indices:
+            return
+        warnings.warn(
+            f"QuEPP: observable(s) at index/indices {zero_indices} produced "
+            f"zero diagonal Pauli paths (truncation_order={self._K_T}, "
+            f"{n_rotations} non-Clifford rotation(s)). The Heisenberg "
+            f"back-propagation terminates in a non-diagonal basis, so "
+            f"mitigation will be a no-op for these observables and the "
+            f"raw noisy expectation will be returned. Consider rebasing "
+            f"the observable or restructuring the circuit's final "
+            f"Clifford layer.",
+            stacklevel=3,
+        )
 
     @staticmethod
     def compute_eta(

--- a/divi/circuits/quepp.py
+++ b/divi/circuits/quepp.py
@@ -1061,6 +1061,9 @@ class QuEPP(QEMProtocol):
             "ensemble_start": 1,
             "n_rotations": len(rotations),
             "n_paths": n_paths,
+            # Persisted for introspect(); the dry path skips per_obs
+            # construction, so the observable count needs its own slot.
+            "n_observables": len(observables),
         }
         if symbolic:
             context["symbolic"] = True

--- a/divi/pipeline/_core.py
+++ b/divi/pipeline/_core.py
@@ -422,7 +422,10 @@ class CircuitPipeline:
                 else:
                     raw = _counts_to_expvals(raw, plan.final_batch)
 
-        return PipelineResult(self._reduce(raw, env, plan.stage_tokens))
+        result = PipelineResult(self._reduce(raw, env, plan.stage_tokens))
+        if any(meta._was_multi_obs for meta in plan.initial_batch.values()):
+            result._squeeze = False
+        return result
 
     def run_forward_pass(
         self,

--- a/divi/pipeline/_dry_run.py
+++ b/divi/pipeline/_dry_run.py
@@ -72,7 +72,7 @@ def _logical_count(mc: MetaCircuit) -> int:
     if mc.observable is not None:
         # Pre-measurement baseline: one circuit per Pauli term, so that
         # grouping at the measurement stage shows up as a reduction.
-        return n_bodies * len(mc.observable)
+        return n_bodies * sum(len(o) for o in mc.observable)
     return n_bodies
 
 

--- a/divi/pipeline/_dry_run.py
+++ b/divi/pipeline/_dry_run.py
@@ -11,8 +11,10 @@ as a reduction (``factor < 1``), since grouping N Pauli terms into
 M ≤ N commuting groups saves circuits.
 """
 
+from statistics import mean, pstdev
 from typing import Any, NamedTuple
 
+from qiskit.dagcircuit import DAGCircuit
 from rich.console import Console
 from rich.tree import Tree
 
@@ -59,10 +61,84 @@ class DryRunReport(NamedTuple):
     need to drop into private helpers or rerun the forward pass manually.
     """
 
+    circuit_stats: dict[str, float] = {}
+    """Aggregate depth/width stats across the post-fan-out final batch's
+    DAG bodies — the pre-execution analogue of
+    :attr:`~divi.backends.CircuitRunner.depth_history`.  Empty when the
+    final batch has no DAG bodies (e.g. probability-mode pipelines that
+    only carry bound QASM strings).  Populated keys: ``mean_depth``,
+    ``std_depth``, ``min_depth``, ``max_depth``, ``mean_width``,
+    ``std_width``, ``min_width``, ``max_width``, ``mean_2q_depth``.
+    """
+
 
 def _effective_bodies(mc: MetaCircuit) -> tuple:
     # Mirrors _compile_batch: bound bodies take priority over parametric DAGs.
     return mc.bound_circuit_bodies or mc.circuit_bodies or ()
+
+
+def _two_qubit_depth(dag: DAGCircuit) -> int:
+    """Longest chain of two-qubit gates connected by shared qubits.
+
+    Mirrors ``DAGCircuit.depth()`` semantics but restricted to gates
+    whose ``qargs`` length is 2.  Single-qubit gates are ignored, even
+    when they would extend a circuit's overall depth — the goal here is
+    to surface the dominant fidelity predictor on superconducting
+    hardware, where two-qubit gates are an order of magnitude noisier
+    than single-qubit ones.
+
+    Internal helper: shared with :class:`~divi.pipeline.stages.CircuitSpecStage`
+    so its ``introspect()`` can report ``depth_2q`` without recomputing
+    the same walk.
+    """
+    qubit_depth: dict = {}
+    for node in dag.op_nodes():
+        if len(node.qargs) != 2:
+            continue
+        new_d = max((qubit_depth.get(q, 0) for q in node.qargs), default=0) + 1
+        for q in node.qargs:
+            qubit_depth[q] = new_d
+    return max(qubit_depth.values(), default=0)
+
+
+def _aggregate_circuit_stats(batch: MetaCircuitBatch) -> dict[str, float]:
+    """Compute mean/std/min/max for depth and width across a batch's DAG bodies.
+
+    Pre-execution analogue of :attr:`~divi.backends.CircuitRunner.depth_history`
+    aggregates: walks every ``circuit_bodies`` DAG in the batch and
+    summarises its depth, two-qubit depth, and qubit count.  Returns an
+    empty dict when no DAG bodies are reachable (e.g. probability-mode
+    pipelines whose final batch carries only bound QASM strings).
+    """
+    depths: list[int] = []
+    twoq_depths: list[int] = []
+    widths: list[int] = []
+    for mc in batch.values():
+        # bound_circuit_bodies are QASM strings — re-parsing them only to
+        # measure depth would be expensive, and in practice their structure
+        # mirrors ``circuit_bodies`` modulo concrete parameter substitution,
+        # which doesn't change depth or width.  Iterate the parametric DAGs
+        # when available; fall back to nothing when a body has only bound
+        # QASM (parameter-binding fast path stripped DAGs).
+        for _tag, dag in mc.circuit_bodies:
+            depths.append(dag.depth())
+            twoq_depths.append(_two_qubit_depth(dag))
+            widths.append(dag.num_qubits())
+
+    if not depths:
+        return {}
+
+    return {
+        "mean_depth": round(mean(depths), 2),
+        "std_depth": round(pstdev(depths), 2),
+        "min_depth": min(depths),
+        "max_depth": max(depths),
+        "mean_2q_depth": round(mean(twoq_depths), 2),
+        "mean_width": round(mean(widths), 2),
+        "std_width": round(pstdev(widths), 2),
+        "min_width": min(widths),
+        "max_width": max(widths),
+    }
 
 
 def _logical_count(mc: MetaCircuit) -> int:
@@ -134,6 +210,7 @@ def dry_run_pipeline(
         stages=tuple(infos),
         total_circuits=total,
         env_artifacts=dict(trace.env_artifacts),
+        circuit_stats=_aggregate_circuit_stats(trace.final_batch),
     )
 
 
@@ -188,6 +265,24 @@ def format_dry_run(reports: dict[str, DryRunReport]) -> None:
             )
         else:
             tree.add(f"[bold]Total: {report.total_circuits:,} circuits[/bold]")
+
+        if report.circuit_stats:
+            stats = report.circuit_stats
+            # Depth: lead with the average so the reader knows which stat
+            # this is. Add ± std and range only when there is spread.
+            if stats["min_depth"] == stats["max_depth"]:
+                depth_part = f"avg depth {stats['mean_depth']:g}"
+            else:
+                depth_part = (
+                    f"avg depth {stats['mean_depth']:g} "
+                    f"± {stats['std_depth']:g} "
+                    f"(range {stats['min_depth']}-{stats['max_depth']})"
+                )
+            if stats["min_width"] == stats["max_width"]:
+                width_part = f"width {stats['min_width']}"
+            else:
+                width_part = f"width {stats['min_width']}-{stats['max_width']}"
+            tree.add(f"[bold]Summary: {depth_part}, {width_part}[/bold]")
 
         console.print(tree)
         console.print()

--- a/divi/pipeline/_grouping.py
+++ b/divi/pipeline/_grouping.py
@@ -211,8 +211,12 @@ def compute_multi_observable_measurement_groups(
 
     # Build a flat union of every observable's Pauli labels and remember
     # which union-index each observable's k-th term occupies, plus that
-    # observable's real coefficient on it.
+    # observable's real coefficient on it.  Duplicate Paulis (across
+    # observables, or within one observable) collapse to a single union
+    # slot so postprocessing computes ``<P>`` once per unique Pauli;
+    # ``obs_indices[i]`` may reference the same slot from multiple owners.
     all_le_labels: list[str] = []
+    label_to_union_idx: dict[str, int] = {}
     obs_indices: list[list[int]] = []
     obs_coeffs: list[np.ndarray] = []
     for obs in observables:
@@ -220,8 +224,12 @@ def compute_multi_observable_measurement_groups(
         coeffs = np.real(obs.coeffs).astype(np.float64)
         indices: list[int] = []
         for lab in le_labels:
-            indices.append(len(all_le_labels))
-            all_le_labels.append(lab)
+            slot = label_to_union_idx.get(lab)
+            if slot is None:
+                slot = len(all_le_labels)
+                label_to_union_idx[lab] = slot
+                all_le_labels.append(lab)
+            indices.append(slot)
         obs_indices.append(indices)
         obs_coeffs.append(coeffs)
 

--- a/divi/pipeline/_grouping.py
+++ b/divi/pipeline/_grouping.py
@@ -170,3 +170,104 @@ def compute_measurement_groups(
 
     postprocessing_fn = _create_postprocessing_fn(coeffs, partition_indices, n_terms)
     return measurement_groups, partition_indices, postprocessing_fn
+
+
+def compute_multi_observable_measurement_groups(
+    observables: tuple[SparsePauliOp, ...],
+    strategy: GroupingStrategy,
+    n_qubits: int,
+) -> tuple[tuple[tuple[str, ...], ...], list[list[int]], Callable]:
+    """Group multiple observables for shared measurement fan-out.
+
+    All observables are measured from the same shot batch by computing
+    measurement groups over the UNION of their Pauli terms.  The returned
+    postprocessing function reads per-group expectation values once and
+    returns a ``list[float]`` of per-observable expectation values (one
+    entry per input observable, in input order).
+
+    The single-observable analogue is :func:`compute_measurement_groups`.
+
+    Args:
+        observables: Non-empty tuple of Hermitian observables.  Each
+            observable contributes its own Pauli terms (and coefficients)
+            to the union; postprocessing recovers per-observable expvals
+            using the original coefficients.
+        strategy: Grouping strategy applied to the union.
+            ``"_backend_expval"`` is rejected — the backend can only
+            evaluate one observable analytically at a time.
+        n_qubits: Total qubit count in the circuit.
+    """
+    if not observables:
+        raise ValueError(
+            "compute_multi_observable_measurement_groups: observables tuple "
+            "is empty."
+        )
+    if strategy == "_backend_expval":
+        raise ValueError(
+            "compute_multi_observable_measurement_groups does not support "
+            "'_backend_expval' (backend evaluates a single observable "
+            "analytically). Use 'qwc' or 'wires'."
+        )
+
+    # Build a flat union of every observable's Pauli labels and remember
+    # which union-index each observable's k-th term occupies, plus that
+    # observable's real coefficient on it.
+    all_le_labels: list[str] = []
+    obs_indices: list[list[int]] = []
+    obs_coeffs: list[np.ndarray] = []
+    for obs in observables:
+        le_labels = list(obs.paulis.to_labels())
+        coeffs = np.real(obs.coeffs).astype(np.float64)
+        indices: list[int] = []
+        for lab in le_labels:
+            indices.append(len(all_le_labels))
+            all_le_labels.append(lab)
+        obs_indices.append(indices)
+        obs_coeffs.append(coeffs)
+
+    if not all_le_labels:
+        raise ValueError(
+            "compute_multi_observable_measurement_groups: every observable "
+            "in the tuple is empty."
+        )
+
+    # Run the existing single-observable grouper on the union; coefficients
+    # are unused for grouping (we only need the partition + per-term group
+    # positions), so we set them to 1.0.
+    union = SparsePauliOp.from_list([(lab, 1.0) for lab in all_le_labels])
+    measurement_groups, partition_indices, _ = compute_measurement_groups(
+        union, strategy, n_qubits
+    )
+
+    n_total = len(all_le_labels)
+    reverse_map: list[tuple[int, int] | None] = [None] * n_total
+    for group_idx, indices in enumerate(partition_indices):
+        for pos, orig_idx in enumerate(indices):
+            reverse_map[orig_idx] = (group_idx, pos)
+    missing = [i for i, v in enumerate(reverse_map) if v is None]
+    if missing:
+        raise RuntimeError(
+            f"partition_indices does not cover all union term indices. "
+            f"Missing: {missing}"
+        )
+
+    n_obs = len(observables)
+
+    def postprocessing_fn(grouped_results):
+        if len(grouped_results) != len(partition_indices):
+            raise RuntimeError(
+                f"Expected {len(partition_indices)} grouped results, "
+                f"got {len(grouped_results)}."
+            )
+        flat = np.zeros(n_total, dtype=np.float64)
+        for orig_idx in range(n_total):
+            g_idx, pos = reverse_map[orig_idx]
+            val = grouped_results[g_idx]
+            if isinstance(val, dict):
+                val = val[pos]
+            flat[orig_idx] = float(np.asarray(val).flat[0])
+        return [
+            float(np.dot(obs_coeffs[i], flat[obs_indices[i]])) for i in range(n_obs)
+        ]
+
+    return measurement_groups, partition_indices, postprocessing_fn

--- a/divi/pipeline/_grouping.py
+++ b/divi/pipeline/_grouping.py
@@ -16,6 +16,8 @@ from typing import Literal
 import numpy as np
 from qiskit.quantum_info import SparsePauliOp
 
+from divi.circuits._core import flatten_observable_tuple
+
 GroupingStrategy = Literal["wires", "default", "qwc", "_backend_expval"] | None
 
 
@@ -52,23 +54,34 @@ def _wire_grouping_from_labels(
 
 
 def _create_postprocessing_fn(
-    coefficients: np.ndarray,
+    observables: tuple[SparsePauliOp, ...],
+    per_obs_term_indices: list[list[int]],
     partition_indices: list[list[int]],
-    n_terms: int,
+    n_union_terms: int,
 ) -> Callable:
-    """Build a callable that reassembles per-group results into a scalar expval."""
+    """Build a callable that reassembles per-group results into per-observable expvals.
+
+    Returns a function that takes per-group results (one entry per
+    measurement group) and returns a ``list[float]`` of per-observable
+    expectation values.
+    """
     reverse_lookup: dict[int, tuple[int, int]] = {}
     for group_idx, indices in enumerate(partition_indices):
         for pos, orig_idx in enumerate(indices):
             reverse_lookup[orig_idx] = (group_idx, pos)
 
-    missing = [i for i in range(n_terms) if i not in reverse_lookup]
+    missing = [i for i in range(n_union_terms) if i not in reverse_lookup]
     if missing:
         raise RuntimeError(
-            f"partition_indices does not cover all term indices. Missing: {missing}"
+            f"partition_indices does not cover all union term indices. "
+            f"Missing: {missing}"
         )
 
-    reverse_map: list[tuple[int, int]] = [reverse_lookup[i] for i in range(n_terms)]
+    reverse_map: list[tuple[int, int]] = [
+        reverse_lookup[i] for i in range(n_union_terms)
+    ]
+    n_obs = len(observables)
+    obs_coeffs = [np.real(o.coeffs).astype(np.float64) for o in observables]
 
     def postprocessing_fn(grouped_results):
         if len(grouped_results) != len(partition_indices):
@@ -76,58 +89,77 @@ def _create_postprocessing_fn(
                 f"Expected {len(partition_indices)} grouped results, "
                 f"got {len(grouped_results)}."
             )
-        flat = np.zeros(n_terms, dtype=np.float64)
-        for orig_idx in range(n_terms):
+        flat = np.zeros(n_union_terms, dtype=np.float64)
+        for orig_idx in range(n_union_terms):
             g_idx, pos = reverse_map[orig_idx]
             val = grouped_results[g_idx]
             if isinstance(val, dict):
                 val = val[pos]
             flat[orig_idx] = float(np.asarray(val).flat[0])
-        return np.dot(coefficients, flat)
+        return [
+            float(np.dot(obs_coeffs[i], flat[per_obs_term_indices[i]]))
+            for i in range(n_obs)
+        ]
 
     return postprocessing_fn
 
 
 def compute_measurement_groups(
-    observable: SparsePauliOp,
+    observable: tuple[SparsePauliOp, ...],
     strategy: GroupingStrategy,
     n_qubits: int,
 ) -> tuple[tuple[tuple[str, ...], ...], list[list[int]], Callable]:
-    """Group an observable's Pauli terms for measurement fan-out.
+    """Group an observable tuple's Pauli terms for measurement fan-out.
+
+    Operates on the union of every observable's Pauli terms — overlapping
+    Paulis (across or within observables) are deduplicated, and QWC
+    grouping shares measurement circuits across observables when their
+    terms are mutually qubit-wise commuting.
 
     Args:
-        observable: The Hermitian observable to group.
+        observable: Non-empty ``tuple[SparsePauliOp, ...]``.
         strategy: ``"qwc"``, ``"default"``, ``"wires"``,
-            ``"_backend_expval"``, or ``None``.
+            ``"_backend_expval"``, or ``None``.  ``"_backend_expval"`` is
+            valid only for length-1 observables.
         n_qubits: Total qubit count in the circuit.
 
     Returns:
         ``(measurement_groups, partition_indices, postprocessing_fn)``
 
         *measurement_groups*: tuple of tuples of big-endian Pauli label
-        strings (qubit 0 on the left).  Each inner tuple is one
-        commuting group.
+        strings (qubit 0 on the left), one tuple per commuting group over
+        the union of Pauli terms.
 
-        *partition_indices*: ``list[list[int]]`` mapping original term
+        *partition_indices*: ``list[list[int]]`` mapping union term
         indices to groups.
 
         *postprocessing_fn*: callable that recombines per-group
-        expectation values into the final scalar using the observable's
-        coefficients.
+        expectation values into a ``list[float]`` of per-observable
+        expectation values, in input order.
     """
-    # Qiskit labels are little-endian; we store big-endian internally.
-    le_labels = observable.paulis.to_labels()
-    be_labels = [label[::-1] for label in le_labels]
-    n_terms = len(be_labels)
-    coeffs = np.real(observable.coeffs).astype(np.float64)
+    if not observable:
+        raise ValueError("compute_measurement_groups: observable tuple is empty.")
+    if strategy == "_backend_expval" and len(observable) > 1:
+        raise ValueError(
+            "compute_measurement_groups does not support '_backend_expval' "
+            "for multi-observable inputs (the backend evaluates a single "
+            "observable analytically). Use 'qwc' or 'wires'."
+        )
 
-    # Pad labels to n_qubits if the observable acts on fewer qubits.
-    if len(be_labels[0]) < n_qubits:
+    union, per_obs_term_indices = flatten_observable_tuple(observable)
+
+    # Qiskit labels are little-endian; we store big-endian internally.
+    le_labels = union.paulis.to_labels()
+    be_labels = [label[::-1] for label in le_labels]
+    n_union_terms = len(be_labels)
+
+    # Pad labels to n_qubits if the union acts on fewer qubits.
+    if be_labels and len(be_labels[0]) < n_qubits:
         pad = n_qubits - len(be_labels[0])
         be_labels = [label + "I" * pad for label in be_labels]
 
     if strategy in ("qwc", "default"):
-        grouped_ops = observable.group_commuting(qubit_wise=True)
+        grouped_ops = union.group_commuting(qubit_wise=True)
         # Reconstruct partition_indices by matching labels back to originals.
         partition_indices: list[list[int]] = []
         grouped_be_labels: list[tuple[str, ...]] = []
@@ -158,126 +190,17 @@ def compute_measurement_groups(
         )
 
     elif strategy is None:
-        partition_indices = [[i] for i in range(n_terms)]
+        partition_indices = [[i] for i in range(n_union_terms)]
         measurement_groups = tuple((label,) for label in be_labels)
 
     elif strategy == "_backend_expval":
-        partition_indices = [list(range(n_terms))]
+        partition_indices = [list(range(n_union_terms))]
         measurement_groups = ((),)
 
     else:
         raise ValueError(f"Unknown grouping strategy: {strategy}")
 
-    postprocessing_fn = _create_postprocessing_fn(coeffs, partition_indices, n_terms)
-    return measurement_groups, partition_indices, postprocessing_fn
-
-
-def compute_multi_observable_measurement_groups(
-    observables: tuple[SparsePauliOp, ...],
-    strategy: GroupingStrategy,
-    n_qubits: int,
-) -> tuple[tuple[tuple[str, ...], ...], list[list[int]], Callable]:
-    """Group multiple observables for shared measurement fan-out.
-
-    All observables are measured from the same shot batch by computing
-    measurement groups over the UNION of their Pauli terms.  The returned
-    postprocessing function reads per-group expectation values once and
-    returns a ``list[float]`` of per-observable expectation values (one
-    entry per input observable, in input order).
-
-    The single-observable analogue is :func:`compute_measurement_groups`.
-
-    Args:
-        observables: Non-empty tuple of Hermitian observables.  Each
-            observable contributes its own Pauli terms (and coefficients)
-            to the union; postprocessing recovers per-observable expvals
-            using the original coefficients.
-        strategy: Grouping strategy applied to the union.
-            ``"_backend_expval"`` is rejected — the backend can only
-            evaluate one observable analytically at a time.
-        n_qubits: Total qubit count in the circuit.
-    """
-    if not observables:
-        raise ValueError(
-            "compute_multi_observable_measurement_groups: observables tuple "
-            "is empty."
-        )
-    if strategy == "_backend_expval":
-        raise ValueError(
-            "compute_multi_observable_measurement_groups does not support "
-            "'_backend_expval' (backend evaluates a single observable "
-            "analytically). Use 'qwc' or 'wires'."
-        )
-
-    # Build a flat union of every observable's Pauli labels and remember
-    # which union-index each observable's k-th term occupies, plus that
-    # observable's real coefficient on it.  Duplicate Paulis (across
-    # observables, or within one observable) collapse to a single union
-    # slot so postprocessing computes ``<P>`` once per unique Pauli;
-    # ``obs_indices[i]`` may reference the same slot from multiple owners.
-    all_le_labels: list[str] = []
-    label_to_union_idx: dict[str, int] = {}
-    obs_indices: list[list[int]] = []
-    obs_coeffs: list[np.ndarray] = []
-    for obs in observables:
-        le_labels = list(obs.paulis.to_labels())
-        coeffs = np.real(obs.coeffs).astype(np.float64)
-        indices: list[int] = []
-        for lab in le_labels:
-            slot = label_to_union_idx.get(lab)
-            if slot is None:
-                slot = len(all_le_labels)
-                label_to_union_idx[lab] = slot
-                all_le_labels.append(lab)
-            indices.append(slot)
-        obs_indices.append(indices)
-        obs_coeffs.append(coeffs)
-
-    if not all_le_labels:
-        raise ValueError(
-            "compute_multi_observable_measurement_groups: every observable "
-            "in the tuple is empty."
-        )
-
-    # Run the existing single-observable grouper on the union; coefficients
-    # are unused for grouping (we only need the partition + per-term group
-    # positions), so we set them to 1.0.
-    union = SparsePauliOp.from_list([(lab, 1.0) for lab in all_le_labels])
-    measurement_groups, partition_indices, _ = compute_measurement_groups(
-        union, strategy, n_qubits
+    postprocessing_fn = _create_postprocessing_fn(
+        observable, per_obs_term_indices, partition_indices, n_union_terms
     )
-
-    n_total = len(all_le_labels)
-    reverse_map: list[tuple[int, int] | None] = [None] * n_total
-    for group_idx, indices in enumerate(partition_indices):
-        for pos, orig_idx in enumerate(indices):
-            reverse_map[orig_idx] = (group_idx, pos)
-    missing = [i for i, v in enumerate(reverse_map) if v is None]
-    if missing:
-        raise RuntimeError(
-            f"partition_indices does not cover all union term indices. "
-            f"Missing: {missing}"
-        )
-
-    n_obs = len(observables)
-
-    def postprocessing_fn(grouped_results):
-        if len(grouped_results) != len(partition_indices):
-            raise RuntimeError(
-                f"Expected {len(partition_indices)} grouped results, "
-                f"got {len(grouped_results)}."
-            )
-        flat = np.zeros(n_total, dtype=np.float64)
-        for orig_idx in range(n_total):
-            entry = reverse_map[orig_idx]
-            assert entry is not None  # validated by the ``missing`` check above
-            g_idx, pos = entry
-            val = grouped_results[g_idx]
-            if isinstance(val, dict):
-                val = val[pos]
-            flat[orig_idx] = float(np.asarray(val).flat[0])
-        return [
-            float(np.dot(obs_coeffs[i], flat[obs_indices[i]])) for i in range(n_obs)
-        ]
-
     return measurement_groups, partition_indices, postprocessing_fn

--- a/divi/pipeline/_grouping.py
+++ b/divi/pipeline/_grouping.py
@@ -269,7 +269,9 @@ def compute_multi_observable_measurement_groups(
             )
         flat = np.zeros(n_total, dtype=np.float64)
         for orig_idx in range(n_total):
-            g_idx, pos = reverse_map[orig_idx]
+            entry = reverse_map[orig_idx]
+            assert entry is not None  # validated by the ``missing`` check above
+            g_idx, pos = entry
             val = grouped_results[g_idx]
             if isinstance(val, dict):
                 val = val[pos]

--- a/divi/pipeline/abc.py
+++ b/divi/pipeline/abc.py
@@ -49,11 +49,29 @@ class PipelineResult(dict):
     instead of ``result[()]``.
     """
 
-    @property
-    def value(self):
-        """Return the single result value.
+    _squeeze: bool = True
+    """When ``True`` (default), :attr:`value` squeezes a length-1 expval list to a
+    scalar.  Pipelines set this to ``False`` when any source MetaCircuit was built
+    with ``_was_multi_obs=True`` (e.g. ``observable=[O]`` was passed explicitly)."""
 
-        Equivalent to ``result[()]`` for single-circuit pipelines.
+    @property
+    def value(self) -> Any:
+        """Return the single result value, unwrapped at the boundary.
+
+        Pipelines store expectation values in a canonical ``list[float]``
+        shape indexed by observable position.  This accessor squeezes a
+        length-1 list (single-observable expval) to a scalar ``float`` so
+        casual callers get the natural shape — mirroring the
+        scalar-in/scalar-out symmetry of higher-level programs like
+        :class:`~divi.qprog.algorithms.TimeEvolution`.  Probability and
+        count dicts pass through unchanged; multi-observable lists are
+        returned as-is.  For the canonical raw form regardless of length,
+        use ``result[()]``.
+
+        When the source MetaCircuit was constructed with
+        ``_was_multi_obs=True`` (e.g. the user wrote ``observable=[O]``),
+        the pipeline disables the squeeze and a length-1 list is returned
+        as-is.
 
         Raises:
             ValueError: If the result contains more than one key.
@@ -64,7 +82,10 @@ class PipelineResult(dict):
                 f"Keys: {list(self.keys())}. "
                 f"Use result[key] to access specific results."
             )
-        return next(iter(self.values()))
+        raw = next(iter(self.values()))
+        if self._squeeze and isinstance(raw, list) and len(raw) == 1:
+            return raw[0]
+        return raw
 
 
 InT = TypeVar("InT")  # Generic input type consumed by Stage.expand.

--- a/divi/pipeline/stages/_circuit_spec_stage.py
+++ b/divi/pipeline/stages/_circuit_spec_stage.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 from divi.circuits import MetaCircuit
+from divi.pipeline._dry_run import _two_qubit_depth
 from divi.pipeline.abc import (
     ChildResults,
     MetaCircuitBatch,
@@ -77,6 +78,8 @@ class CircuitSpecStage(SpecStage[CircuitSpec]):
             "n_gates": dag.size(),
             "n_1q_gates": n_1q,
             "n_2q_gates": n_2q,
+            "depth": dag.depth(),
+            "depth_2q": _two_qubit_depth(dag),
         }
 
     def reduce(

--- a/divi/pipeline/stages/_measurement_stage.py
+++ b/divi/pipeline/stages/_measurement_stage.py
@@ -14,7 +14,11 @@ from divi.circuits._conversions import (
     measurement_qasms_from_groups,
     sparse_pauli_op_to_ham_string,
 )
-from divi.pipeline._grouping import GroupingStrategy, compute_measurement_groups
+from divi.pipeline._grouping import (
+    GroupingStrategy,
+    compute_measurement_groups,
+    compute_multi_observable_measurement_groups,
+)
 from divi.pipeline._shot_distribution import (
     ShotDistStrategy,
     compute_group_l1_norms,
@@ -390,14 +394,26 @@ class MeasurementStage(BundleStage):
         # analytical fallback entirely so the user's per-group allocation
         # is actually used.
         strategy = self._grouping_strategy
+        # ``_backend_expval`` auto-promotion only applies when every meta
+        # carries the *same* single observable.  Tuple-observable metas
+        # (multi-expval) cannot use the backend's analytical path because
+        # it evaluates one observable at a time.
+        any_tuple_obs = any(
+            isinstance(meta.observable, tuple) for meta in batch.values()
+        )
         if (
             self._shot_distribution is None
             and strategy in ("qwc", "_backend_expval")
             and env.backend.supports_expval
+            and not any_tuple_obs
         ):
             first_obs = next(iter(batch.values())).observable
             all_same_obs = all(meta.observable == first_obs for meta in batch.values())
             strategy = "_backend_expval" if all_same_obs else "qwc"
+        elif strategy == "_backend_expval" and any_tuple_obs:
+            # User explicitly asked for backend_expval but a tuple meta is
+            # present — fall back to QWC for the multi-observable path.
+            strategy = "qwc"
 
         if self._shot_distribution is not None and strategy == "_backend_expval":
             raise ValueError(
@@ -423,23 +439,44 @@ class MeasurementStage(BundleStage):
             if sample_observable is None:
                 sample_observable = observable
 
-            measurement_groups, partition_indices, postprocessing_fn = (
-                compute_measurement_groups(observable, strategy, meta.n_qubits)
-            )
-            if strategy == "_backend_expval" and n_observable_terms is None:
-                n_observable_terms = sum(len(p) for p in partition_indices)
-
-            # Decide which groups to actually submit and with how many shots.
-            surviving_indices, zero_shot_groups, surviving_shots = (
-                _allocate_per_group_shots(
-                    key,
-                    observable,
-                    measurement_groups,
-                    partition_indices,
-                    env,
-                    self._shot_distribution,
+            if isinstance(observable, tuple):
+                # Multi-observable: QWC across the UNION of every
+                # observable's Pauli terms.  postprocessing_fn returns a
+                # ``list[float]`` of per-observable expvals (in tuple order).
+                measurement_groups, partition_indices, postprocessing_fn = (
+                    compute_multi_observable_measurement_groups(
+                        observable, strategy, meta.n_qubits
+                    )
                 )
-            )
+                # Adaptive shot allocation needs a single observable to
+                # weight groups by; not yet supported for tuple metas.
+                if self._shot_distribution is not None:
+                    raise ValueError(
+                        "shot_distribution is not supported for "
+                        "multi-observable (tuple) metas; pass a single "
+                        "observable or disable shot_distribution."
+                    )
+                surviving_indices = list(range(len(measurement_groups)))
+                zero_shot_groups: dict[int, object] = {}
+                surviving_shots = None
+            else:
+                measurement_groups, partition_indices, postprocessing_fn = (
+                    compute_measurement_groups(observable, strategy, meta.n_qubits)
+                )
+                if strategy == "_backend_expval" and n_observable_terms is None:
+                    n_observable_terms = sum(len(p) for p in partition_indices)
+
+                # Decide which groups to actually submit and with how many shots.
+                surviving_indices, zero_shot_groups, surviving_shots = (
+                    _allocate_per_group_shots(
+                        key,
+                        observable,
+                        measurement_groups,
+                        partition_indices,
+                        env,
+                        self._shot_distribution,
+                    )
+                )
             if zero_shot_groups:
                 zero_shot_groups_by_spec[key] = zero_shot_groups
             if surviving_shots is not None:

--- a/divi/pipeline/stages/_measurement_stage.py
+++ b/divi/pipeline/stages/_measurement_stage.py
@@ -427,7 +427,7 @@ class MeasurementStage(BundleStage):
         n_observable_terms: int | None = None
         zero_shot_groups_by_spec: dict[object, dict[int, object]] = {}
         per_group_shots_by_spec: dict[object, dict[int, int]] = {}
-        sample_observable: SparsePauliOp | None = None
+        sample_observable: SparsePauliOp | tuple[SparsePauliOp, ...] | None = None
 
         for key, meta in batch.items():
             observable = meta.observable
@@ -504,7 +504,11 @@ class MeasurementStage(BundleStage):
 
         # For expval-native backends, compute ham_ops from the SparsePauliOp
         # and store it in env.artifacts so _default_execute_fn can use it.
+        # ``_backend_expval`` is rejected upstream for tuple observables
+        # (compute_multi_observable_measurement_groups raises and the
+        # auto-promotion guard falls back to QWC), so a tuple here is a bug.
         if strategy == "_backend_expval" and sample_observable is not None:
+            assert isinstance(sample_observable, SparsePauliOp)
             env.artifacts["ham_ops"] = sparse_pauli_op_to_ham_string(sample_observable)
         else:
             env.artifacts.pop("ham_ops", None)

--- a/divi/pipeline/stages/_measurement_stage.py
+++ b/divi/pipeline/stages/_measurement_stage.py
@@ -541,7 +541,9 @@ class MeasurementStage(BundleStage):
         if effective_strategy == "_backend_expval":
             info["n_groups"] = 1
             if getattr(token, "n_observable_terms", None) is not None:
-                info["n_terms"] = token.n_observable_terms
+                # Pauli-term count across observables, distinct from
+                # TrotterSpec's ``n_terms`` (Hamiltonian-term count).
+                info["n_pauli_terms"] = token.n_observable_terms
             obs_str = str(meta.observable[0]) if meta.observable else ""
             if len(obs_str) > 80:
                 obs_str = obs_str[:77] + "..."
@@ -550,14 +552,34 @@ class MeasurementStage(BundleStage):
 
         groups = meta.measurement_groups
         info["n_groups"] = len(groups)
-        n_terms = sum(len(g) for g in groups)
-        info["n_terms"] = n_terms
-        # Largest group by term count
+        info["n_pauli_terms"] = sum(len(g) for g in groups)
+        # Two complementary "biggest measurement" stats: how many Pauli
+        # strings the largest group contains, and how many qubits its
+        # measurement actually touches (union of non-I positions across
+        # group members). The first answers "how much QWC saves us"; the
+        # second answers "how big a basis change does this group require".
         if groups:
             largest = max(groups, key=len)
-            info["largest_group"] = ", ".join(str(op) for op in largest[:5])
-            if len(largest) > 5:
-                info["largest_group"] += f" ... ({len(largest)} terms)"
+            info["largest_group_size"] = len(largest)
+            touched = {
+                q for label in largest for q, c in enumerate(str(label)) if c != "I"
+            }
+            info["largest_group_width"] = f"{len(touched)} qubits"
+
+        # Shot-budget surface: tells the user what each circuit will be
+        # billed for (or how the budget was distributed across QWC groups).
+        backend_shots = getattr(env.backend, "shots", None)
+        if backend_shots is not None:
+            per_group_shots = env.artifacts.get("per_group_shots") or {}
+            spec_pgs = next(iter(per_group_shots.values()), None)
+            if spec_pgs:
+                # Shot-distribution strategy active — each group gets its
+                # own slice; surface the range so users see the spread.
+                values = sorted(spec_pgs.values())
+                info["shots_per_group"] = [values[0], values[-1]]
+            else:
+                # Default: every circuit submitted with backend.shots.
+                info["shots_per_circuit"] = backend_shots
         return info
 
     # Reduce

--- a/divi/pipeline/stages/_measurement_stage.py
+++ b/divi/pipeline/stages/_measurement_stage.py
@@ -5,7 +5,7 @@
 import warnings
 from collections.abc import Callable, Hashable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 from qiskit.quantum_info import SparsePauliOp
@@ -14,10 +14,10 @@ from divi.circuits._conversions import (
     measurement_qasms_from_groups,
     sparse_pauli_op_to_ham_string,
 )
+from divi.circuits._core import flatten_observable_tuple
 from divi.pipeline._grouping import (
     GroupingStrategy,
     compute_measurement_groups,
-    compute_multi_observable_measurement_groups,
 )
 from divi.pipeline._shot_distribution import (
     ShotDistStrategy,
@@ -390,30 +390,26 @@ class MeasurementStage(BundleStage):
         """
         env.result_format = ResultFormat.EXPVALS
 
-        # Setting shot_distribution declares sampling intent — skip the
-        # analytical fallback entirely so the user's per-group allocation
-        # is actually used.
         strategy = self._grouping_strategy
-        # ``_backend_expval`` auto-promotion only applies when every meta
-        # carries the *same* single observable.  Tuple-observable metas
-        # (multi-expval) cannot use the backend's analytical path because
-        # it evaluates one observable at a time.
-        any_tuple_obs = any(
-            isinstance(meta.observable, tuple) for meta in batch.values()
+        all_single_obs = all(
+            meta.observable is not None and len(meta.observable) == 1
+            for meta in batch.values()
         )
         if (
             self._shot_distribution is None
             and strategy in ("qwc", "_backend_expval")
             and env.backend.supports_expval
-            and not any_tuple_obs
+            and all_single_obs
         ):
             first_obs = next(iter(batch.values())).observable
             all_same_obs = all(meta.observable == first_obs for meta in batch.values())
             strategy = "_backend_expval" if all_same_obs else "qwc"
-        elif strategy == "_backend_expval" and any_tuple_obs:
-            # User explicitly asked for backend_expval but a tuple meta is
-            # present — fall back to QWC for the multi-observable path.
-            strategy = "qwc"
+        elif strategy == "_backend_expval" and not all_single_obs:
+            raise NotImplementedError(
+                "'_backend_expval' grouping strategy requires a single "
+                "observable per MetaCircuit (length-1 tuple); a multi-"
+                "observable tuple was supplied. Use 'qwc' or 'wires' instead."
+            )
 
         if self._shot_distribution is not None and strategy == "_backend_expval":
             raise ValueError(
@@ -427,56 +423,36 @@ class MeasurementStage(BundleStage):
         n_observable_terms: int | None = None
         zero_shot_groups_by_spec: dict[object, dict[int, object]] = {}
         per_group_shots_by_spec: dict[object, dict[int, int]] = {}
-        sample_observable: SparsePauliOp | tuple[SparsePauliOp, ...] | None = None
+        sample_union: SparsePauliOp | None = None
 
         for key, meta in batch.items():
-            observable = meta.observable
-            if observable is None:
+            if meta.observable is None:
                 raise ValueError(
                     f"MeasurementStage (expval path): key '{key}' has no "
                     "observable set."
                 )
-            if sample_observable is None:
-                sample_observable = observable
+            observable = cast(tuple[SparsePauliOp, ...], meta.observable)
 
-            if isinstance(observable, tuple):
-                # Multi-observable: QWC across the UNION of every
-                # observable's Pauli terms.  postprocessing_fn returns a
-                # ``list[float]`` of per-observable expvals (in tuple order).
-                measurement_groups, partition_indices, postprocessing_fn = (
-                    compute_multi_observable_measurement_groups(
-                        observable, strategy, meta.n_qubits
-                    )
-                )
-                # Adaptive shot allocation needs a single observable to
-                # weight groups by; not yet supported for tuple metas.
-                if self._shot_distribution is not None:
-                    raise ValueError(
-                        "shot_distribution is not supported for "
-                        "multi-observable (tuple) metas; pass a single "
-                        "observable or disable shot_distribution."
-                    )
-                surviving_indices = list(range(len(measurement_groups)))
-                zero_shot_groups: dict[int, object] = {}
-                surviving_shots = None
-            else:
-                measurement_groups, partition_indices, postprocessing_fn = (
-                    compute_measurement_groups(observable, strategy, meta.n_qubits)
-                )
-                if strategy == "_backend_expval" and n_observable_terms is None:
-                    n_observable_terms = sum(len(p) for p in partition_indices)
+            measurement_groups, partition_indices, postprocessing_fn = (
+                compute_measurement_groups(observable, strategy, meta.n_qubits)
+            )
+            if strategy == "_backend_expval" and n_observable_terms is None:
+                n_observable_terms = sum(len(p) for p in partition_indices)
 
-                # Decide which groups to actually submit and with how many shots.
-                surviving_indices, zero_shot_groups, surviving_shots = (
-                    _allocate_per_group_shots(
-                        key,
-                        observable,
-                        measurement_groups,
-                        partition_indices,
-                        env,
-                        self._shot_distribution,
-                    )
+            # Shot allocation weights groups by the union's coefficient L1 norm.
+            union_obs, _ = flatten_observable_tuple(observable)
+            if sample_union is None:
+                sample_union = union_obs
+            surviving_indices, zero_shot_groups, surviving_shots = (
+                _allocate_per_group_shots(
+                    key,
+                    union_obs,
+                    measurement_groups,
+                    partition_indices,
+                    env,
+                    self._shot_distribution,
                 )
+            )
             if zero_shot_groups:
                 zero_shot_groups_by_spec[key] = zero_shot_groups
             if surviving_shots is not None:
@@ -504,12 +480,8 @@ class MeasurementStage(BundleStage):
 
         # For expval-native backends, compute ham_ops from the SparsePauliOp
         # and store it in env.artifacts so _default_execute_fn can use it.
-        # ``_backend_expval`` is rejected upstream for tuple observables
-        # (compute_multi_observable_measurement_groups raises and the
-        # auto-promotion guard falls back to QWC), so a tuple here is a bug.
-        if strategy == "_backend_expval" and sample_observable is not None:
-            assert isinstance(sample_observable, SparsePauliOp)
-            env.artifacts["ham_ops"] = sparse_pauli_op_to_ham_string(sample_observable)
+        if strategy == "_backend_expval" and sample_union is not None:
+            env.artifacts["ham_ops"] = sparse_pauli_op_to_ham_string(sample_union)
         else:
             env.artifacts.pop("ham_ops", None)
 
@@ -543,7 +515,7 @@ class MeasurementStage(BundleStage):
             info["n_groups"] = 1
             if getattr(token, "n_observable_terms", None) is not None:
                 info["n_terms"] = token.n_observable_terms
-            obs_str = str(meta.observable) if meta.observable is not None else ""
+            obs_str = str(meta.observable[0]) if meta.observable else ""
             if len(obs_str) > 80:
                 obs_str = obs_str[:77] + "..."
             info["observable"] = obs_str

--- a/divi/pipeline/stages/_measurement_stage.py
+++ b/divi/pipeline/stages/_measurement_stage.py
@@ -39,6 +39,47 @@ OBS_GROUP_AXIS = "obs_group"
 PROBS_MEAS_AXIS = "meas"
 
 
+def _warn_imag_coeffs(
+    observable: SparsePauliOp | tuple[SparsePauliOp, ...],
+    spec_key: object,
+) -> None:
+    """Warn if any observable term carries a non-negligible imaginary coefficient.
+
+    Runs at the boundary of :class:`MeasurementStage` — before the
+    observable is flattened via :func:`flatten_observable_tuple` (which
+    drops imaginary parts via ``np.real``) — so the diagnostic still
+    fires when the user's original coefficients carry information that
+    shot allocation will silently discard.  Hermitian operators may
+    legitimately produce purely-imaginary coefficients (e.g. ``j*(O -
+    O.adjoint())`` decompositions); the warning steers users to
+    ``0.5 * (O + O.adjoint())`` symmetrization.
+    """
+    obs_iter = observable if isinstance(observable, tuple) else (observable,)
+    for obs in obs_iter:
+        coeffs = np.asarray(obs.coeffs)
+        if not coeffs.size:
+            continue
+        max_abs = float(np.max(np.abs(coeffs)))
+        if max_abs == 0.0:
+            continue
+        max_imag = float(np.max(np.abs(coeffs.imag)))
+        if max_imag > 1e-8 * max_abs:
+            warnings.warn(
+                f"Observable for spec {spec_key!r} has non-negligible "
+                f"imaginary coefficients (max |Im(c)| = {max_imag:.3g}, "
+                f"max |c| = {max_abs:.3g}). Shot allocation uses only the "
+                f"real parts; if the operator is meant to be Hermitian, "
+                f"symmetrize it as 0.5 * (O + O.adjoint()) before "
+                f"constructing the program.",
+                UserWarning,
+                stacklevel=3,
+            )
+            # One warning per spec is sufficient — the user needs to
+            # inspect their construction once, not once per offending
+            # tuple element.
+            return
+
+
 def _allocate_per_group_shots(
     spec_key: object,
     observable,
@@ -53,6 +94,10 @@ def _allocate_per_group_shots(
     ``env.rng`` from the pipeline environment, and ``shot_distribution``
     from the caller.
 
+    The ``observable`` here is the post-flatten union (real coefficients
+    only); imaginary-coefficient diagnostics are emitted earlier by
+    :func:`_warn_imag_coeffs` against the user's original observable.
+
     Returns:
         surviving_indices: Original indices of groups to actually submit.
         zero_shot_groups: ``{orig_idx: zero_result_for_group}`` for each
@@ -65,26 +110,7 @@ def _allocate_per_group_shots(
     if shot_distribution is None or n_groups == 0:
         return list(range(n_groups)), {}, None
 
-    raw_coeffs = np.asarray(observable.coeffs)
-    # SparsePauliOp stores complex coefficients. For a Hermitian operator the
-    # imaginary parts are zero up to construction round-off (~1e-15 relative).
-    # A non-trivial imaginary component means the operator isn't Hermitian,
-    # and silently dropping it would produce wrong group norms — warn so the
-    # user can symmetrize the operator or inspect their construction.
-    max_abs = float(np.max(np.abs(raw_coeffs))) if raw_coeffs.size else 0.0
-    if max_abs > 0:
-        max_imag = float(np.max(np.abs(raw_coeffs.imag)))
-        if max_imag > 1e-8 * max_abs:
-            warnings.warn(
-                f"Observable for spec {spec_key!r} has non-negligible imaginary "
-                f"coefficients (max |Im(c)| = {max_imag:.3g}, max |c| = "
-                f"{max_abs:.3g}). Shot allocation uses only the real parts; if "
-                f"the operator is meant to be Hermitian, symmetrize it as "
-                f"0.5 * (O + O.adjoint()) before constructing the program.",
-                UserWarning,
-                stacklevel=2,
-            )
-    coefficients = raw_coeffs.real.astype(np.float64)
+    coefficients = np.asarray(observable.coeffs).real.astype(np.float64)
     group_norms = compute_group_l1_norms(coefficients, partition_indices)
     per_group_shots = compute_shot_distribution(
         group_norms,
@@ -432,6 +458,7 @@ class MeasurementStage(BundleStage):
                     "observable set."
                 )
             observable = cast(tuple[SparsePauliOp, ...], meta.observable)
+            _warn_imag_coeffs(observable, key)
 
             measurement_groups, partition_indices, postprocessing_fn = (
                 compute_measurement_groups(observable, strategy, meta.n_qubits)

--- a/divi/pipeline/stages/_pauli_twirl_stage.py
+++ b/divi/pipeline/stages/_pauli_twirl_stage.py
@@ -444,6 +444,15 @@ class PauliTwirlStage(BundleStage):
                 reduced[base_key] = {
                     k: sum(v[k] for v in values) / len(values) for k in obs_keys
                 }
+            elif isinstance(values[0], list):
+                # Per-observable expval lists from multi-observable
+                # MeasurementStage — average element-wise so each observable's
+                # twirl-averaged value is preserved.
+                n = len(values)
+                n_obs = len(values[0])
+                reduced[base_key] = [
+                    sum(v[i] for v in values) / n for i in range(n_obs)
+                ]
             else:
                 reduced[base_key] = sum(values) / len(values)
         return reduced

--- a/divi/pipeline/stages/_pauli_twirl_stage.py
+++ b/divi/pipeline/stages/_pauli_twirl_stage.py
@@ -445,9 +445,8 @@ class PauliTwirlStage(BundleStage):
                     k: sum(v[k] for v in values) / len(values) for k in obs_keys
                 }
             elif isinstance(values[0], list):
-                # Per-observable expval lists from multi-observable
-                # MeasurementStage — average element-wise so each observable's
-                # twirl-averaged value is preserved.
+                # Per-observable list[float] from MeasurementStage —
+                # average element-wise.
                 n = len(values)
                 n_obs = len(values[0])
                 reduced[base_key] = [

--- a/divi/pipeline/stages/_pce_cost_stage.py
+++ b/divi/pipeline/stages/_pce_cost_stage.py
@@ -191,21 +191,25 @@ class PCECostStage(BundleStage):
 
             if self._soft:
                 probs = counts / total_shots
-                reduced[base_key] = _compute_soft_energy(
-                    parities,
-                    probs,
-                    self._alpha,
-                    self._problem,
-                    _compiled=self._compiled,
-                )
+                reduced[base_key] = [
+                    _compute_soft_energy(
+                        parities,
+                        probs,
+                        self._alpha,
+                        self._problem,
+                        _compiled=self._compiled,
+                    )
+                ]
             else:
-                reduced[base_key] = _compute_hard_cvar_energy(
-                    parities,
-                    counts,
-                    total_shots,
-                    self._problem,
-                    self._alpha_cvar,
-                    _compiled=self._compiled,
-                )
+                reduced[base_key] = [
+                    _compute_hard_cvar_energy(
+                        parities,
+                        counts,
+                        total_shots,
+                        self._problem,
+                        self._alpha_cvar,
+                        _compiled=self._compiled,
+                    )
+                ]
 
         return reduced

--- a/divi/pipeline/stages/_qem_stage.py
+++ b/divi/pipeline/stages/_qem_stage.py
@@ -195,7 +195,7 @@ class QEMStage(BundleStage):
 
         # Skip float-dependent stats for symbolic weights (not yet bound).
         if ctx.get("symbolic"):
-            info["symbolic"] = True
+            info["weights"] = "unbound (run after parameter binding)"
             return info
 
         per_obs = ctx.get("per_obs")
@@ -203,11 +203,23 @@ class QEMStage(BundleStage):
             info["n_observables"] = len(per_obs)
             data = per_obs[0]
         else:
+            # Dry path skips per_obs but persists the count separately so
+            # introspect() can still surface it.
+            if "n_observables" in ctx:
+                info["n_observables"] = ctx["n_observables"]
             data = ctx
 
         weights = data.get("weights")
         if weights is not None and len(weights) > 0:
             info["weight_sum"] = round(float(np.sum(weights)), 4)
+            # L1 norm = ∑|w_i|. Coincides with weight_sum for non-negative
+            # weight schemes but diverges when any path carries a negative
+            # weight (e.g. QuEPP sin-branches with sign flips). It is the
+            # variance-amplification factor: a noiseless mitigated estimate
+            # has variance proportional to (l1_norm)^2 / shots, so a value
+            # of 3.2 means the user's error bar grows ~3.2× compared to
+            # an unmitigated estimate at the same shot budget.
+            info["weight_l1_norm"] = round(float(np.sum(np.abs(weights))), 4)
             info["weight_range"] = [
                 round(float(np.min(weights)), 4),
                 round(float(np.max(weights)), 4),

--- a/divi/pipeline/stages/_qem_stage.py
+++ b/divi/pipeline/stages/_qem_stage.py
@@ -159,7 +159,7 @@ class QEMStage(BundleStage):
     def _reduce_grouped(
         self,
         grouped: dict[tuple, dict[int, Any]],
-        contexts: dict[tuple, QEMContext | list[QEMContext]] | None,
+        contexts: dict[tuple, QEMContext] | None,
         per_obs: bool,
     ) -> ChildResults:
         reduced: ChildResults = {}
@@ -167,14 +167,7 @@ class QEMStage(BundleStage):
             ordered = [v for _, v in sorted(values_by_idx.items())]
             ctx = {} if contexts is None else contexts[base_key]
 
-            if isinstance(ctx, list):
-                # Multi-observable: protocol.reduce dispatches on list-of-
-                # contexts and returns one mitigated value per observable.
-                # ``ordered`` is the full QEM-axis ordered result array; each
-                # per-observable context selects its own slice via
-                # ``dag_indices``.
-                reduced[base_key] = self.protocol.reduce(ordered, ctx)
-            elif per_obs:
+            if per_obs:
                 reduced[base_key] = {
                     obs_idx: self.protocol.reduce([d[obs_idx] for d in ordered], ctx)
                     for obs_idx in sorted(ordered[0].keys())
@@ -193,23 +186,24 @@ class QEMStage(BundleStage):
         ctx = next(iter(contexts.values()), None)
         if ctx is None:
             return info
-        if isinstance(ctx, list):
-            info["n_observables"] = len(ctx)
-            if not ctx:
-                return info
-            data = ctx[0]
-        else:
-            data = ctx
+
         for key in ("n_rotations", "n_paths"):
-            if key in data:
-                info[key] = data[key]
-        if "n_paths" in data:
-            info["n_clifford_sims"] = data["n_paths"]
+            if key in ctx:
+                info[key] = ctx[key]
+        if "n_paths" in ctx:
+            info["n_clifford_sims"] = ctx["n_paths"]
 
         # Skip float-dependent stats for symbolic weights (not yet bound).
-        if data.get("symbolic"):
+        if ctx.get("symbolic"):
             info["symbolic"] = True
             return info
+
+        per_obs = ctx.get("per_obs")
+        if per_obs:
+            info["n_observables"] = len(per_obs)
+            data = per_obs[0]
+        else:
+            data = ctx
 
         weights = data.get("weights")
         if weights is not None and len(weights) > 0:
@@ -225,7 +219,7 @@ class QEMStage(BundleStage):
 
     def _bind_symbolic_weights(
         self,
-        contexts: dict[tuple, QEMContext | list[QEMContext]],
+        contexts: dict[tuple, QEMContext],
         foreign_key: tuple,
         env: PipelineEnv,
     ) -> None:
@@ -233,39 +227,30 @@ class QEMStage(BundleStage):
 
         When QuEPP runs before ParameterBindingStage, weights are stored
         as sympy expressions.  This method substitutes the concrete
-        parameter values for the current param_set group.  For
-        multi-observable contexts (a list of dicts) it binds each entry
-        independently.
+        parameter values for the current param_set group, iterating over
+        each ``per_obs`` slot.
         """
         param_idx = next((v for k, v in foreign_key if k == "param_set"), None)
         if param_idx is None:
             return
         param_values = np.asarray(env.param_sets, dtype=float)[param_idx]
 
-        def _bind_single(c: QEMContext) -> QEMContext:
-            c = dict(c)
-            symbols = c.get("weight_symbols", [])
-            QuEPP.evaluate_symbolic_weights(c, symbols, param_values)
-            return c
-
         for key, ctx in list(contexts.items()):
-            if isinstance(ctx, list):
-                if not any(
-                    isinstance(c, dict) and c.get("symbolic") for c in ctx
-                ):
-                    continue
-                contexts[key] = [
-                    _bind_single(c)
-                    if isinstance(c, dict) and c.get("symbolic")
-                    else c
-                    for c in ctx
-                ]
-                continue
             if not isinstance(ctx, dict) or not ctx.get("symbolic"):
                 continue
-            # Shallow-copy to avoid mutating the shared context across
-            # different param_set groups.
-            contexts[key] = _bind_single(ctx)
+            # Shallow-copy so different param_set groups don't share state.
+            new_ctx = dict(ctx)
+            symbols = new_ctx.get("weight_symbols", [])
+            per_obs = new_ctx.get("per_obs")
+            if per_obs:
+                new_per_obs = []
+                for entry in per_obs:
+                    new_entry = dict(entry)
+                    QuEPP.evaluate_symbolic_weights(new_entry, symbols, param_values)
+                    new_per_obs.append(new_entry)
+                new_ctx["per_obs"] = new_per_obs
+            new_ctx["symbolic"] = False
+            contexts[key] = new_ctx
 
     def reduce(
         self, results: ChildResults, env: PipelineEnv, token: StageToken
@@ -283,12 +268,6 @@ class QEMStage(BundleStage):
         reduced = self._reduce_grouped(grouped, contexts, per_obs=per_obs)
 
         if contexts is not None:
-            all_ctxs: list[QEMContext] = []
-            for v in contexts.values():
-                if isinstance(v, list):
-                    all_ctxs.extend(v)
-                else:
-                    all_ctxs.append(v)
-            self.protocol.post_reduce(all_ctxs)
+            self.protocol.post_reduce(list(contexts.values()))
 
         return reduced

--- a/divi/pipeline/stages/_qem_stage.py
+++ b/divi/pipeline/stages/_qem_stage.py
@@ -159,7 +159,7 @@ class QEMStage(BundleStage):
     def _reduce_grouped(
         self,
         grouped: dict[tuple, dict[int, Any]],
-        contexts: dict[tuple, QEMContext] | None,
+        contexts: dict[tuple, QEMContext | list[QEMContext]] | None,
         per_obs: bool,
     ) -> ChildResults:
         reduced: ChildResults = {}
@@ -167,7 +167,14 @@ class QEMStage(BundleStage):
             ordered = [v for _, v in sorted(values_by_idx.items())]
             ctx = {} if contexts is None else contexts[base_key]
 
-            if per_obs:
+            if isinstance(ctx, list):
+                # Multi-observable: protocol.reduce dispatches on list-of-
+                # contexts and returns one mitigated value per observable.
+                # ``ordered`` is the full QEM-axis ordered result array; each
+                # per-observable context selects its own slice via
+                # ``dag_indices``.
+                reduced[base_key] = self.protocol.reduce(ordered, ctx)
+            elif per_obs:
                 reduced[base_key] = {
                     obs_idx: self.protocol.reduce([d[obs_idx] for d in ordered], ctx)
                     for obs_idx in sorted(ordered[0].keys())
@@ -186,7 +193,13 @@ class QEMStage(BundleStage):
         ctx = next(iter(contexts.values()), None)
         if ctx is None:
             return info
-        data = ctx
+        if isinstance(ctx, list):
+            info["n_observables"] = len(ctx)
+            if not ctx:
+                return info
+            data = ctx[0]
+        else:
+            data = ctx
         for key in ("n_rotations", "n_paths"):
             if key in data:
                 info[key] = data[key]
@@ -212,7 +225,7 @@ class QEMStage(BundleStage):
 
     def _bind_symbolic_weights(
         self,
-        contexts: dict[tuple, QEMContext],
+        contexts: dict[tuple, QEMContext | list[QEMContext]],
         foreign_key: tuple,
         env: PipelineEnv,
     ) -> None:
@@ -220,22 +233,39 @@ class QEMStage(BundleStage):
 
         When QuEPP runs before ParameterBindingStage, weights are stored
         as sympy expressions.  This method substitutes the concrete
-        parameter values for the current param_set group.
+        parameter values for the current param_set group.  For
+        multi-observable contexts (a list of dicts) it binds each entry
+        independently.
         """
         param_idx = next((v for k, v in foreign_key if k == "param_set"), None)
         if param_idx is None:
             return
         param_values = np.asarray(env.param_sets, dtype=float)[param_idx]
 
+        def _bind_single(c: QEMContext) -> QEMContext:
+            c = dict(c)
+            symbols = c.get("weight_symbols", [])
+            QuEPP.evaluate_symbolic_weights(c, symbols, param_values)
+            return c
+
         for key, ctx in list(contexts.items()):
+            if isinstance(ctx, list):
+                if not any(
+                    isinstance(c, dict) and c.get("symbolic") for c in ctx
+                ):
+                    continue
+                contexts[key] = [
+                    _bind_single(c)
+                    if isinstance(c, dict) and c.get("symbolic")
+                    else c
+                    for c in ctx
+                ]
+                continue
             if not isinstance(ctx, dict) or not ctx.get("symbolic"):
                 continue
             # Shallow-copy to avoid mutating the shared context across
             # different param_set groups.
-            ctx = dict(ctx)
-            contexts[key] = ctx
-            symbols = ctx.get("weight_symbols", [])
-            QuEPP.evaluate_symbolic_weights(ctx, symbols, param_values)
+            contexts[key] = _bind_single(ctx)
 
     def reduce(
         self, results: ChildResults, env: PipelineEnv, token: StageToken
@@ -253,7 +283,12 @@ class QEMStage(BundleStage):
         reduced = self._reduce_grouped(grouped, contexts, per_obs=per_obs)
 
         if contexts is not None:
-            all_ctxs = list(contexts.values())
+            all_ctxs: list[QEMContext] = []
+            for v in contexts.values():
+                if isinstance(v, list):
+                    all_ctxs.extend(v)
+                else:
+                    all_ctxs.append(v)
             self.protocol.post_reduce(all_ctxs)
 
         return reduced

--- a/divi/pipeline/stages/_trotter_spec_stage.py
+++ b/divi/pipeline/stages/_trotter_spec_stage.py
@@ -136,7 +136,13 @@ class TrotterSpecStage(SpecStage[qp.operation.Operator]):
     ) -> dict[str, Any]:
         if not isinstance(token, dict):
             return {}
-        return dict(token)
+        info = dict(token)
+        # ExactTrotterization is deterministic — its n_samples is structurally
+        # always 1 and adds no information for the user. For stochastic
+        # strategies (QDrift et al.) the count is a load-bearing knob.
+        if info.get("strategy") == "ExactTrotterization":
+            info.pop("n_samples", None)
+        return info
 
     def reduce(
         self, results: ChildResults, env: PipelineEnv, token: StageToken

--- a/divi/pipeline/transformations.py
+++ b/divi/pipeline/transformations.py
@@ -110,9 +110,7 @@ def reduce_mean(
         if values and isinstance(values[0], list):
             n = len(values)
             n_obs = len(values[0])
-            out[base_key] = [
-                sum(v[i] for v in values) / n for i in range(n_obs)
-            ]
+            out[base_key] = [sum(v[i] for v in values) / n for i in range(n_obs)]
         else:
             out[base_key] = sum(values) / len(values)
     return out

--- a/divi/pipeline/transformations.py
+++ b/divi/pipeline/transformations.py
@@ -93,12 +93,29 @@ def reduce_mean(
 ) -> ChildResults:
     """Reduce grouped values by averaging (e.g. Trotter ham samples).
 
+    Each entry's values may be scalars (the standard case — averaged
+    arithmetically) or per-observable lists of equal length emitted by a
+    multi-observable :class:`MeasurementStage` postprocess (averaged
+    element-wise so each observable's mean is preserved).
+
     Example::
 
         >>> reduce_mean({(('circ', 0),): [1.0, 3.0]})
         {(('circ', 0),): 2.0}
+        >>> reduce_mean({(('circ', 0),): [[1.0, 5.0], [3.0, 7.0]]})
+        {(('circ', 0),): [2.0, 6.0]}
     """
-    return {base_key: sum(values) / len(values) for base_key, values in grouped.items()}
+    out: ChildResults = {}
+    for base_key, values in grouped.items():
+        if values and isinstance(values[0], list):
+            n = len(values)
+            n_obs = len(values[0])
+            out[base_key] = [
+                sum(v[i] for v in values) / n for i in range(n_obs)
+            ]
+        else:
+            out[base_key] = sum(values) / len(values)
+    return out
 
 
 def reduce_postprocess_ordered(

--- a/divi/qprog/_batch_coordinator.py
+++ b/divi/qprog/_batch_coordinator.py
@@ -75,12 +75,19 @@ class BatchConfig:
     Attributes:
         mode: Whether to merge circuit submissions across programs.
             Defaults to :attr:`~divi.qprog.ensemble.BatchMode.MERGED`.
-        max_batch_size: Maximum number of circuits per merged backend call.
-            When set, the coordinator flushes early once the pending circuit
-            count reaches this limit instead of waiting for every active
-            program to submit.  ``None`` (the default) preserves the
-            wait-for-all barrier behavior.  Only meaningful when
-            ``mode`` is :attr:`~divi.qprog.ensemble.BatchMode.MERGED`.
+        max_batch_size: Flush-trigger threshold on the pending circuit
+            count, **not** a hard cap on merged-call size.  When set, the
+            coordinator fires a flush as soon as pending circuits reach
+            this value, and the flush includes every circuit pending at
+            that moment — so an actual merged submission may exceed
+            ``max_batch_size`` when programs submit multiple circuits per
+            call.  ``None`` (the default) preserves the wait-for-all
+            barrier behavior.  Setting this value also couples the
+            executor pool size to it (when ``max_concurrent_programs``
+            is unset): the pool is sized to
+            ``min(max_batch_size, len(programs))`` so the barrier
+            predicate can fill the batch in one wave.  Only meaningful
+            when ``mode`` is :attr:`~divi.qprog.ensemble.BatchMode.MERGED`.
         max_concurrent_programs: Maximum number of programs running
             concurrently.  When set to a positive integer, sizes the
             executor pool to that value and bypasses the default
@@ -88,13 +95,17 @@ class BatchConfig:
             a single merged submission of up to this many programs.
             Pass ``-1`` to size the pool to the entire ensemble — the
             cloud-merge recipe — without having to query
-            ``len(ensemble.programs)`` yourself.  ``None`` (the default)
-            auto-sizes the pool: ``max(len(programs), cpu_count + 4)``
-            in barrier mode (capped at 256), or ``cpu_count + 4`` when
-            ``max_batch_size`` is set.  Explicit values above 1024 emit
-            a :class:`UserWarning`; the ``-1`` form is silent because
-            it's an intentional opt-in.  Only meaningful when ``mode``
-            is :attr:`~divi.qprog.ensemble.BatchMode.MERGED`.
+            ``len(ensemble.programs)`` yourself; when combined with
+            ``max_batch_size`` the pool is capped at
+            ``min(max_batch_size, len(programs))`` so the barrier and
+            batch size align (one full wave per flush, no surplus
+            threads).  ``None`` (the default) auto-sizes the pool:
+            ``max(len(programs), cpu_count + 4)`` in barrier mode
+            (capped at 256), or ``min(max_batch_size, len(programs))``
+            when ``max_batch_size`` is set.  Explicit values above 1024
+            emit a :class:`UserWarning`; the ``-1`` form is silent
+            because it's an intentional opt-in.  Only meaningful when
+            ``mode`` is :attr:`~divi.qprog.ensemble.BatchMode.MERGED`.
         _sort_programs: Whether to sort programs by key before merging their
             circuits into a single backend call.  Defaults to ``False``.
 

--- a/divi/qprog/algorithms/_time_evolution.py
+++ b/divi/qprog/algorithms/_time_evolution.py
@@ -101,11 +101,6 @@ class TimeEvolution(QuantumProgram):
         self.time = time
         self.n_steps = n_steps
         self.order = order
-        # Normalise multi-observable input to a tuple so downstream
-        # ``isinstance(..., tuple)`` checks fire regardless of whether the
-        # caller passed a list or a tuple.  Single observables and ``None``
-        # are passed through unchanged so the standard scalar code path is
-        # bit-for-bit unchanged.
         if isinstance(observable, list):
             observable = tuple(observable)
         self.observable = observable
@@ -171,8 +166,12 @@ class TimeEvolution(QuantumProgram):
             )
         return results
 
-    def expval(self) -> float:
+    def expval(self) -> float | list[float]:
         """Return expectation-value-mode results.
+
+        Returns a ``float`` when ``observable`` was a single operator, or a
+        ``list[float]`` (one entry per observable, in input order) when
+        ``observable`` was a list/tuple.
 
         Raises:
             RuntimeError: If ``.run()`` has not yet been called, or if this
@@ -180,7 +179,7 @@ class TimeEvolution(QuantumProgram):
                 mode). Use :meth:`probabilities` instead.
         """
         results = self.results
-        if not isinstance(results, float):
+        if isinstance(results, dict):
             raise RuntimeError(
                 "TimeEvolution was run in probability mode; use "
                 ".probabilities() instead of .expval()."
@@ -241,6 +240,7 @@ class TimeEvolution(QuantumProgram):
             measurements = [qp.expval(self.observable)]
         return qscript_to_meta(
             qp.tape.QuantumScript(ops=ops, measurements=measurements),
+            was_multi_obs=isinstance(self.observable, tuple),
         )
 
     def run(self, **kwargs) -> "TimeEvolution":
@@ -264,10 +264,10 @@ class TimeEvolution(QuantumProgram):
         if self.observable is None:
             self._results = raw
         elif isinstance(self.observable, tuple):
-            # Multi-observable: pipeline yields a per-observable list.
             self._results = [float(v) for v in raw]
         else:
-            self._results = float(raw)
+            (single,) = raw
+            self._results = float(single)
 
         self.reporter.info(
             message="Finished successfully!", final_status=TerminalStatus.SUCCESS

--- a/divi/qprog/algorithms/_time_evolution.py
+++ b/divi/qprog/algorithms/_time_evolution.py
@@ -47,7 +47,12 @@ class TimeEvolution(QuantumProgram):
         n_steps: int = 1,
         order: int = 1,
         initial_state: InitialState | None = None,
-        observable: qp.operation.Operator | None = None,
+        observable: (
+            qp.operation.Operator
+            | tuple[qp.operation.Operator, ...]
+            | list[qp.operation.Operator]
+            | None
+        ) = None,
         _template_meta: MetaCircuit | None = None,
         _template_param: Parameter | None = None,
         **kwargs,
@@ -64,7 +69,19 @@ class TimeEvolution(QuantumProgram):
             initial_state: Initial state preparation. Pass an :class:`~divi.qprog.algorithms.InitialState`
                 instance (e.g. ``ZerosState()``, ``SuperpositionState()``).
                 Defaults to ``ZerosState()`` if None.
-            observable: If None, measure ``qp.probs()``; else ``qp.expval(observable)``.
+            observable: One of:
+
+                * ``None`` — measure ``qp.probs()``.
+                * Single :class:`~pennylane.operation.Operator` — one
+                  ``qp.expval(observable)`` measurement; ``self.results`` is
+                  a ``float``.
+                * ``Sequence[Operator]`` — multiple ``qp.expval(O_i)``
+                  measurements from the same circuit; ``self.results`` is a
+                  ``list[float]`` (one mitigated value per observable).
+                  Commuting observables are measured from a shared shot
+                  batch via :class:`MeasurementStage`'s QWC grouping; QuEPP
+                  shares the target circuit and dedupes path DAGs across
+                  observables.
             **kwargs: Passed to QuantumProgram (backend, seed, progress_queue, etc.).
                 Accepts ``qem_protocol`` for quantum error mitigation (requires
                 ``observable`` to be set, since QEM operates on expectation values).
@@ -83,6 +100,13 @@ class TimeEvolution(QuantumProgram):
         self.time = time
         self.n_steps = n_steps
         self.order = order
+        # Normalise multi-observable input to a tuple so downstream
+        # ``isinstance(..., tuple)`` checks fire regardless of whether the
+        # caller passed a list or a tuple.  Single observables and ``None``
+        # are passed through unchanged so the standard scalar code path is
+        # bit-for-bit unchanged.
+        if isinstance(observable, list):
+            observable = tuple(observable)
         self.observable = observable
         self._circuit_wires = tuple(hamiltonian_clean.wires)
         self.n_qubits = len(self._circuit_wires)
@@ -102,7 +126,7 @@ class TimeEvolution(QuantumProgram):
         self._template_meta = _template_meta
         self._template_param = _template_param
 
-        self._results: dict[str, float] | float | None = None
+        self._results: dict[str, float] | float | list[float] | None = None
 
         self._pipelines = self._build_pipelines()
 
@@ -110,12 +134,16 @@ class TimeEvolution(QuantumProgram):
         return self._results is not None
 
     @property
-    def results(self) -> dict[str, float] | float:
+    def results(self) -> dict[str, float] | float | list[float]:
         """Get the final results.
 
-        Returns either a probability distribution (``dict[str, float]``) when
-        no observable was provided, or an expectation value (``float``) when
-        ``observable`` was specified.
+        Returns one of:
+
+        * ``dict[str, float]`` — probability distribution when no
+          ``observable`` was provided.
+        * ``float`` — expectation value for a single ``observable``.
+        * ``list[float]`` — per-observable expectation values when
+          ``observable`` is a list/tuple.
 
         Raises:
             RuntimeError: If ``.run()`` has not yet been called.
@@ -205,11 +233,13 @@ class TimeEvolution(QuantumProgram):
         ops = [qp.Identity(w) for w in self._circuit_wires] + ops
 
         if self.observable is None:
-            measurement = qp.probs()
+            measurements = [qp.probs()]
+        elif isinstance(self.observable, tuple):
+            measurements = [qp.expval(o) for o in self.observable]
         else:
-            measurement = qp.expval(self.observable)
+            measurements = [qp.expval(self.observable)]
         return qscript_to_meta(
-            qp.tape.QuantumScript(ops=ops, measurements=[measurement]),
+            qp.tape.QuantumScript(ops=ops, measurements=measurements),
         )
 
     def run(self, **kwargs) -> "TimeEvolution":
@@ -230,7 +260,13 @@ class TimeEvolution(QuantumProgram):
                 f"Expected exactly 1 pipeline result, got {len(result)}."
             )
         (raw,) = result.values()
-        self._results = raw if self.observable is None else float(raw)
+        if self.observable is None:
+            self._results = raw
+        elif isinstance(self.observable, tuple):
+            # Multi-observable: pipeline yields a per-observable list.
+            self._results = [float(v) for v in raw]
+        else:
+            self._results = float(raw)
 
         self.reporter.info(
             message="Finished successfully!", final_status=TerminalStatus.SUCCESS

--- a/divi/qprog/algorithms/_time_evolution.py
+++ b/divi/qprog/algorithms/_time_evolution.py
@@ -79,9 +79,10 @@ class TimeEvolution(QuantumProgram):
                   measurements from the same circuit; ``self.results`` is a
                   ``list[float]`` (one mitigated value per observable).
                   Commuting observables are measured from a shared shot
-                  batch via :class:`MeasurementStage`'s QWC grouping; QuEPP
-                  shares the target circuit and dedupes path DAGs across
-                  observables.
+                  batch via
+                  :class:`~divi.pipeline.stages.MeasurementStage`'s QWC
+                  grouping; QuEPP shares the target circuit and dedupes
+                  path DAGs across observables.
             **kwargs: Passed to QuantumProgram (backend, seed, progress_queue, etc.).
                 Accepts ``qem_protocol`` for quantum error mitigation (requires
                 ``observable`` to be set, since QEM operates on expectation values).

--- a/divi/qprog/ensemble.py
+++ b/divi/qprog/ensemble.py
@@ -386,13 +386,23 @@ class ProgramEnsemble(ABC):
                 "You must provide a unique instance for each program ID."
             )
 
-        # In barrier mode the pool is sized to fit every program so the
-        # merge is maximal.
+        # In barrier mode the pool is sized so the barrier predicate can
+        # actually fill a batch.  When ``max_batch_size`` is set, the pool
+        # is capped at ``min(max_batch_size, len(programs))`` so:
+        #   - the barrier and the batch size align (one full wave per flush);
+        #   - we don't spawn more threads than necessary (avoids macOS's
+        #     per-process thread cap on large ensembles);
+        #   - threads recycle for the next wave after each flush completes.
         default_workers = (os.cpu_count() or 1) + 4
         if batching_enabled:
             if batch_config.max_concurrent_programs is not None:
                 if batch_config.max_concurrent_programs == -1:
-                    n_workers = len(self._programs)
+                    if batch_config.max_batch_size is not None:
+                        n_workers = min(
+                            batch_config.max_batch_size, len(self._programs)
+                        )
+                    else:
+                        n_workers = len(self._programs)
                 else:
                     n_workers = batch_config.max_concurrent_programs
                     if n_workers > _CONCURRENT_PROGRAMS_SOFT_CAP:
@@ -404,7 +414,7 @@ class ProgramEnsemble(ABC):
                             stacklevel=2,
                         )
             elif batch_config.max_batch_size is not None:
-                n_workers = default_workers
+                n_workers = min(batch_config.max_batch_size, len(self._programs))
             elif len(self._programs) <= _BARRIER_PROGRAM_LIMIT:
                 n_workers = max(len(self._programs), default_workers)
             else:

--- a/divi/qprog/variational_quantum_algorithm.py
+++ b/divi/qprog/variational_quantum_algorithm.py
@@ -1145,7 +1145,7 @@ class VariationalQuantumAlgorithm(QuantumProgram):
         self._current_execution_result = env.artifacts.get("_current_execution_result")
 
         indexed = {
-            _extract_param_set_idx(key): value + self.loss_constant
+            _extract_param_set_idx(key): float(value[0]) + self.loss_constant
             for key, value in result.items()
         }
         return dict(sorted(indexed.items()))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -150,6 +150,8 @@ nitpick_ignore_regex = [
     (r"py:class", r"dimod\..*"),
     # dwave-hybrid does not publish a sphinx inventory.
     (r"py:class", r"hybrid\..*"),
+    # qoro-maestro does not publish a sphinx inventory.
+    (r"py:class", r"maestro\..*"),
     # TypeVars in ``Generic[InT, OutT]`` — not documentable by Sphinx.
     (r"py:obj", r"divi\.pipeline\.abc\.(InT|OutT)"),
     # ``numpy.float64`` is ``py:attribute`` in numpy's inventory, but

--- a/docs/source/conftest.py
+++ b/docs/source/conftest.py
@@ -22,6 +22,7 @@ import matplotlib
 # Headless backend must be selected before pyplot is imported.
 os.environ.setdefault("MPLBACKEND", "Agg")
 matplotlib.use("Agg")
+import maestro
 import matplotlib.pyplot as plt  # noqa: E402 — after matplotlib.use
 import numpy as np
 import pennylane as qp
@@ -226,6 +227,13 @@ def setup(namespace):
         coordinates=np.array([[0.0, 0.0, -0.6614], [0.0, 0.0, 0.6614]]),
     )
     namespace["backend"] = MaestroSimulator()
+
+    # Pre-built noise model for noisy-simulation snippets: uniform 1 % depolarizing
+    # on a 2-qubit register.  Snippets that need a different topology should
+    # construct their own, but most examples can share this fixture.
+    _noise_model = maestro.NoiseModel()
+    _noise_model.set_all_depolarizing(num_qubits=2, p=0.01)
+    namespace["noise_model"] = _noise_model
 
 
 def teardown(namespace):

--- a/docs/source/user_guide/backends.rst
+++ b/docs/source/user_guide/backends.rst
@@ -73,8 +73,8 @@ Available Backends
 
 Divi ships three :class:`~divi.backends.CircuitRunner` implementations:
 
-* :class:`~divi.backends.MaestroSimulator` — A high-performance local simulator, recommended as the default for development and testing.
-* :class:`~divi.backends.QiskitSimulator` — A convenience wrapper around Qiskit's ``AerSimulator`` with simplified noise modeling and thread-count control. Use this when you need noisy simulation.
+* :class:`~divi.backends.MaestroSimulator` — A high-performance local simulator, recommended as the default for development and testing.  Supports Pauli-channel noise via ``maestro.NoiseModel`` (see :ref:`noisy-simulation-maestro`).
+* :class:`~divi.backends.QiskitSimulator` — A convenience wrapper around Qiskit's ``AerSimulator`` with thread-count control.  Use this when you need device-calibrated noise from a Qiskit fake backend or an arbitrary ``qiskit_aer.noise.NoiseModel``.
 * :class:`~divi.backends.QoroService` — A cloud-based quantum computing service for accessing powerful simulators and real quantum hardware.
 
 MaestroSimulator
@@ -87,6 +87,7 @@ MaestroSimulator
 * **Native C++ Core**: Backed by ``qoro-maestro``, a compiled simulator designed for low per-circuit overhead.
 * **Auto Method Selection**: Switches from Statevector to MatrixProductState for circuits exceeding 22 qubits (configurable via :class:`~divi.backends.MaestroConfig`'s ``mps_qubit_threshold``), so a single backend handles both narrow and wide registers.
 * **Multiple Simulation Methods**: Statevector, MatrixProductState, Stabilizer, TensorNetwork, PauliPropagator.
+* **Pauli-channel noise**: Analytical exact-mean expectation values or Monte-Carlo sampling under a ``maestro.NoiseModel``, configured directly on :class:`~divi.backends.MaestroConfig` — see :ref:`noisy-simulation-maestro`.
 
 
 .. _configuring-maestrosimulator:
@@ -125,10 +126,121 @@ to store a full statevector.
    )
 
 
+.. _noisy-simulation-maestro:
+
+Noisy simulation
+^^^^^^^^^^^^^^^^
+
+Pass a ``maestro.NoiseModel`` via :class:`~divi.backends.MaestroConfig` to
+enable Pauli-channel noise.
+
+**Building a noise model**
+
+Each ``set_*`` method on a ``NoiseModel`` *adds* a Pauli channel to the
+qubits it touches; calling more than one composes them, it does not
+overwrite.
+
+.. code-block:: python
+
+   import maestro
+
+   # Start with uniform 1 % depolarizing on every qubit of a 2-qubit circuit.
+   noise_model = maestro.NoiseModel()
+   noise_model.set_all_depolarizing(num_qubits=2, p=0.01)
+
+   # Add stronger dephasing on top, per-qubit (composes with the above).
+   noise_model.set_dephasing(qubit=0, p=0.005)
+   noise_model.set_dephasing(qubit=1, p=0.02)
+
+   # Add an asymmetric Pauli channel on qubit 0 (also composes).
+   noise_model.set_qubit_noise(qubit=0, px=0.002, py=0.001, pz=0.003)
+
+**Choosing an execution mode**
+
+:attr:`~divi.backends.MaestroConfig.noise_model` and
+:attr:`~divi.backends.MaestroConfig.noise_realizations` together select
+one of five Maestro entry points:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 20 55
+
+   * - ``noise_realizations``
+     - Backend
+     - Notes
+   * - *(not set)*
+     - ``simple_execute`` / ``simple_estimate``
+     - No noise applied.
+   * - ``None`` *(expval mode, default when* ``noise_model`` *is set)*
+     - ``noisy_estimate``
+     - Exact analytical mean: applies per-Pauli damping coefficients to
+       noiseless expectation values.  Deterministic; zero Monte-Carlo overhead.
+   * - ``None`` *(sampling mode)*
+     - ``noisy_execute`` with 1 realization
+     - One random Pauli error pattern per circuit; counts are stochastic.
+       For statistical accuracy set an explicit count (e.g. ``noise_realizations=20``).
+   * - Positive ``int`` *N* *(expval mode)*
+     - ``noisy_estimate_montecarlo``
+     - *N* independent Pauli-injection passes; mean of expectation values.
+       Converges to analytical as *N* → ∞.
+   * - Positive ``int`` *N* *(sampling mode)*
+     - ``noisy_execute`` with *N* batches
+     - Total shots is always ``shots``; distributed across
+       ``min(shots, N)`` batches, each with a fresh noise pattern.
+
+.. note::
+
+   ``noise_realizations=1`` (expval) is **not** the same as ``noise_realizations=None``:
+   the former is one random Pauli sampling; the latter is the exact analytical mean.
+
+**Analytical noisy expectation values**
+
+.. code-block:: python
+
+   from divi.backends import MaestroSimulator, MaestroConfig
+
+   # noise_realizations defaults to None → analytical noisy_estimate
+   sim = MaestroSimulator(config=MaestroConfig(noise_model=noise_model))
+   result = sim.submit_circuits({"c0": qasm_string}, ham_ops="ZI;IZ")
+   expvals = result.results[0]["results"]   # {"ZI": <float>, "IZ": <float>}
+
+**Monte Carlo noisy expectation values**
+
+.. code-block:: python
+
+   sim_mc = MaestroSimulator(
+       config=MaestroConfig(
+           noise_model=noise_model,
+           noise_realizations=20,
+           noise_seed=42,
+       )
+   )
+   result = sim_mc.submit_circuits({"c0": qasm_string}, ham_ops="ZI;IZ")
+   expvals = result.results[0]["results"]
+
+**Noisy sampling (counts mode)**
+
+.. code-block:: python
+
+   sim_sample = MaestroSimulator(
+       shots=5000,
+       config=MaestroConfig(
+           noise_model=noise_model,
+           noise_realizations=10,
+           noise_seed=0,
+       ),
+   )
+   result = sim_sample.submit_circuits({"c0": qasm_string})
+   counts = result.results[0]["results"]
+   # 5000 shots distributed across 10 random Pauli error patterns.
+
+For reproducibility under noisy execution see :ref:`Operational notes <operational-notes-shot-reproducibility>` below.
+
+
 QiskitSimulator
 ------------------
 
-:class:`~divi.backends.QiskitSimulator` wraps Qiskit's ``AerSimulator`` with simplified thread-count control and noise configuration. Use it when you need to model realistic hardware noise - for example, when developing error mitigation strategies or benchmarking algorithm robustness.
+:class:`~divi.backends.QiskitSimulator` wraps Qiskit's ``AerSimulator`` with thread-count control and Qiskit-native noise configuration.  Use it when you need device-calibrated noise from a Qiskit fake backend, or when you have an existing ``qiskit_aer.noise.NoiseModel`` you want to run as-is.  For Pauli-channel noise written from scratch, :ref:`MaestroSimulator's noisy paths <noisy-simulation-maestro>` are usually faster.
 
 
 Examples
@@ -306,7 +418,8 @@ Backend Selection Guide
 
 Choosing the right backend depends on what stage of development you're in.
 
-* **For Development and Testing**, use :class:`~divi.backends.MaestroSimulator` for exact noiseless simulation. For device noise models, use :class:`~divi.backends.QiskitSimulator` with Qiskit noise models.
+* **For Development and Testing**, use :class:`~divi.backends.MaestroSimulator` — for exact noiseless simulation, for analytical Pauli-channel noise, or for fast Monte Carlo over a hand-written noise model.
+* **For Qiskit-native noise**, use :class:`~divi.backends.QiskitSimulator` — its strength is plugging into Qiskit fake backends and arbitrary ``qiskit_aer.noise.NoiseModel`` instances built from device calibration data.
 * **For Production Runs**, use :class:`~divi.backends.QoroService` for cloud simulation, real quantum hardware, and scalable execution.
 * **For Research**, start with :class:`~divi.backends.MaestroSimulator` for prototyping, then use :class:`~divi.backends.QoroService` for validation against real hardware.
 
@@ -323,19 +436,19 @@ Backend Comparison
      - :class:`~divi.backends.QiskitSimulator`
      - :class:`~divi.backends.QoroService`
    * - **Use Case**
-     - Default local simulation
-     - Noisy simulation
+     - Default local simulation; Pauli-channel noise
+     - Qiskit-native noise (fake backends, calibrated models)
      - Production & real hardware
    * - **Simulation Engine**
      - Qoro C++ (qoro-maestro)
      - Qiskit Aer
      - Cloud (Maestro / Aer / hardware)
    * - **Noise Support**
-     - No
+     - ``maestro.NoiseModel`` (Pauli channels)
      - Qiskit fake backends & noise models
      - Hardware noise (real QPUs)
    * - **Seed / Reproducibility**
-     - No (``set_seed`` is a no-op)
+     - ``noise_seed`` (noisy paths only)
      - ``simulation_seed`` parameter
      - N/A
    * - **Depth Tracking**
@@ -357,7 +470,10 @@ Operational notes
 
 * **MaestroSimulator and many qubits**: See :ref:`Configuring MaestroSimulator <configuring-maestrosimulator>` above for the auto-MPS threshold and the :class:`~divi.backends.MaestroConfig` fields that control it (``mps_qubit_threshold``, ``simulation_type``, ``max_bond_dimension``).  Note that switching to MPS changes memory and runtime scaling — it is not a generic "make it faster" switch.
 * **QiskitSimulator**: ``n_processes`` and ``shots`` trade throughput, memory, and statistical noise; there is no single knob—balance them for your machine and accuracy needs.
-* **Shot reproducibility**: :meth:`~divi.backends.MaestroSimulator.set_seed` is currently a no-op (the C++ engine does not expose sampling seeds yet). For reproducible shots through Aer, use :class:`~divi.backends.QiskitSimulator` with ``simulation_seed``.
+
+.. _operational-notes-shot-reproducibility:
+
+* **Shot reproducibility**: :meth:`~divi.backends.MaestroSimulator.set_seed` is a no-op — Maestro's noiseless simulators seed their measurement RNG from system entropy.  :attr:`~divi.backends.MaestroConfig.noise_seed` pins **Pauli error patterns** for noisy execution (each circuit gets ``noise_seed + i``), so noisy expval runs are fully reproducible; noisy sampling counts still vary because Maestro's measurement sampler re-seeds from entropy each call.  For reproducible noiseless counts, use :class:`~divi.backends.QiskitSimulator` with ``simulation_seed``.
 * **QoroService latency**: Client-side wait time is dominated by how you poll; tune ``polling_interval`` and ``max_retries`` on :class:`~divi.backends.QoroService`. For fast inner loops, use a local simulator; cloud queue time is outside the client library.
 
 Next Steps

--- a/docs/source/user_guide/backends.rst
+++ b/docs/source/user_guide/backends.rst
@@ -159,7 +159,8 @@ overwrite.
 
 :attr:`~divi.backends.MaestroConfig.noise_model` and
 :attr:`~divi.backends.MaestroConfig.noise_realizations` together select
-one of five Maestro entry points:
+one of five dispatch scenarios across four C++ entry points
+(``noisy_execute`` covers two of the rows below):
 
 .. list-table::
    :header-rows: 1
@@ -448,7 +449,7 @@ Backend Comparison
      - Qiskit fake backends & noise models
      - Hardware noise (real QPUs)
    * - **Seed / Reproducibility**
-     - ``noise_seed`` (noisy paths only)
+     - ``noise_seed`` (noisy paths only, defaults to ``42``)
      - ``simulation_seed`` parameter
      - N/A
    * - **Depth Tracking**

--- a/docs/source/user_guide/hamiltonian_time_evolution.rst
+++ b/docs/source/user_guide/hamiltonian_time_evolution.rst
@@ -3,10 +3,11 @@ Hamiltonian Time Evolution
 
 The :class:`~divi.qprog.algorithms.TimeEvolution` program performs Hamiltonian time evolution simulation — simulating real-time quantum dynamics under a given Hamiltonian. Divi supports multiple Trotterization techniques out of the box: :class:`~divi.hamiltonians.ExactTrotterization` (full Trotter-Suzuki decomposition) and :class:`~divi.hamiltonians.QDrift` (randomized term sampling for shallower circuits on large Hamiltonians).
 
-It supports two output modes:
+It supports three output modes:
 
 - **Probability mode**: ``te.results`` contains measured basis-state probabilities (``dict[str, float]``).
 - **Observable mode**: ``te.results`` contains the estimated expectation value (``float``).
+- **Multi-observable mode**: ``te.results`` contains one expectation value per observable (``list[float]``), measured from a single shared evolution.
 
 Basic Usage
 -----------
@@ -61,6 +62,50 @@ Provide ``observable=...`` to estimate expectation values after evolution:
    On sampling backends, pass ``shot_distribution="weighted"`` to focus the
    shot budget on the observable's dominant terms.  See
    :ref:`adaptive-shot-allocation` for the full list of strategies.
+
+.. _time-evolution-multi-observable:
+
+Multi-Observable Mode
+---------------------
+
+Pass a list (or tuple) to ``observable=`` to estimate several expectation
+values from a single evolution.  ``te.results`` becomes a ``list[float]`` in
+the same order as the input observables, and the cost is shared across them:
+
+.. code-block:: python
+
+   import math
+   import pennylane as qp
+   from divi.backends import MaestroSimulator
+   from divi.qprog import TimeEvolution
+
+   backend = MaestroSimulator(shots=5000)
+
+   te = TimeEvolution(
+       hamiltonian=qp.PauliX(0) + qp.PauliX(1),
+       time=math.pi / 2,
+       observable=[qp.PauliZ(0), qp.PauliZ(1), qp.PauliZ(0) @ qp.PauliZ(1)],
+       backend=backend,
+   )
+   te.run()
+
+   z0, z1, zz = te.results
+   print(f"<Z0>   = {z0:+.4f}")
+   print(f"<Z1>   = {z1:+.4f}")
+   print(f"<Z0Z1> = {zz:+.4f}")
+
+Two cost-saving mechanisms apply automatically:
+
+- **Shared evolution**: the ``e^{-iHt}`` body is built and executed once per
+  measurement group, not once per observable.
+- **Cross-observable QWC grouping**:
+  :class:`~divi.pipeline.stages.MeasurementStage` unions the Pauli terms of
+  every observable and groups commuting terms into shared shot batches.  In
+  the example above all three observables are diagonal in the Z basis, so
+  they collapse into a single measurement group.
+
+When a quantum error mitigation protocol is set, the savings extend further;
+see :ref:`qem-multi-observable`.
 
 QDrift Trotterization
 ---------------------

--- a/docs/source/user_guide/improving_results_qem.rst
+++ b/docs/source/user_guide/improving_results_qem.rst
@@ -312,6 +312,26 @@ Performance Considerations
   :meth:`~divi.qprog.QuantumProgram.dry_run` to preview expansion before a long
   run.
 
+.. _qem-multi-observable:
+
+Multi-Observable Programs
+-------------------------
+
+Programs that accept several observables in one run (for example
+:class:`~divi.qprog.algorithms.TimeEvolution` with
+``observable=[O1, O2, ...]`` — see :ref:`time-evolution-multi-observable`)
+amortise mitigation cost across the group:
+
+- **ZNE** runs each scale factor's circuit once for the *whole* observable
+  set, not once per observable.  Total shots scale with the number of
+  scale factors, not with ``#scales × #observables``.
+- **QuEPP** shares the target circuit across all observables and dedupes
+  path DAGs across observables that produce coincident branches, so a
+  large fraction of the classical Clifford simulation is reused.
+
+Both protocols return one mitigated value per input observable, in input
+order.
+
 Custom Error Mitigation Protocols
 ---------------------------------
 

--- a/docs/source/user_guide/pipelines.rst
+++ b/docs/source/user_guide/pipelines.rst
@@ -83,6 +83,12 @@ and reduction stay consistent:
   collapses results back to the final shape (e.g. a single expectation value or
   a dict of bitstring probabilities per key).
 
+- **Reading single-circuit results**: Use :attr:`~divi.pipeline.PipelineResult.value`
+  for the natural shape — a scalar for single-observable expectation values,
+  a ``list[float]`` for multi-observable runs, a ``dict`` for probabilities and
+  counts.  For the canonical pipeline-internal form regardless of length (always
+  a list for expectation values), index the result directly via ``result[()]``.
+
 Built-in Stages
 ---------------
 
@@ -390,6 +396,16 @@ converter spec stages — no ``QuantumProgram`` required.
    print(result.value)  # {"00": ~0.5, "11": ~0.5}
 
 Both stages accept single circuits, sequences, or mappings as input.
+
+.. tip::
+
+   ``result.value`` returns the natural shape: a scalar ``float`` for a
+   single ``qp.expval(...)`` measurement, a ``list[float]`` for several
+   ``qp.expval(...)`` measurements (or when the user explicitly wrapped a
+   single observable in a list at the program layer), and a ``dict`` for
+   ``qp.probs`` / ``qp.counts``.  For the canonical pipeline-internal form
+   regardless of length (always a ``list[float]`` for expectation values),
+   use ``result[()]``.
 
 
 Example 3: Writing a Custom SpecStage

--- a/tests/backends/test_maestro_simulator.py
+++ b/tests/backends/test_maestro_simulator.py
@@ -1054,6 +1054,33 @@ class TestNoisyExpvalSubmission:
 
         assert result.results[0]["results"] == {"ZI": 0.1, "IX": 0.2, "YY": 0.3}
 
+    def test_montecarlo_multi_circuit_label_alignment_and_seed_offset(self, mocker):
+        """Submit two circuits through the Monte Carlo path and verify:
+        labels keep their input order in the result; per-circuit seed is
+        ``noise_seed + i`` so circuit 0 sees seed N, circuit 1 sees N+1."""
+        fake = _make_fake_maestro(mocker, expvals=[0.9])
+        seeds_seen: dict[int, int] = {}
+
+        def _capture(
+            circuit, observables, noise_model, noise_realizations, seed, config
+        ):
+            # Each call gets a unique parsed-circuit tuple keyed on the qasm
+            # string, recovered from the parser side_effect.
+            seeds_seen[id(circuit)] = seed
+            return {"expectation_values": [0.9]}
+
+        fake.noisy_estimate_montecarlo.side_effect = _capture
+        sim, _ = _make_noisy_sim(mocker, fake, noise_seed=10, noise_realizations=3)
+
+        result = sim.submit_circuits(
+            {"a": _BELL_QASM, "b": _BELL_QASM.replace("h q[0]", "x q[0]")},
+            ham_ops="ZI",
+        )
+
+        labels = [r["label"] for r in result.results]
+        assert labels == ["a", "b"]
+        assert sorted(seeds_seen.values()) == [10, 11]
+
 
 # ---------------------------------------------------------------------------
 # _strip_measurements

--- a/tests/backends/test_maestro_simulator.py
+++ b/tests/backends/test_maestro_simulator.py
@@ -64,11 +64,20 @@ def _make_fake_maestro(mocker, counts=None, expvals=None):
     if counts is None:
         counts = {"00": 2500, "11": 2500}
     maestro.simple_execute.return_value = {"counts": counts}
+    maestro.noisy_execute.return_value = {"counts": counts}
 
     # Expval — maestro returns {"expectation_values": [...], ...}
     if expvals is None:
         expvals = [0.5, -0.3]
     maestro.simple_estimate.return_value = {"expectation_values": expvals}
+    maestro.noisy_estimate.return_value = {"expectation_values": expvals}
+    maestro.noisy_estimate_montecarlo.return_value = {"expectation_values": expvals}
+
+    # ``QasmToCirc().parse_and_translate(qasm) -> "MaestroCircuit"`` —
+    # tag the parser so we can assert it was used (instead of the raw qasm).
+    parser = mocker.MagicMock(name="QasmToCirc")
+    parser.parse_and_translate.side_effect = lambda qasm: ("maestro_circuit", qasm)
+    maestro.QasmToCirc.return_value = parser
 
     return maestro
 
@@ -787,6 +796,220 @@ class TestExpvalSubmission:
         assert calls[0][1]["observables"] == "ZI"
         # Circuit 1 not in any group — falls back to full ham_ops
         assert calls[1][1]["observables"] == "ZI|XX"
+
+
+# ---------------------------------------------------------------------------
+# Noisy simulation: sampling (noisy_execute) and expval (noisy_estimate /
+# noisy_estimate_montecarlo) dispatch.
+# ---------------------------------------------------------------------------
+
+
+class TestNoiseConfigDefaults:
+    """Constructor stores noise knobs; defaults disable noise."""
+
+    def test_default_noise_config(self, mocker):
+        """No noise kwargs → noise_model is None, default seed=42, no realizations."""
+        sim = _make_simulator(mocker, _make_fake_maestro(mocker))
+        assert sim.noise_config["noise_model"] is None
+        assert sim.noise_config["noise_seed"] == 42
+        assert sim.noise_config["noise_realizations"] is None
+
+    def test_noise_kwargs_stored(self, mocker):
+        """noise_model / noise_seed / noise_realizations land on noise_config."""
+        nm = mocker.MagicMock(name="NoiseModel")
+        sim = _make_simulator(
+            mocker,
+            _make_fake_maestro(mocker),
+            noise_model=nm,
+            noise_seed=7,
+            noise_realizations=4,
+        )
+        assert sim.noise_config["noise_model"] is nm
+        assert sim.noise_config["noise_seed"] == 7
+        assert sim.noise_config["noise_realizations"] == 4
+
+
+class TestNoisySamplingSubmission:
+    """Sampling-mode dispatch: ``simple_execute`` vs ``noisy_execute``."""
+
+    def test_no_noise_uses_simple_execute(self, mocker):
+        """``noise_model=None`` keeps the sampling path on ``simple_execute``."""
+        fake = _make_fake_maestro(mocker)
+        sim = _make_simulator(mocker, fake)
+
+        sim.submit_circuits({"c0": _BELL_QASM})
+
+        fake.simple_execute.assert_called_once()
+        fake.noisy_execute.assert_not_called()
+        fake.QasmToCirc.assert_not_called()
+
+    def test_noise_routes_to_noisy_execute(self, mocker):
+        """A non-None ``noise_model`` swaps ``simple_execute`` for ``noisy_execute``."""
+        fake = _make_fake_maestro(mocker)
+        nm = mocker.MagicMock(name="NoiseModel")
+        sim = _make_simulator(mocker, fake, noise_model=nm)
+
+        sim.submit_circuits({"c0": _BELL_QASM})
+
+        fake.noisy_execute.assert_called_once()
+        fake.simple_execute.assert_not_called()
+        # noisy_execute consumes a parsed maestro Circuit, not raw QASM.
+        fake.QasmToCirc.assert_called_once()
+        fake.QasmToCirc.return_value.parse_and_translate.assert_called_once()
+
+    def test_noisy_execute_passes_noise_model_seed_and_default_realizations(
+        self, mocker
+    ):
+        """``noisy_execute`` receives the noise model, default seed=42, and
+        ``noise_realizations`` falls back to 1 when unset."""
+        fake = _make_fake_maestro(mocker)
+        nm = mocker.MagicMock(name="NoiseModel")
+        sim = _make_simulator(mocker, fake, shots=321, noise_model=nm)
+
+        sim.submit_circuits({"c0": _BELL_QASM})
+
+        call = fake.noisy_execute.call_args
+        # First positional: parsed maestro circuit; second positional: noise_model
+        assert call.args[0] == ("maestro_circuit", _BELL_QASM)
+        assert call.args[1] is nm
+        assert call.kwargs["shots"] == 321
+        assert call.kwargs["seed"] == 42
+        assert call.kwargs["noise_realizations"] == 1
+        assert "config" in call.kwargs
+
+    def test_noisy_execute_forwards_explicit_seed_and_realizations(self, mocker):
+        fake = _make_fake_maestro(mocker)
+        nm = mocker.MagicMock(name="NoiseModel")
+        sim = _make_simulator(
+            mocker, fake, noise_model=nm, noise_seed=11, noise_realizations=8
+        )
+
+        sim.submit_circuits({"c0": _BELL_QASM})
+
+        call = fake.noisy_execute.call_args
+        assert call.kwargs["seed"] == 11
+        assert call.kwargs["noise_realizations"] == 8
+
+    def test_noisy_sampling_reverses_bitstrings(self, mocker):
+        """Big-endian → little-endian reversal applies to noisy results too."""
+        fake = _make_fake_maestro(mocker, counts={"100": 70, "001": 30})
+        # Both backends share the counts return value; assert the path is correct.
+        nm = mocker.MagicMock(name="NoiseModel")
+        sim = _make_simulator(mocker, fake, noise_model=nm)
+
+        result = sim.submit_circuits({"c0": _BELL_QASM})
+
+        assert result.results[0]["results"] == {"001": 70, "100": 30}
+
+    def test_noisy_sampling_honors_shot_groups(self, mocker):
+        """Per-circuit shot allocation is forwarded to ``noisy_execute``."""
+        fake = _make_fake_maestro(mocker)
+        nm = mocker.MagicMock(name="NoiseModel")
+        sim = _make_simulator(mocker, fake, shots=999, noise_model=nm)
+
+        sim.submit_circuits(
+            {"c0": _QASM_SMALL, "c1": _QASM_SMALL, "c2": _QASM_SMALL},
+            shot_groups=[[0, 1, 50], [1, 3, 200]],
+        )
+
+        calls = fake.noisy_execute.call_args_list
+        assert len(calls) == 3
+        assert calls[0].kwargs["shots"] == 50
+        assert calls[1].kwargs["shots"] == 200
+        assert calls[2].kwargs["shots"] == 200
+
+
+class TestNoisyExpvalSubmission:
+    """Expval-mode dispatch: ``simple_estimate`` vs ``noisy_estimate``
+    vs ``noisy_estimate_montecarlo``."""
+
+    def test_no_noise_uses_simple_estimate(self, mocker):
+        fake = _make_fake_maestro(mocker)
+        sim = _make_simulator(mocker, fake)
+
+        sim.submit_circuits({"c0": _BELL_QASM}, ham_ops="ZI;IZ")
+
+        fake.simple_estimate.assert_called_once()
+        fake.noisy_estimate.assert_not_called()
+        fake.noisy_estimate_montecarlo.assert_not_called()
+        fake.QasmToCirc.assert_not_called()
+
+    def test_noise_no_realizations_uses_noisy_estimate(self, mocker):
+        """``noise_realizations`` unset (None) takes the analytical noisy path."""
+        fake = _make_fake_maestro(mocker)
+        nm = mocker.MagicMock(name="NoiseModel")
+        sim = _make_simulator(mocker, fake, noise_model=nm)
+
+        sim.submit_circuits({"c0": _BELL_QASM}, ham_ops="ZI;IZ")
+
+        fake.noisy_estimate.assert_called_once()
+        fake.noisy_estimate_montecarlo.assert_not_called()
+        fake.simple_estimate.assert_not_called()
+
+    def test_noise_zero_realizations_uses_noisy_estimate(self, mocker):
+        """``noise_realizations=0`` is treated as 'no Monte Carlo' (analytical)."""
+        fake = _make_fake_maestro(mocker)
+        nm = mocker.MagicMock(name="NoiseModel")
+        sim = _make_simulator(mocker, fake, noise_model=nm, noise_realizations=0)
+
+        sim.submit_circuits({"c0": _BELL_QASM}, ham_ops="ZI")
+
+        fake.noisy_estimate.assert_called_once()
+        fake.noisy_estimate_montecarlo.assert_not_called()
+
+    def test_noise_with_realizations_uses_montecarlo(self, mocker):
+        """``noise_realizations >= 1`` switches to ``noisy_estimate_montecarlo``."""
+        fake = _make_fake_maestro(mocker)
+        nm = mocker.MagicMock(name="NoiseModel")
+        sim = _make_simulator(mocker, fake, noise_model=nm, noise_realizations=5)
+
+        sim.submit_circuits({"c0": _BELL_QASM}, ham_ops="ZI;IZ")
+
+        fake.noisy_estimate_montecarlo.assert_called_once()
+        fake.noisy_estimate.assert_not_called()
+        call = fake.noisy_estimate_montecarlo.call_args
+        assert call.kwargs["noise_model"] is nm
+        assert call.kwargs["noise_realizations"] == 5
+        assert call.kwargs["observables"] == "ZI;IZ"
+        assert "config" in call.kwargs
+
+    def test_noisy_estimate_strips_measurements(self, mocker):
+        """``noisy_estimate``/``montecarlo`` receive a parsed circuit built
+        from QASM that has had its ``measure`` lines stripped — measurements
+        would corrupt the analytical statevector."""
+        fake = _make_fake_maestro(mocker)
+        nm = mocker.MagicMock(name="NoiseModel")
+        sim = _make_simulator(mocker, fake, noise_model=nm)
+
+        sim.submit_circuits({"c0": _BELL_QASM}, ham_ops="ZI")
+
+        # The fake parser's side effect captures the QASM passed in;
+        # verify no `measure` lines made it through.
+        parsed_input = fake.QasmToCirc.return_value.parse_and_translate.call_args.args[
+            0
+        ]
+        assert "measure" not in parsed_input
+        assert "h q[0]" in parsed_input  # body preserved
+
+    def test_noisy_estimate_passes_observables_string(self, mocker):
+        fake = _make_fake_maestro(mocker)
+        nm = mocker.MagicMock(name="NoiseModel")
+        sim = _make_simulator(mocker, fake, noise_model=nm)
+
+        sim.submit_circuits({"c0": _BELL_QASM}, ham_ops="ZI;IZ")
+
+        assert fake.noisy_estimate.call_args.kwargs["observables"] == "ZI;IZ"
+
+    def test_noisy_estimate_zips_results(self, mocker):
+        """Pauli operators map to expectation values regardless of which
+        noisy backend was used."""
+        fake = _make_fake_maestro(mocker, expvals=[0.1, 0.2, 0.3])
+        nm = mocker.MagicMock(name="NoiseModel")
+        sim = _make_simulator(mocker, fake, noise_model=nm, noise_realizations=2)
+
+        result = sim.submit_circuits({"c0": _BELL_QASM}, ham_ops="ZI;IX;YY")
+
+        assert result.results[0]["results"] == {"ZI": 0.1, "IX": 0.2, "YY": 0.3}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/backends/test_maestro_simulator.py
+++ b/tests/backends/test_maestro_simulator.py
@@ -88,6 +88,21 @@ def _make_simulator(mocker, fake_maestro, *, config=None, **kwargs):
     return MaestroSimulator(config=config, **kwargs)
 
 
+def _make_noisy_sim(mocker, fake_maestro, *, shots=None, **noise_kwargs):
+    """Build a simulator with a fresh ``NoiseModel`` mock baked into its config.
+
+    ``noise_kwargs`` are forwarded to ``MaestroConfig`` (so callers can
+    pass ``noise_seed=...``, ``noise_realizations=...``).  Returns
+    ``(sim, noise_model)`` so tests can assert the model identity.
+    """
+    nm = mocker.MagicMock(name="NoiseModel")
+    cfg = MaestroConfig(noise_model=nm, **noise_kwargs)
+    sim_kwargs: dict = {"config": cfg}
+    if shots is not None:
+        sim_kwargs["shots"] = shots
+    return _make_simulator(mocker, fake_maestro, **sim_kwargs), nm
+
+
 def _sim_config_call(fake_maestro):
     """Return kwargs passed to the most recent ``SimulatorConfig(**kwargs)`` call."""
     return fake_maestro.SimulatorConfig.call_args.kwargs
@@ -804,29 +819,43 @@ class TestExpvalSubmission:
 # ---------------------------------------------------------------------------
 
 
-class TestNoiseConfigDefaults:
-    """Constructor stores noise knobs; defaults disable noise."""
+class TestMaestroConfigNoiseDefaults:
+    """``MaestroConfig`` carries noise knobs; defaults disable noise."""
 
-    def test_default_noise_config(self, mocker):
-        """No noise kwargs → noise_model is None, default seed=42, no realizations."""
+    def test_default_noise_fields(self, mocker):
+        """No noise overrides → noise_model is None, default seed=42, no realizations."""
         sim = _make_simulator(mocker, _make_fake_maestro(mocker))
-        assert sim.noise_config["noise_model"] is None
-        assert sim.noise_config["noise_seed"] == 42
-        assert sim.noise_config["noise_realizations"] is None
+        assert sim.config.noise_model is None
+        assert sim.config.noise_seed == 42
+        assert sim.config.noise_realizations is None
 
-    def test_noise_kwargs_stored(self, mocker):
-        """noise_model / noise_seed / noise_realizations land on noise_config."""
-        nm = mocker.MagicMock(name="NoiseModel")
-        sim = _make_simulator(
-            mocker,
-            _make_fake_maestro(mocker),
-            noise_model=nm,
-            noise_seed=7,
-            noise_realizations=4,
+    def test_noise_fields_stored(self, mocker):
+        """noise_model / noise_seed / noise_realizations land on MaestroConfig."""
+        sim, nm = _make_noisy_sim(
+            mocker, _make_fake_maestro(mocker), noise_seed=7, noise_realizations=4
         )
-        assert sim.noise_config["noise_model"] is nm
-        assert sim.noise_config["noise_seed"] == 7
-        assert sim.noise_config["noise_realizations"] == 4
+        assert sim.config.noise_model is nm
+        assert sim.config.noise_seed == 7
+        assert sim.config.noise_realizations == 4
+
+    def test_override_carries_noise_model(self, mocker):
+        """``MaestroConfig.override`` propagates a noise_model from ``other``."""
+        nm = mocker.MagicMock(name="NoiseModel")
+        base = MaestroConfig(simulation_type="Statevector")
+        merged = base.override(MaestroConfig(noise_model=nm, noise_realizations=3))
+        assert merged.noise_model is nm
+        assert merged.noise_realizations == 3
+        # Base's other fields survive.
+        assert merged.simulation_type == "Statevector"
+
+    def test_override_preserves_base_realizations_when_other_uses_default(self, mocker):
+        """override() must not clobber base's noise_realizations when other's is
+        still at the default ``None``."""
+        nm = mocker.MagicMock(name="NoiseModel")
+        base = MaestroConfig(noise_realizations=5)
+        merged = base.override(MaestroConfig(noise_model=nm))
+        assert merged.noise_model is nm
+        assert merged.noise_realizations == 5  # base value, not other's None default
 
 
 class TestNoisySamplingSubmission:
@@ -846,8 +875,7 @@ class TestNoisySamplingSubmission:
     def test_noise_routes_to_noisy_execute(self, mocker):
         """A non-None ``noise_model`` swaps ``simple_execute`` for ``noisy_execute``."""
         fake = _make_fake_maestro(mocker)
-        nm = mocker.MagicMock(name="NoiseModel")
-        sim = _make_simulator(mocker, fake, noise_model=nm)
+        sim, _ = _make_noisy_sim(mocker, fake)
 
         sim.submit_circuits({"c0": _BELL_QASM})
 
@@ -863,8 +891,7 @@ class TestNoisySamplingSubmission:
         """``noisy_execute`` receives the noise model, default seed=42, and
         ``noise_realizations`` falls back to 1 when unset."""
         fake = _make_fake_maestro(mocker)
-        nm = mocker.MagicMock(name="NoiseModel")
-        sim = _make_simulator(mocker, fake, shots=321, noise_model=nm)
+        sim, nm = _make_noisy_sim(mocker, fake, shots=321)
 
         sim.submit_circuits({"c0": _BELL_QASM})
 
@@ -879,10 +906,7 @@ class TestNoisySamplingSubmission:
 
     def test_noisy_execute_forwards_explicit_seed_and_realizations(self, mocker):
         fake = _make_fake_maestro(mocker)
-        nm = mocker.MagicMock(name="NoiseModel")
-        sim = _make_simulator(
-            mocker, fake, noise_model=nm, noise_seed=11, noise_realizations=8
-        )
+        sim, _ = _make_noisy_sim(mocker, fake, noise_seed=11, noise_realizations=8)
 
         sim.submit_circuits({"c0": _BELL_QASM})
 
@@ -893,9 +917,7 @@ class TestNoisySamplingSubmission:
     def test_noisy_sampling_reverses_bitstrings(self, mocker):
         """Big-endian → little-endian reversal applies to noisy results too."""
         fake = _make_fake_maestro(mocker, counts={"100": 70, "001": 30})
-        # Both backends share the counts return value; assert the path is correct.
-        nm = mocker.MagicMock(name="NoiseModel")
-        sim = _make_simulator(mocker, fake, noise_model=nm)
+        sim, _ = _make_noisy_sim(mocker, fake)
 
         result = sim.submit_circuits({"c0": _BELL_QASM})
 
@@ -904,8 +926,7 @@ class TestNoisySamplingSubmission:
     def test_noisy_sampling_honors_shot_groups(self, mocker):
         """Per-circuit shot allocation is forwarded to ``noisy_execute``."""
         fake = _make_fake_maestro(mocker)
-        nm = mocker.MagicMock(name="NoiseModel")
-        sim = _make_simulator(mocker, fake, shots=999, noise_model=nm)
+        sim, _ = _make_noisy_sim(mocker, fake, shots=999)
 
         sim.submit_circuits(
             {"c0": _QASM_SMALL, "c1": _QASM_SMALL, "c2": _QASM_SMALL},
@@ -914,9 +935,18 @@ class TestNoisySamplingSubmission:
 
         calls = fake.noisy_execute.call_args_list
         assert len(calls) == 3
-        assert calls[0].kwargs["shots"] == 50
-        assert calls[1].kwargs["shots"] == 200
-        assert calls[2].kwargs["shots"] == 200
+        # ``ThreadPoolExecutor.map`` may reorder per-call kwargs; verify the
+        # shot multiset rather than positional ordering.
+        seen_shots = sorted(call.kwargs["shots"] for call in calls)
+        assert seen_shots == [50, 200, 200]
+
+    @pytest.mark.parametrize("realizations", [0, -1])
+    def test_invalid_realizations_raises_in_sampling(self, mocker, realizations):
+        """``noise_realizations`` must be ``None`` or a positive integer."""
+        fake = _make_fake_maestro(mocker)
+        sim, _ = _make_noisy_sim(mocker, fake, noise_realizations=realizations)
+        with pytest.raises(ValueError, match="noise_realizations"):
+            sim.submit_circuits({"c0": _BELL_QASM})
 
 
 class TestNoisyExpvalSubmission:
@@ -937,8 +967,7 @@ class TestNoisyExpvalSubmission:
     def test_noise_no_realizations_uses_noisy_estimate(self, mocker):
         """``noise_realizations`` unset (None) takes the analytical noisy path."""
         fake = _make_fake_maestro(mocker)
-        nm = mocker.MagicMock(name="NoiseModel")
-        sim = _make_simulator(mocker, fake, noise_model=nm)
+        sim, _ = _make_noisy_sim(mocker, fake)
 
         sim.submit_circuits({"c0": _BELL_QASM}, ham_ops="ZI;IZ")
 
@@ -946,22 +975,41 @@ class TestNoisyExpvalSubmission:
         fake.noisy_estimate_montecarlo.assert_not_called()
         fake.simple_estimate.assert_not_called()
 
-    def test_noise_zero_realizations_uses_noisy_estimate(self, mocker):
-        """``noise_realizations=0`` is treated as 'no Monte Carlo' (analytical)."""
+    def test_analytical_noisy_estimate_does_not_receive_seed(self, mocker):
+        """``noisy_estimate`` (analytical) must not receive ``seed=`` — it is only
+        relevant for Monte-Carlo sampling.  A non-default seed is used to confirm
+        it does not leak onto the analytical path."""
         fake = _make_fake_maestro(mocker)
-        nm = mocker.MagicMock(name="NoiseModel")
-        sim = _make_simulator(mocker, fake, noise_model=nm, noise_realizations=0)
+        sim, _ = _make_noisy_sim(mocker, fake, noise_seed=99)
 
         sim.submit_circuits({"c0": _BELL_QASM}, ham_ops="ZI")
 
-        fake.noisy_estimate.assert_called_once()
-        fake.noisy_estimate_montecarlo.assert_not_called()
+        assert "seed" not in fake.noisy_estimate.call_args.kwargs
+
+    def test_realizations_1_uses_montecarlo_not_analytical(self, mocker):
+        """``noise_realizations=1`` must route to Monte Carlo, not the analytical
+        backend — one random Pauli sampling is not equivalent to the analytical mean.
+        This pins the documented non-equivalence: None → analytical, 1 → MC."""
+        fake = _make_fake_maestro(mocker)
+        sim, _ = _make_noisy_sim(mocker, fake, noise_realizations=1)
+
+        sim.submit_circuits({"c0": _BELL_QASM}, ham_ops="ZI")
+
+        fake.noisy_estimate_montecarlo.assert_called_once()
+        fake.noisy_estimate.assert_not_called()
+
+    @pytest.mark.parametrize("realizations", [0, -1])
+    def test_invalid_realizations_raises_in_expval(self, mocker, realizations):
+        """``noise_realizations`` must be ``None`` or a positive integer."""
+        fake = _make_fake_maestro(mocker)
+        sim, _ = _make_noisy_sim(mocker, fake, noise_realizations=realizations)
+        with pytest.raises(ValueError, match="noise_realizations"):
+            sim.submit_circuits({"c0": _BELL_QASM}, ham_ops="ZI")
 
     def test_noise_with_realizations_uses_montecarlo(self, mocker):
         """``noise_realizations >= 1`` switches to ``noisy_estimate_montecarlo``."""
         fake = _make_fake_maestro(mocker)
-        nm = mocker.MagicMock(name="NoiseModel")
-        sim = _make_simulator(mocker, fake, noise_model=nm, noise_realizations=5)
+        sim, nm = _make_noisy_sim(mocker, fake, noise_realizations=5)
 
         sim.submit_circuits({"c0": _BELL_QASM}, ham_ops="ZI;IZ")
 
@@ -978,13 +1026,10 @@ class TestNoisyExpvalSubmission:
         from QASM that has had its ``measure`` lines stripped — measurements
         would corrupt the analytical statevector."""
         fake = _make_fake_maestro(mocker)
-        nm = mocker.MagicMock(name="NoiseModel")
-        sim = _make_simulator(mocker, fake, noise_model=nm)
+        sim, _ = _make_noisy_sim(mocker, fake)
 
         sim.submit_circuits({"c0": _BELL_QASM}, ham_ops="ZI")
 
-        # The fake parser's side effect captures the QASM passed in;
-        # verify no `measure` lines made it through.
         parsed_input = fake.QasmToCirc.return_value.parse_and_translate.call_args.args[
             0
         ]
@@ -993,8 +1038,7 @@ class TestNoisyExpvalSubmission:
 
     def test_noisy_estimate_passes_observables_string(self, mocker):
         fake = _make_fake_maestro(mocker)
-        nm = mocker.MagicMock(name="NoiseModel")
-        sim = _make_simulator(mocker, fake, noise_model=nm)
+        sim, _ = _make_noisy_sim(mocker, fake)
 
         sim.submit_circuits({"c0": _BELL_QASM}, ham_ops="ZI;IZ")
 
@@ -1004,8 +1048,7 @@ class TestNoisyExpvalSubmission:
         """Pauli operators map to expectation values regardless of which
         noisy backend was used."""
         fake = _make_fake_maestro(mocker, expvals=[0.1, 0.2, 0.3])
-        nm = mocker.MagicMock(name="NoiseModel")
-        sim = _make_simulator(mocker, fake, noise_model=nm, noise_realizations=2)
+        sim, _ = _make_noisy_sim(mocker, fake, noise_realizations=2)
 
         result = sim.submit_circuits({"c0": _BELL_QASM}, ham_ops="ZI;IX;YY")
 
@@ -1190,10 +1233,24 @@ class TestRealMaestroIntegration:
             for name in dir(_real_maestro.SimulatorConfig)
             if not name.startswith("_")
         }
-        divi_fields = {f.name for f in fields(MaestroConfig)} - {
+        _divi_only = {
             # mps_qubit_threshold is divi-side auto-MPS logic, not a maestro knob.
-            "mps_qubit_threshold"
+            "mps_qubit_threshold",
+            # Noise lives on MaestroConfig but is consumed by the noisy entry
+            # points (noisy_execute / noisy_estimate / *_montecarlo) — Maestro
+            # keeps noise out of SimulatorConfig itself.
+            "noise_model",
+            "noise_seed",
+            "noise_realizations",
         }
+        # Guard: if any divi-only field is removed from MaestroConfig, the
+        # exclusion set would silently over-exclude and the parity check would
+        # pass even though a field went missing.
+        assert _divi_only <= {f.name for f in fields(MaestroConfig)}, (
+            f"Exclusion set names fields no longer in MaestroConfig: "
+            f"{_divi_only - {f.name for f in fields(MaestroConfig)}}"
+        )
+        divi_fields = {f.name for f in fields(MaestroConfig)} - _divi_only
         assert maestro_fields == divi_fields, (
             "MaestroConfig is out of sync with maestro.SimulatorConfig.\n"
             f"  Missing in MaestroConfig: {sorted(maestro_fields - divi_fields)}\n"

--- a/tests/circuits/test_circuits.py
+++ b/tests/circuits/test_circuits.py
@@ -51,7 +51,7 @@ class TestMetaCircuit:
     def test_with_observable(self, plain_dag):
         obs = SparsePauliOp.from_list([("IZ", 1.0), ("ZI", -1.0)])
         meta = MetaCircuit(circuit_bodies=(((), plain_dag),), observable=obs)
-        assert meta.observable is obs
+        assert meta.observable == (obs,)
 
     def test_with_measured_wires(self, plain_dag):
         meta = MetaCircuit(

--- a/tests/circuits/test_conversions.py
+++ b/tests/circuits/test_conversions.py
@@ -360,13 +360,15 @@ class TestEndToEndEquivalence:
 class TestQscriptToMetaObservable:
     """``meta.observable`` shape varies with the qscript's measurement(s)."""
 
-    def test_single_expval_yields_sparse_pauli_op(self):
+    def test_single_expval_yields_length_one_tuple(self):
         qs = qp.tape.QuantumScript(
             ops=[qp.Hadamard(0)],
             measurements=[qp.expval(qp.PauliZ(0))],
         )
         meta = qscript_to_meta(qs)
-        assert isinstance(meta.observable, SparsePauliOp)
+        assert isinstance(meta.observable, tuple)
+        assert len(meta.observable) == 1
+        assert isinstance(meta.observable[0], SparsePauliOp)
         assert meta.measured_wires is None
 
     def test_two_expvals_yields_tuple_of_sparse_pauli_ops(self):

--- a/tests/circuits/test_conversions.py
+++ b/tests/circuits/test_conversions.py
@@ -19,6 +19,7 @@ from divi.circuits._conversions import (
     _sympy_to_qiskit,
     dag_to_qasm_body,
     observable_to_sparse_pauli_op,
+    qscript_to_meta,
 )
 from divi.circuits._qasm_template import build_template, render_template
 
@@ -354,3 +355,81 @@ class TestEndToEndEquivalence:
         ref_qc.ry(1.5, 0)
         u_ref = Operator(ref_qc).data
         assert np.allclose(u, u_ref, atol=1e-10)
+
+
+class TestQscriptToMetaObservable:
+    """``meta.observable`` shape varies with the qscript's measurement(s)."""
+
+    def test_single_expval_yields_sparse_pauli_op(self):
+        qs = qp.tape.QuantumScript(
+            ops=[qp.Hadamard(0)],
+            measurements=[qp.expval(qp.PauliZ(0))],
+        )
+        meta = qscript_to_meta(qs)
+        assert isinstance(meta.observable, SparsePauliOp)
+        assert meta.measured_wires is None
+
+    def test_two_expvals_yields_tuple_of_sparse_pauli_ops(self):
+        qs = qp.tape.QuantumScript(
+            ops=[qp.Hadamard(0), qp.CNOT([0, 1])],
+            measurements=[
+                qp.expval(qp.PauliZ(0)),
+                qp.expval(qp.PauliZ(0) @ qp.PauliZ(1)),
+            ],
+        )
+        meta = qscript_to_meta(qs)
+        assert isinstance(meta.observable, tuple)
+        assert len(meta.observable) == 2
+        for obs in meta.observable:
+            assert isinstance(obs, SparsePauliOp)
+        assert meta.measured_wires is None
+
+    def test_three_expvals_preserve_order(self):
+        """Tuple entries are in the same order as the qscript's measurements."""
+        ops = [qp.Hadamard(0), qp.CNOT([0, 1])]
+        qs = qp.tape.QuantumScript(
+            ops=ops,
+            measurements=[
+                qp.expval(qp.PauliX(0)),
+                qp.expval(qp.PauliY(0)),
+                qp.expval(qp.PauliZ(0)),
+            ],
+        )
+        meta = qscript_to_meta(qs)
+        labels = [str(o.paulis.to_labels()[0]) for o in meta.observable]
+        # Qiskit labels are little-endian (qubit 0 on the right).  PauliX(0)
+        # on a 2-qubit wire frame → "IX"; PauliY(0) → "IY"; PauliZ(0) → "IZ".
+        assert labels == ["IX", "IY", "IZ"]
+
+    def test_mixing_multi_expval_with_probs_raises(self):
+        """Mixed measurement types on the multi-expval path are rejected —
+        the multi-observable code path expects every measurement to be an
+        expval."""
+        qs = qp.tape.QuantumScript(
+            ops=[qp.Hadamard(0)],
+            measurements=[
+                qp.expval(qp.PauliZ(0)),
+                qp.expval(qp.PauliX(0)),
+                qp.probs(wires=[0]),
+            ],
+        )
+        with pytest.raises(ValueError, match="mixing"):
+            qscript_to_meta(qs)
+
+    def test_single_probs_yields_measured_wires_no_observable(self):
+        qs = qp.tape.QuantumScript(
+            ops=[qp.Hadamard(0)],
+            measurements=[qp.probs(wires=[0])],
+        )
+        meta = qscript_to_meta(qs)
+        assert meta.observable is None
+        assert meta.measured_wires == (0,)
+
+    def test_no_measurement_yields_no_observable(self):
+        qs = qp.tape.QuantumScript(
+            ops=[qp.Hadamard(0)],
+            measurements=[],
+        )
+        meta = qscript_to_meta(qs)
+        assert meta.observable is None
+        assert meta.measured_wires is None

--- a/tests/circuits/test_qem.py
+++ b/tests/circuits/test_qem.py
@@ -44,7 +44,10 @@ class TestNoMitigation:
         dags, ctx = _NoMitigation().expand(bell_dag)
         assert len(dags) == 1
         assert dags[0] is bell_dag
-        assert ctx == {}
+        # ``dag_indices`` is set uniformly by every protocol's ``expand`` so
+        # that ``reduce`` can slice ``quantum_results`` consistently in both
+        # single- and multi-observable mode.
+        assert ctx == {"dag_indices": [0]}
 
     def test_reduce_returns_single_value(self, bell_dag):
         p = _NoMitigation()

--- a/tests/circuits/test_qem.py
+++ b/tests/circuits/test_qem.py
@@ -172,6 +172,91 @@ class TestLinearExtrapolator:
             LinearExtrapolator().extrapolate([1.0, float("inf")], [1.0, 2.0])
 
 
+class TestNoMitigationMultiObservable:
+    """Tuple-observable expand/reduce path on the trivial protocol."""
+
+    def test_expand_with_tuple_returns_list_of_contexts(self, bell_dag):
+        # Two distinct "observables" — the protocol ignores their content,
+        # but the loop helper still produces one context per entry.
+        dags, ctxs = _NoMitigation().expand(bell_dag, observable=("o1", "o2"))
+        assert isinstance(ctxs, list)
+        assert len(ctxs) == 2
+        # Each context's dag_indices points at exactly one DAG slot,
+        # and slots are disjoint (one DAG per observable for _NoMitigation).
+        all_indices = [i for c in ctxs for i in c["dag_indices"]]
+        assert len(all_indices) == len(set(all_indices))
+        assert len(dags) == 2
+
+    def test_reduce_with_per_dag_per_obs_rows(self, bell_dag):
+        """When ``MeasurementStage`` emits per-DAG list[float], reduce slices
+        out each observable's column."""
+        _, ctxs = _NoMitigation().expand(bell_dag, observable=("o1", "o2"))
+        # Each row is [val_for_obs1, val_for_obs2] for that DAG.  Each ctx
+        # selects a single row via dag_indices and a single column via
+        # _reduce_for_list_context's per-observable slicing.
+        rows = [[0.7, -0.3], [0.5, 0.1]]
+        out = _NoMitigation().reduce(rows, ctxs)
+        assert out == [0.7, 0.1]
+
+    def test_reduce_with_scalar_rows_falls_back_to_full_results(self, bell_dag):
+        """Scalar quantum_results path: each ctx sees the full sequence."""
+        # A protocol like _NoMitigation expects 1 result per ctx; build a
+        # tuple of length-1 contexts so the inner reduce calls don't choke.
+        # Use a fresh expand for each obs to ensure dag_indices line up.
+        dags, ctxs = _NoMitigation().expand(bell_dag, observable=("o1",))
+        # Single observable in the tuple → one ctx → one inner reduce call.
+        out = _NoMitigation().reduce([0.42], ctxs)
+        assert out == [0.42]
+
+    def test_empty_observables_tuple_rejected(self, bell_dag):
+        with pytest.raises(ValueError, match="at least one observable"):
+            _NoMitigation().expand(bell_dag, observable=())
+
+    def test_per_dag_row_count_mismatch_raises(self, bell_dag):
+        """Per-DAG rows whose length doesn't match the number of contexts
+        is treated as a sync bug between MeasurementStage and the protocol."""
+        _, ctxs = _NoMitigation().expand(bell_dag, observable=("o1", "o2"))
+        # 3 columns but only 2 contexts → mismatch.
+        rows = [[0.1, 0.2, 0.3]]
+        with pytest.raises(RuntimeError, match="out of sync"):
+            _NoMitigation().reduce(rows, ctxs)
+
+
+class TestZNEMultiObservable:
+    """ZNE on tuple observables loops the helper (folding is observable-independent)."""
+
+    def test_expand_with_tuple_returns_list_of_contexts(self, bell_dag):
+        zne = ZNE(scale_factors=[1.0, 3.0])
+        dags, ctxs = zne.expand(bell_dag, observable=("o1", "o2"))
+        assert isinstance(ctxs, list)
+        assert len(ctxs) == 2
+        # 2 observables × 2 scale factors → 4 DAG slots in the merged tuple.
+        # The default _expand_per_observable_loop does NOT dedupe folded DAGs.
+        assert len(dags) == 4
+        for ctx in ctxs:
+            assert "effective_scales" in ctx
+            assert "dag_indices" in ctx
+            assert len(ctx["dag_indices"]) == 2
+
+    def test_reduce_with_tuple_returns_list_of_floats(self, bell_dag):
+        # y_obs1 = 2 - s, y_obs2 = 4 - 2s; intercepts at s=0 are 2 and 4.
+        zne = ZNE(scale_factors=[1.0, 3.0], extrapolator=LinearExtrapolator())
+        _, ctxs = zne.expand(bell_dag, observable=("a", "b"))
+        # Each row is a per-observable list at one DAG.  Build them so that
+        # each ctx's dag_indices selects [y@s=1, y@s=3] for that observable.
+        # The two ctxs have disjoint dag_indices (loop helper, no dedup).
+        n_dags = 4
+        rows = [[float("nan"), float("nan")] for _ in range(n_dags)]
+        for slot, d in enumerate(ctxs[0]["dag_indices"]):
+            rows[d][0] = (1.0, -1.0)[slot]  # y_obs1 at s=1, s=3
+        for slot, d in enumerate(ctxs[1]["dag_indices"]):
+            rows[d][1] = (2.0, -2.0)[slot]  # y_obs2 at s=1, s=3
+        out = zne.reduce(rows, ctxs)
+        assert isinstance(out, list)
+        assert out[0] == pytest.approx(2.0)
+        assert out[1] == pytest.approx(4.0)
+
+
 class TestRichardsonExtrapolator:
     def test_interpolates_polynomial_exactly(self):
         e = RichardsonExtrapolator()

--- a/tests/circuits/test_qem.py
+++ b/tests/circuits/test_qem.py
@@ -51,8 +51,8 @@ class TestNoMitigation:
 
     def test_reduce_returns_single_value(self, bell_dag):
         p = _NoMitigation()
-        assert p.reduce([1.23], {}) == 1.23
-        assert p.reduce([-0.5], {}) == -0.5
+        assert p.reduce([1.23], {}) == [1.23]
+        assert p.reduce([-0.5], {}) == [-0.5]
 
     def test_reduce_raises_on_multi_results(self, bell_dag):
         with pytest.raises(RuntimeError, match="multiple partial results"):
@@ -120,19 +120,19 @@ class TestZNE:
         extrapolated = zne.reduce(
             [1.0, -1.0, -3.0], {"effective_scales": (1.0, 3.0, 5.0)}
         )
-        assert extrapolated == pytest.approx(2.0)
+        assert extrapolated == pytest.approx([2.0])
 
     def test_reduce_falls_back_to_requested_scales_without_context(self, bell_dag):
         """If a legacy context lacks effective_scales, reduce uses the requested values."""
         zne = ZNE(scale_factors=[1.0, 3.0, 5.0], extrapolator=LinearExtrapolator())
-        assert zne.reduce([1.0, -1.0, -3.0], {}) == pytest.approx(2.0)
+        assert zne.reduce([1.0, -1.0, -3.0], {}) == pytest.approx([2.0])
 
     def test_expand_forwards_effective_scales_to_reduce(self, bell_dag):
         """Effective scales survive the expand→reduce roundtrip unbiased."""
         zne = ZNE(scale_factors=[1.0, 3.0, 5.0], extrapolator=LinearExtrapolator())
         _, ctx = zne.expand(bell_dag)
         # y = 2 - s evaluated at effective scales (1, 3, 5).
-        assert zne.reduce([1.0, -1.0, -3.0], ctx) == pytest.approx(2.0)
+        assert zne.reduce([1.0, -1.0, -3.0], ctx) == pytest.approx([2.0])
 
     def test_expand_warns_when_scales_collapse(self, bell_dag):
         """Small-d circuits can snap distinct requested scales to the same effective value."""
@@ -172,86 +172,28 @@ class TestLinearExtrapolator:
             LinearExtrapolator().extrapolate([1.0, float("inf")], [1.0, 2.0])
 
 
-class TestNoMitigationMultiObservable:
-    """Tuple-observable expand/reduce path on the trivial protocol."""
+class TestNoMitigationTupleObservable:
+    """Tuple-observable expand/reduce on the trivial protocol."""
 
-    def test_expand_with_tuple_returns_list_of_contexts(self, bell_dag):
-        # Two distinct "observables" — the protocol ignores their content,
-        # but the loop helper still produces one context per entry.
-        dags, ctxs = _NoMitigation().expand(bell_dag, observable=("o1", "o2"))
-        assert isinstance(ctxs, list)
-        assert len(ctxs) == 2
-        # Each context's dag_indices points at exactly one DAG slot,
-        # and slots are disjoint (one DAG per observable for _NoMitigation).
-        all_indices = [i for c in ctxs for i in c["dag_indices"]]
-        assert len(all_indices) == len(set(all_indices))
-        assert len(dags) == 2
+    def test_expand_with_tuple_returns_single_context(self, bell_dag):
+        dags, ctx = _NoMitigation().expand(bell_dag, observable=("o1", "o2"))
+        assert ctx == {"dag_indices": [0]}
+        assert len(dags) == 1
 
-    def test_reduce_with_per_dag_per_obs_rows(self, bell_dag):
-        """When ``MeasurementStage`` emits per-DAG list[float], reduce slices
-        out each observable's column."""
-        _, ctxs = _NoMitigation().expand(bell_dag, observable=("o1", "o2"))
-        # Each row is [val_for_obs1, val_for_obs2] for that DAG.  Each ctx
-        # selects a single row via dag_indices and a single column via
-        # _reduce_for_list_context's per-observable slicing.
-        rows = [[0.7, -0.3], [0.5, 0.1]]
-        out = _NoMitigation().reduce(rows, ctxs)
-        assert out == [0.7, 0.1]
-
-    def test_reduce_with_scalar_rows_falls_back_to_full_results(self, bell_dag):
-        """Scalar quantum_results path: each ctx sees the full sequence."""
-        # A protocol like _NoMitigation expects 1 result per ctx; build a
-        # tuple of length-1 contexts so the inner reduce calls don't choke.
-        # Use a fresh expand for each obs to ensure dag_indices line up.
-        dags, ctxs = _NoMitigation().expand(bell_dag, observable=("o1",))
-        # Single observable in the tuple → one ctx → one inner reduce call.
-        out = _NoMitigation().reduce([0.42], ctxs)
-        assert out == [0.42]
-
-    def test_empty_observables_tuple_rejected(self, bell_dag):
-        with pytest.raises(ValueError, match="at least one observable"):
-            _NoMitigation().expand(bell_dag, observable=())
-
-    def test_per_dag_row_count_mismatch_raises(self, bell_dag):
-        """Per-DAG rows whose length doesn't match the number of contexts
-        is treated as a sync bug between MeasurementStage and the protocol."""
-        _, ctxs = _NoMitigation().expand(bell_dag, observable=("o1", "o2"))
-        # 3 columns but only 2 contexts → mismatch.
-        rows = [[0.1, 0.2, 0.3]]
-        with pytest.raises(RuntimeError, match="out of sync"):
-            _NoMitigation().reduce(rows, ctxs)
+    def test_reduce_with_per_obs_list(self, bell_dag):
+        out = _NoMitigation().reduce([[0.7, -0.3]], {"dag_indices": [0]})
+        assert out == [0.7, -0.3]
 
 
-class TestZNEMultiObservable:
-    """ZNE on tuple observables loops the helper (folding is observable-independent)."""
+class TestZNETupleObservable:
+    """ZNE on a tuple observable extrapolates per-observable element-wise."""
 
-    def test_expand_with_tuple_returns_list_of_contexts(self, bell_dag):
-        zne = ZNE(scale_factors=[1.0, 3.0])
-        dags, ctxs = zne.expand(bell_dag, observable=("o1", "o2"))
-        assert isinstance(ctxs, list)
-        assert len(ctxs) == 2
-        # 2 observables × 2 scale factors → 4 DAG slots in the merged tuple.
-        # The default _expand_per_observable_loop does NOT dedupe folded DAGs.
-        assert len(dags) == 4
-        for ctx in ctxs:
-            assert "effective_scales" in ctx
-            assert "dag_indices" in ctx
-            assert len(ctx["dag_indices"]) == 2
-
-    def test_reduce_with_tuple_returns_list_of_floats(self, bell_dag):
-        # y_obs1 = 2 - s, y_obs2 = 4 - 2s; intercepts at s=0 are 2 and 4.
+    def test_reduce_with_per_obs_list(self, bell_dag):
+        # y_obs1 = 2 - s → 2; y_obs2 = 4 - 2s → 4.
         zne = ZNE(scale_factors=[1.0, 3.0], extrapolator=LinearExtrapolator())
-        _, ctxs = zne.expand(bell_dag, observable=("a", "b"))
-        # Each row is a per-observable list at one DAG.  Build them so that
-        # each ctx's dag_indices selects [y@s=1, y@s=3] for that observable.
-        # The two ctxs have disjoint dag_indices (loop helper, no dedup).
-        n_dags = 4
-        rows = [[float("nan"), float("nan")] for _ in range(n_dags)]
-        for slot, d in enumerate(ctxs[0]["dag_indices"]):
-            rows[d][0] = (1.0, -1.0)[slot]  # y_obs1 at s=1, s=3
-        for slot, d in enumerate(ctxs[1]["dag_indices"]):
-            rows[d][1] = (2.0, -2.0)[slot]  # y_obs2 at s=1, s=3
-        out = zne.reduce(rows, ctxs)
+        _, ctx = zne.expand(bell_dag, observable=("a", "b"))
+        rows = [[1.0, 2.0], [-1.0, -2.0]]
+        out = zne.reduce(rows, ctx)
         assert isinstance(out, list)
         assert out[0] == pytest.approx(2.0)
         assert out[1] == pytest.approx(4.0)

--- a/tests/circuits/test_quepp.py
+++ b/tests/circuits/test_quepp.py
@@ -529,6 +529,82 @@ class TestQuEPPSignalDestruction:
         assert per_obs[0].get("_signal_destroyed") is True
 
 
+class TestQuEPPNoDiagonalPathsWarning:
+    """Spec: when path enumeration yields zero diagonal-final paths for an
+    observable, ``QuEPP.reduce`` silently returns the noisy target unchanged
+    (mitigation is a no-op). The expand-time warning surfaces this so the
+    user does not consume noisy results believing they were mitigated.
+    """
+
+    @staticmethod
+    def _h_then_rz_qc() -> QuantumCircuit:
+        # Single non-Clifford rotation (RZ) preceded by an H Clifford. Walking
+        # back-to-front, observable Z passes through RZ unchanged (commute),
+        # then conjugates through H to land as X — non-diagonal, so every
+        # candidate path is rejected by the diagonal-final filter.
+        qc = QuantumCircuit(1)
+        qc.h(0)
+        qc.rz(0.5, 0)
+        return qc
+
+    def test_warns_on_zero_diagonal_paths_in_expand(self):
+        proto = QuEPP(sampling="exhaustive", truncation_order=1, n_twirls=0)
+        obs = SparsePauliOp.from_list([("Z", 1.0)])
+        with warnings.catch_warnings():
+            # The truncation-ratio warning also fires on this tiny circuit
+            # (K/n_rot = 100%); silence it so pytest.warns sees the target.
+            warnings.filterwarnings("ignore", message=r"QuEPP:.*shallow circuits")
+            with pytest.warns(UserWarning, match=r"zero diagonal Pauli paths"):
+                proto.expand(circuit_to_dag(self._h_then_rz_qc()), (obs,))
+
+    def test_warns_on_zero_diagonal_paths_in_dry_expand(self):
+        proto = QuEPP(sampling="exhaustive", truncation_order=1, n_twirls=0)
+        obs = SparsePauliOp.from_list([("Z", 1.0)])
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=r"QuEPP:.*shallow circuits")
+            with pytest.warns(UserWarning, match=r"zero diagonal Pauli paths"):
+                proto.dry_expand(circuit_to_dag(self._h_then_rz_qc()), (obs,))
+
+    def test_warns_lists_all_offending_observables_once(self):
+        # Two failing observables in one tuple → ONE batched warning that
+        # mentions both indices, not two separate warnings.
+        proto = QuEPP(sampling="exhaustive", truncation_order=1, n_twirls=0)
+        bad1 = SparsePauliOp.from_list([("Z", 1.0)])
+        bad2 = SparsePauliOp.from_list([("Z", 0.5)])
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            proto.expand(circuit_to_dag(self._h_then_rz_qc()), (bad1, bad2))
+        zero_path_warnings = [
+            w for w in caught if "zero diagonal Pauli paths" in str(w.message)
+        ]
+        assert len(zero_path_warnings) == 1
+        assert "[0, 1]" in str(zero_path_warnings[0].message)
+
+    def test_no_warning_when_paths_exist(self):
+        # RX(θ) with observable Z keeps Z as the back-propagated Pauli on the
+        # cos branch (diagonal) → at least one path survives → no warning.
+        qc = QuantumCircuit(1)
+        qc.rx(0.7, 0)
+        proto = QuEPP(sampling="exhaustive", truncation_order=1, n_twirls=0)
+        obs = SparsePauliOp.from_list([("Z", 1.0)])
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            warnings.filterwarnings("ignore", message=r"QuEPP:.*shallow circuits")
+            proto.expand(circuit_to_dag(qc), (obs,))
+
+    def test_no_warning_for_clifford_only_circuit(self):
+        # n_rotations == 0 guard: a Clifford-only circuit has nothing to
+        # mitigate by construction, so the warning is suppressed even when
+        # no diagonal paths would survive in principle.
+        qc = QuantumCircuit(1)
+        qc.h(0)
+        proto = QuEPP(sampling="exhaustive", truncation_order=1, n_twirls=0)
+        obs = SparsePauliOp.from_list([("Z", 1.0)])
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            proto.expand(circuit_to_dag(qc), (obs,))
+
+
 class TestSymbolicExpand:
     @pytest.mark.usefixtures("suppress_quepp_warnings")
     def test_expand_marks_symbolic(self):

--- a/tests/circuits/test_quepp.py
+++ b/tests/circuits/test_quepp.py
@@ -1006,3 +1006,247 @@ class TestQuEPPPipelineIntegration:
             f"QuEPP error ({quepp_err:.4f}) should be less than half "
             f"of noisy error ({noisy_err:.4f})"
         )
+
+
+class TestQuEPPMultiObservable:
+    """QuEPP with a tuple of observables (shared target + deduped paths)."""
+
+    @pytest.fixture
+    def qc_two_rotations(self):
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.rx(0.3, 0)
+        qc.cx(0, 1)
+        qc.rz(0.7, 1)
+        return qc
+
+    def test_expand_returns_list_of_contexts(self, qc_two_rotations):
+        obs1 = SparsePauliOp.from_list([("IZ", 1.0)])
+        obs2 = SparsePauliOp.from_list([("ZZ", 1.0)])
+        protocol = QuEPP(sampling="exhaustive", truncation_order=2, n_twirls=0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            _, ctxs = protocol.expand(circuit_to_dag(qc_two_rotations), (obs1, obs2))
+        assert isinstance(ctxs, list)
+        assert len(ctxs) == 2
+        for ctx in ctxs:
+            assert "classical_values" in ctx
+            assert "weights" in ctx
+            assert "dag_indices" in ctx
+            # Target shared across all observables, always at merged index 0.
+            assert ctx["dag_indices"][0] == 0
+
+    def test_classical_values_match_independent_runs(self, qc_two_rotations):
+        """Multi-observable expand produces the same per-observable
+        classical values as N independent single-observable expand calls.
+        """
+        obs1 = SparsePauliOp.from_list([("IZ", 1.0)])
+        obs2 = SparsePauliOp.from_list([("ZZ", 1.0)])
+        protocol = QuEPP(sampling="exhaustive", truncation_order=2, n_twirls=0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            _, ctx1 = protocol.expand(circuit_to_dag(qc_two_rotations.copy()), obs1)
+            _, ctx2 = protocol.expand(circuit_to_dag(qc_two_rotations.copy()), obs2)
+            _, ctxs_multi = protocol.expand(
+                circuit_to_dag(qc_two_rotations.copy()), (obs1, obs2)
+            )
+        # Per-observable enumeration is observable-specific (per the paper)
+        # — same paths up to enumeration order, so compare sorted classical
+        # values.
+        np.testing.assert_allclose(
+            sorted(ctxs_multi[0]["classical_values"]),
+            sorted(ctx1["classical_values"]),
+            atol=1e-9,
+        )
+        np.testing.assert_allclose(
+            sorted(ctxs_multi[1]["classical_values"]),
+            sorted(ctx2["classical_values"]),
+            atol=1e-9,
+        )
+
+    def test_target_dag_is_shared_across_observables(self, qc_two_rotations):
+        obs1 = SparsePauliOp.from_list([("IZ", 1.0)])
+        obs2 = SparsePauliOp.from_list([("ZZ", 1.0)])
+        protocol = QuEPP(sampling="exhaustive", truncation_order=2, n_twirls=0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            dags, ctxs = protocol.expand(
+                circuit_to_dag(qc_two_rotations), (obs1, obs2)
+            )
+        # Both observables' dag_indices must point at the SAME object for
+        # their target — the cost saving of the multi-observable path.
+        target_dag_for_obs1 = dags[ctxs[0]["dag_indices"][0]]
+        target_dag_for_obs2 = dags[ctxs[1]["dag_indices"][0]]
+        assert target_dag_for_obs1 is target_dag_for_obs2
+
+    def test_path_dag_dedup_across_observables(self):
+        """Two observables that produce the same branches tuple should
+        share a single path DAG in the merged tuple.
+        """
+        # Identical observables → identical paths → dedup is maximal.
+        qc = QuantumCircuit(1)
+        qc.rx(0.4, 0)
+        obs = SparsePauliOp.from_list([("Z", 1.0)])
+        protocol = QuEPP(sampling="exhaustive", truncation_order=1, n_twirls=0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            dags_solo, _ = protocol.expand(circuit_to_dag(qc.copy()), obs)
+            dags_multi, ctxs_multi = protocol.expand(
+                circuit_to_dag(qc.copy()), (obs, obs)
+            )
+        # Solo: target + n_paths.  Multi with two identical observables:
+        # also target + n_paths (every path is shared).  Same total DAG count.
+        assert len(dags_multi) == len(dags_solo)
+        # Both ctxs hold identical dag_indices (they reference the same
+        # shared target and paths).
+        assert ctxs_multi[0]["dag_indices"] == ctxs_multi[1]["dag_indices"]
+
+    def test_reduce_returns_list_when_context_is_list(self, qc_two_rotations):
+        obs1 = SparsePauliOp.from_list([("IZ", 1.0)])
+        obs2 = SparsePauliOp.from_list([("ZZ", 1.0)])
+        protocol = QuEPP(sampling="exhaustive", truncation_order=2, n_twirls=0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            dags, ctxs = protocol.expand(
+                circuit_to_dag(qc_two_rotations), (obs1, obs2)
+            )
+        # MeasurementStage emits per-DAG list[float] of per-observable expvals
+        # for tuple-observable metas; mimic that here with arbitrary numbers.
+        per_dag_per_obs = [[0.5, 0.3] for _ in dags]
+        out = protocol.reduce(per_dag_per_obs, ctxs)
+        assert isinstance(out, list)
+        assert len(out) == 2
+        assert all(isinstance(v, float) for v in out)
+
+    def test_reduce_per_observable_matches_independent_runs(self, qc_two_rotations):
+        """When given the same noisy measurement values, the multi-observable
+        reduce produces the same numbers as running QuEPP per observable
+        separately.  (Both modes are observable-specific in path enumeration
+        and η — sharing the target/path DAGs doesn't change the arithmetic.)
+        """
+        obs1 = SparsePauliOp.from_list([("IZ", 1.0)])
+        obs2 = SparsePauliOp.from_list([("ZZ", 1.0)])
+        protocol = QuEPP(sampling="exhaustive", truncation_order=2, n_twirls=0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            _, ctx1 = protocol.expand(circuit_to_dag(qc_two_rotations.copy()), obs1)
+            _, ctx2 = protocol.expand(circuit_to_dag(qc_two_rotations.copy()), obs2)
+            dags_multi, ctxs_multi = protocol.expand(
+                circuit_to_dag(qc_two_rotations.copy()), (obs1, obs2)
+            )
+
+        # Build a noiseless oracle: for the multi-observable case, every
+        # DAG produces a per-observable list of "noisy" values that are
+        # exact classical values for that observable.  Then per-observable
+        # reduce should recover those exact classical values from the
+        # noiseless ensemble (η=1).
+        rng = np.random.default_rng(0)
+        # Independent runs: per-observable noisy results (target + ensemble).
+        noisy_solo_1 = np.concatenate(
+            [[float(rng.uniform(-1, 1))], np.array(ctx1["classical_values"])]
+        )
+        noisy_solo_2 = np.concatenate(
+            [[float(rng.uniform(-1, 1))], np.array(ctx2["classical_values"])]
+        )
+        out1 = protocol.reduce(noisy_solo_1.tolist(), ctx1)
+        out2 = protocol.reduce(noisy_solo_2.tolist(), ctx2)
+
+        # Multi run: build a per-DAG list[float] structure where row d's
+        # column 0 is the noisy result for obs1 (when d is in obs1's
+        # dag_indices) and column 1 is for obs2.  For DAGs not in an obs's
+        # ensemble, the value is unused (so we put NaN to assert this).
+        n_dags = len(dags_multi)
+        rows = [[float("nan"), float("nan")] for _ in range(n_dags)]
+        # obs1 sees dag_indices into rows; assign noisy_solo_1 in order.
+        for slot, d in enumerate(ctxs_multi[0]["dag_indices"]):
+            rows[d][0] = noisy_solo_1[slot]
+        for slot, d in enumerate(ctxs_multi[1]["dag_indices"]):
+            rows[d][1] = noisy_solo_2[slot]
+
+        out_multi = protocol.reduce(rows, ctxs_multi)
+        assert out_multi[0] == pytest.approx(out1, abs=1e-9)
+        assert out_multi[1] == pytest.approx(out2, abs=1e-9)
+
+    def test_qscript_to_meta_multi_expval_populates_tuple(self):
+        """A multi-measurement qscript with N expvals → meta.observable
+        is a tuple of N SparsePauliOps."""
+        qc_pl = qp.tape.QuantumScript(
+            ops=[qp.Hadamard(0), qp.RX(0.3, 0), qp.CNOT([0, 1])],
+            measurements=[
+                qp.expval(qp.PauliZ(0)),
+                qp.expval(qp.PauliZ(0) @ qp.PauliZ(1)),
+            ],
+        )
+        meta = qscript_to_meta(qc_pl)
+        assert isinstance(meta.observable, tuple)
+        assert len(meta.observable) == 2
+        for obs in meta.observable:
+            assert isinstance(obs, SparsePauliOp)
+
+    def test_empty_observables_tuple_rejected(self, qc_two_rotations):
+        protocol = QuEPP(sampling="exhaustive", truncation_order=2, n_twirls=0)
+        with pytest.raises(ValueError, match="at least one observable"):
+            protocol.expand(circuit_to_dag(qc_two_rotations), ())
+
+    def test_pipeline_e2e_matches_independent_runs(self, suppress_quepp_warnings):
+        """End-to-end pipeline (CircuitSpecStage → QEMStage(QuEPP) →
+        MeasurementStage) on a noiseless backend with two QWC observables
+        produces the same per-observable mitigated values as running each
+        observable through its own pipeline.
+        """
+        # Single multi-observable qscript (two expvals on QWC observables).
+        ops = [qp.Hadamard(0), qp.RX(0.3, 0), qp.CNOT([0, 1]), qp.RZ(0.7, 1)]
+        multi_meta = qscript_to_meta(
+            qp.tape.QuantumScript(
+                ops=ops,
+                measurements=[
+                    qp.expval(qp.Z(0)),
+                    qp.expval(qp.Z(0) @ qp.Z(1)),
+                ],
+            )
+        )
+        single_meta_1 = qscript_to_meta(
+            qp.tape.QuantumScript(ops=ops, measurements=[qp.expval(qp.Z(0))])
+        )
+        single_meta_2 = qscript_to_meta(
+            qp.tape.QuantumScript(
+                ops=ops, measurements=[qp.expval(qp.Z(0) @ qp.Z(1))]
+            )
+        )
+
+        backend_kwargs = dict(
+            shots=200000, simulation_seed=42, _deterministic_execution=True
+        )
+
+        def _run(meta):
+            return list(
+                CircuitPipeline(
+                    stages=[
+                        CircuitSpecStage(),
+                        QEMStage(
+                            protocol=QuEPP(
+                                sampling="exhaustive",
+                                truncation_order=2,
+                                n_twirls=0,
+                            )
+                        ),
+                        MeasurementStage(),
+                    ],
+                    suppress_performance_warnings=True,
+                )
+                .run(meta, PipelineEnv(backend=QiskitSimulator(**backend_kwargs)))
+                .values()
+            )[0]
+
+        multi_out = _run(multi_meta)
+        solo_1 = _run(single_meta_1)
+        solo_2 = _run(single_meta_2)
+
+        assert isinstance(multi_out, list)
+        assert len(multi_out) == 2
+        # Tolerances are loose because the noiseless QuEPP path still passes
+        # through finite-shot measurement; QWC grouping plus the η rescale
+        # produce numbers that agree between modes only up to statistical
+        # noise (and tiny numerical drift from the path-DAG dedup).
+        assert multi_out[0] == pytest.approx(solo_1, abs=5e-3)
+        assert multi_out[1] == pytest.approx(solo_2, abs=5e-3)

--- a/tests/circuits/test_quepp.py
+++ b/tests/circuits/test_quepp.py
@@ -447,7 +447,7 @@ class TestQuEPPProtocol:
         p = QuEPP(truncation_order=2, sampling="exhaustive", n_twirls=0)
         dags, ctx = p.expand(circuit_to_dag(mixed_qc), obs)
         assert len(dags) == ctx["n_paths"] + 1
-        assert "classical_values" in ctx
+        assert "classical_values" in ctx["per_obs"][0]
         assert ctx["target_idx"] == 0
         assert ctx["ensemble_start"] == 1
 
@@ -463,10 +463,10 @@ class TestQuEPPProtocol:
         obs = SparsePauliOp.from_list([("ZZ", 1.0)])
         p = QuEPP(truncation_order=0, sampling="exhaustive", n_twirls=0)
         _, ctx = p.expand(circuit_to_dag(bell_qc), obs)
-        assert ctx["classical_values"][0] == pytest.approx(1.0)
+        assert ctx["per_obs"][0]["classical_values"][0] == pytest.approx(1.0)
         # No rotations → reduce returns weights @ classical_values.
         result = p.reduce([1.0, 1.0], ctx)
-        assert result == pytest.approx(1.0)
+        assert result == pytest.approx([1.0])
 
     def test_missing_observable_raises(self, bell_qc):
         p = QuEPP()
@@ -509,9 +509,15 @@ class TestQuEPPSignalDestruction:
         """
         # Non-zero classical values (so "valid" mask has entries) but the
         # ensemble_noisy values are ~0 ⇒ η ≈ 0 < min_eta (0.1) ⇒ fallback.
+        per_obs = [
+            {
+                "classical_values": np.array([1.0, 0.5]),
+                "weights": np.array([0.5, 0.5]),
+                "dag_indices": [0, 1, 2],
+            }
+        ]
         ctx = {
-            "classical_values": np.array([1.0, 0.5]),
-            "weights": np.array([0.5, 0.5]),
+            "per_obs": per_obs,
             "target_idx": 0,
             "ensemble_start": 1,
             "n_rotations": 1,
@@ -519,8 +525,8 @@ class TestQuEPPSignalDestruction:
         }
         p = QuEPP(n_twirls=0)
         result = p.reduce([0.3, 0.0, 0.0], ctx)
-        assert result == pytest.approx(0.3)
-        assert ctx.get("_signal_destroyed") is True
+        assert result == pytest.approx([0.3])
+        assert per_obs[0].get("_signal_destroyed") is True
 
 
 class TestSymbolicExpand:
@@ -547,8 +553,9 @@ class TestSymbolicExpand:
         obs = SparsePauliOp.from_list([("IZ", 1.0)])
         p = QuEPP(sampling="exhaustive", truncation_order=1, n_twirls=0)
         _, ctx = p.expand(circuit_to_dag(qc), obs)
-        assert ctx["weights"].dtype == object
-        for w in ctx["weights"]:
+        weights = ctx["per_obs"][0]["weights"]
+        assert weights.dtype == object
+        for w in weights:
             assert isinstance(w, (ParameterExpression, int, float))
 
     @pytest.mark.usefixtures("suppress_quepp_warnings")
@@ -569,14 +576,19 @@ class TestEvaluateSymbolicWeights:
         # Build ParameterExpression weights: cos(theta) and sin(theta).
         cos_w = theta.cos()
         sin_w = theta.sin()
+        entry = {"weights": np.array([cos_w, sin_w], dtype=object)}
+        QuEPP.evaluate_symbolic_weights(entry, [theta], np.array([0.0]))
+        assert entry["weights"][0] == pytest.approx(1.0)
+        assert entry["weights"][1] == pytest.approx(0.0)
+
+    def test_rejects_full_context(self):
+        theta = Parameter("theta_full_ctx")
         ctx = {
-            "weights": np.array([cos_w, sin_w], dtype=object),
+            "per_obs": [{"weights": np.array([theta.cos()], dtype=object)}],
             "symbolic": True,
         }
-        QuEPP.evaluate_symbolic_weights(ctx, [theta], np.array([0.0]))
-        assert ctx["weights"][0] == pytest.approx(1.0)
-        assert ctx["weights"][1] == pytest.approx(0.0)
-        assert ctx["symbolic"] is False
+        with pytest.raises(TypeError, match="per_obs entry"):
+            QuEPP.evaluate_symbolic_weights(ctx, [theta], np.array([0.0]))
 
 
 # ---------------------------------------------------------------------------
@@ -614,7 +626,8 @@ class TestCPTExpansion:
         _, ctx = QuEPP(sampling="exhaustive", truncation_order=5, n_twirls=0).expand(
             circuit_to_dag(qc), obs
         )
-        cpt = float(ctx["weights"] @ ctx["classical_values"])
+        entry = ctx["per_obs"][0]
+        cpt = float(entry["weights"] @ entry["classical_values"])
         assert cpt == pytest.approx(np.cos(angle), abs=1e-6)
 
     @pytest.mark.usefixtures("suppress_quepp_warnings")
@@ -629,7 +642,8 @@ class TestCPTExpansion:
         _, ctx = QuEPP(sampling="exhaustive", truncation_order=5, n_twirls=0).expand(
             circuit_to_dag(qc), obs
         )
-        cpt = float(ctx["weights"] @ ctx["classical_values"])
+        entry = ctx["per_obs"][0]
+        cpt = float(entry["weights"] @ entry["classical_values"])
         assert cpt == pytest.approx(_exact_expval(qc, obs), abs=1e-4)
 
     @pytest.mark.usefixtures("suppress_quepp_warnings")
@@ -639,7 +653,8 @@ class TestCPTExpansion:
         _, ctx = QuEPP(sampling="exhaustive", truncation_order=5, n_twirls=0).expand(
             circuit_to_dag(mixed_qc), obs
         )
-        cpt = float(ctx["weights"] @ ctx["classical_values"])
+        entry = ctx["per_obs"][0]
+        cpt = float(entry["weights"] @ entry["classical_values"])
         assert cpt == pytest.approx(_exact_expval(mixed_qc, obs), abs=1e-4)
 
     @pytest.mark.usefixtures("suppress_quepp_warnings")
@@ -656,7 +671,8 @@ class TestCPTExpansion:
             circuit_to_dag(qc), obs
         )
         assert ctx["n_paths"] == 0
-        assert float(ctx["weights"] @ ctx["classical_values"]) == pytest.approx(0.0)
+        entry = ctx["per_obs"][0]
+        assert float(entry["weights"] @ entry["classical_values"]) == pytest.approx(0.0)
 
 
 # ---------------------------------------------------------------------------
@@ -702,7 +718,8 @@ class TestNormalizeCircuitExtended:
         _, ctx = QuEPP(sampling="exhaustive", truncation_order=5, n_twirls=0).expand(
             circuit_to_dag(qc), obs
         )
-        cpt = float(ctx["weights"] @ ctx["classical_values"])
+        entry = ctx["per_obs"][0]
+        cpt = float(entry["weights"] @ entry["classical_values"])
         assert cpt == pytest.approx(np.cos(angle), abs=1e-6)
 
 
@@ -752,8 +769,8 @@ class TestQuEPPRoundTrip:
         protocol = QuEPP(sampling="exhaustive", truncation_order=10, n_twirls=0)
         _, ctx = protocol.expand(circuit_to_dag(qc), obs)
         qr = [exact]
-        qr.extend(ctx["classical_values"])
-        assert protocol.reduce(qr, ctx) == pytest.approx(exact, abs=1e-6)
+        qr.extend(ctx["per_obs"][0]["classical_values"])
+        assert protocol.reduce(qr, ctx) == pytest.approx([exact], abs=1e-6)
 
     @pytest.mark.usefixtures("suppress_quepp_warnings")
     def test_noise_correction(self):
@@ -766,8 +783,8 @@ class TestQuEPPRoundTrip:
         _, ctx = protocol.expand(circuit_to_dag(qc), obs)
         noise_factor = 0.9
         qr = [exact * noise_factor]
-        qr.extend(ctx["classical_values"] * noise_factor)
-        assert protocol.reduce(qr, ctx) == pytest.approx(exact, abs=1e-4)
+        qr.extend(ctx["per_obs"][0]["classical_values"] * noise_factor)
+        assert protocol.reduce(qr, ctx) == pytest.approx([exact], abs=1e-4)
 
     @pytest.mark.usefixtures("suppress_quepp_warnings")
     def test_expand_with_controlled_rotation(self):
@@ -779,7 +796,8 @@ class TestQuEPPRoundTrip:
         obs = SparsePauliOp.from_list([("ZZ", 1.0)])
         protocol = QuEPP(sampling="exhaustive", truncation_order=5, n_twirls=0)
         _, ctx = protocol.expand(circuit_to_dag(qc), obs)
-        cpt = float(ctx["weights"] @ ctx["classical_values"])
+        entry = ctx["per_obs"][0]
+        cpt = float(entry["weights"] @ entry["classical_values"])
         assert cpt == pytest.approx(_exact_expval(qc, obs), abs=1e-4)
 
 
@@ -795,9 +813,13 @@ class TestQuEPPSignalDestructionExtended:
     def _make_context(classical_values, weights=None):
         cv = np.array(classical_values)
         w = np.array(weights) if weights is not None else np.ones(len(cv)) / len(cv)
-        return {
+        per_obs_entry = {
             "classical_values": cv,
             "weights": w,
+            "dag_indices": list(range(1 + len(cv))),
+        }
+        return {
+            "per_obs": [per_obs_entry],
             "target_idx": 0,
             "ensemble_start": 1,
             "n_rotations": len(cv),
@@ -810,19 +832,19 @@ class TestQuEPPSignalDestructionExtended:
         # Ensemble noisy close to classical → eta ≈ 1.0
         quantum_results = [0.5, 0.48, 0.29]
         QuEPP(truncation_order=1, n_twirls=0).reduce(quantum_results, ctx)
-        assert "_signal_destroyed" not in ctx
+        assert "_signal_destroyed" not in ctx["per_obs"][0]
 
     def test_signal_destroyed_flag_not_set_for_near_zero_classical(self):
         """reduce() does NOT flag when classical values are all near zero."""
         ctx = self._make_context([1e-15, 1e-15])
         quantum_results = [0.5, 0.01, 0.01]
         QuEPP(truncation_order=1, n_twirls=0).reduce(quantum_results, ctx)
-        assert "_signal_destroyed" not in ctx
+        assert "_signal_destroyed" not in ctx["per_obs"][0]
 
     def test_post_reduce_warns_on_destroyed_signal(self):
         """post_reduce() emits a UserWarning when contexts have destroyed signals."""
-        destroyed = {"_signal_destroyed": True}
-        healthy = {}
+        destroyed = {"per_obs": [{"_signal_destroyed": True}]}
+        healthy = {"per_obs": [{}]}
         protocol = QuEPP(truncation_order=1, n_twirls=0)
         with pytest.warns(UserWarning, match=r"signal destroyed"):
             protocol.post_reduce([destroyed, healthy])
@@ -832,7 +854,7 @@ class TestQuEPPSignalDestructionExtended:
         protocol = QuEPP(truncation_order=1, n_twirls=0)
         with warnings.catch_warnings():
             warnings.simplefilter("error")
-            protocol.post_reduce([{}, {}])
+            protocol.post_reduce([{"per_obs": [{}]}, {"per_obs": [{}]}])
 
     def test_post_reduce_default_noop_on_base_class(self):
         """QEMProtocol.post_reduce() is a no-op that does not raise."""
@@ -967,7 +989,7 @@ class TestQuEPPPipelineIntegration:
             CircuitPipeline(stages=[CircuitSpecStage(), MeasurementStage()])
             .run(meta, PipelineEnv(backend=QiskitSimulator(**shared)))
             .values()
-        )[0]
+        )[0][0]
 
         noisy = list(
             CircuitPipeline(stages=[CircuitSpecStage(), MeasurementStage()])
@@ -976,7 +998,7 @@ class TestQuEPPPipelineIntegration:
                 PipelineEnv(backend=QiskitSimulator(noise_model=noise, **shared)),
             )
             .values()
-        )[0]
+        )[0][0]
 
         quepp_val = list(
             CircuitPipeline(
@@ -998,7 +1020,7 @@ class TestQuEPPPipelineIntegration:
                 PipelineEnv(backend=QiskitSimulator(noise_model=noise, **shared)),
             )
             .values()
-        )[0]
+        )[0][0]
 
         noisy_err = abs(noisy - exact)
         quepp_err = abs(quepp_val - exact)
@@ -1020,21 +1042,22 @@ class TestQuEPPMultiObservable:
         qc.rz(0.7, 1)
         return qc
 
-    def test_expand_returns_list_of_contexts(self, qc_two_rotations):
+    def test_expand_returns_per_obs_entries(self, qc_two_rotations):
         obs1 = SparsePauliOp.from_list([("IZ", 1.0)])
         obs2 = SparsePauliOp.from_list([("ZZ", 1.0)])
         protocol = QuEPP(sampling="exhaustive", truncation_order=2, n_twirls=0)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            _, ctxs = protocol.expand(circuit_to_dag(qc_two_rotations), (obs1, obs2))
-        assert isinstance(ctxs, list)
-        assert len(ctxs) == 2
-        for ctx in ctxs:
-            assert "classical_values" in ctx
-            assert "weights" in ctx
-            assert "dag_indices" in ctx
+            _, ctx = protocol.expand(circuit_to_dag(qc_two_rotations), (obs1, obs2))
+        per_obs = ctx["per_obs"]
+        assert isinstance(per_obs, list)
+        assert len(per_obs) == 2
+        for entry in per_obs:
+            assert "classical_values" in entry
+            assert "weights" in entry
+            assert "dag_indices" in entry
             # Target shared across all observables, always at merged index 0.
-            assert ctx["dag_indices"][0] == 0
+            assert entry["dag_indices"][0] == 0
 
     def test_classical_values_match_independent_runs(self, qc_two_rotations):
         """Multi-observable expand produces the same per-observable
@@ -1047,20 +1070,17 @@ class TestQuEPPMultiObservable:
             warnings.simplefilter("ignore")
             _, ctx1 = protocol.expand(circuit_to_dag(qc_two_rotations.copy()), obs1)
             _, ctx2 = protocol.expand(circuit_to_dag(qc_two_rotations.copy()), obs2)
-            _, ctxs_multi = protocol.expand(
+            _, ctx_multi = protocol.expand(
                 circuit_to_dag(qc_two_rotations.copy()), (obs1, obs2)
             )
-        # Per-observable enumeration is observable-specific (per the paper)
-        # — same paths up to enumeration order, so compare sorted classical
-        # values.
         np.testing.assert_allclose(
-            sorted(ctxs_multi[0]["classical_values"]),
-            sorted(ctx1["classical_values"]),
+            sorted(ctx_multi["per_obs"][0]["classical_values"]),
+            sorted(ctx1["per_obs"][0]["classical_values"]),
             atol=1e-9,
         )
         np.testing.assert_allclose(
-            sorted(ctxs_multi[1]["classical_values"]),
-            sorted(ctx2["classical_values"]),
+            sorted(ctx_multi["per_obs"][1]["classical_values"]),
+            sorted(ctx2["per_obs"][0]["classical_values"]),
             atol=1e-9,
         )
 
@@ -1070,20 +1090,13 @@ class TestQuEPPMultiObservable:
         protocol = QuEPP(sampling="exhaustive", truncation_order=2, n_twirls=0)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            dags, ctxs = protocol.expand(
-                circuit_to_dag(qc_two_rotations), (obs1, obs2)
-            )
-        # Both observables' dag_indices must point at the SAME object for
-        # their target — the cost saving of the multi-observable path.
-        target_dag_for_obs1 = dags[ctxs[0]["dag_indices"][0]]
-        target_dag_for_obs2 = dags[ctxs[1]["dag_indices"][0]]
+            dags, ctx = protocol.expand(circuit_to_dag(qc_two_rotations), (obs1, obs2))
+        per_obs = ctx["per_obs"]
+        target_dag_for_obs1 = dags[per_obs[0]["dag_indices"][0]]
+        target_dag_for_obs2 = dags[per_obs[1]["dag_indices"][0]]
         assert target_dag_for_obs1 is target_dag_for_obs2
 
     def test_path_dag_dedup_across_observables(self):
-        """Two observables that produce the same branches tuple should
-        share a single path DAG in the merged tuple.
-        """
-        # Identical observables → identical paths → dedup is maximal.
         qc = QuantumCircuit(1)
         qc.rx(0.4, 0)
         obs = SparsePauliOp.from_list([("Z", 1.0)])
@@ -1091,39 +1104,40 @@ class TestQuEPPMultiObservable:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             dags_solo, _ = protocol.expand(circuit_to_dag(qc.copy()), obs)
-            dags_multi, ctxs_multi = protocol.expand(
+            dags_multi, ctx_multi = protocol.expand(
                 circuit_to_dag(qc.copy()), (obs, obs)
             )
-        # Solo: target + n_paths.  Multi with two identical observables:
-        # also target + n_paths (every path is shared).  Same total DAG count.
+        per_obs = ctx_multi["per_obs"]
         assert len(dags_multi) == len(dags_solo)
-        # Both ctxs hold identical dag_indices (they reference the same
-        # shared target and paths).
-        assert ctxs_multi[0]["dag_indices"] == ctxs_multi[1]["dag_indices"]
+        assert per_obs[0]["dag_indices"] == per_obs[1]["dag_indices"]
 
-    def test_reduce_returns_list_when_context_is_list(self, qc_two_rotations):
+    def test_n_identical_observables_share_path_dags(self):
+        """N identical observables produce the same number of DAGs as 1
+        observable solo — path enumeration is not duplicated."""
+        qc = QuantumCircuit(1)
+        qc.rx(0.4, 0)
+        obs = SparsePauliOp.from_list([("Z", 1.0)])
+        protocol = QuEPP(sampling="exhaustive", truncation_order=1, n_twirls=0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            dags_solo, _ = protocol.expand(circuit_to_dag(qc.copy()), obs)
+            dags_multi, _ = protocol.expand(circuit_to_dag(qc.copy()), (obs, obs, obs))
+        assert len(dags_multi) == len(dags_solo)
+
+    def test_reduce_returns_list_for_multi_obs_context(self, qc_two_rotations):
         obs1 = SparsePauliOp.from_list([("IZ", 1.0)])
         obs2 = SparsePauliOp.from_list([("ZZ", 1.0)])
         protocol = QuEPP(sampling="exhaustive", truncation_order=2, n_twirls=0)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            dags, ctxs = protocol.expand(
-                circuit_to_dag(qc_two_rotations), (obs1, obs2)
-            )
-        # MeasurementStage emits per-DAG list[float] of per-observable expvals
-        # for tuple-observable metas; mimic that here with arbitrary numbers.
+            dags, ctx = protocol.expand(circuit_to_dag(qc_two_rotations), (obs1, obs2))
         per_dag_per_obs = [[0.5, 0.3] for _ in dags]
-        out = protocol.reduce(per_dag_per_obs, ctxs)
+        out = protocol.reduce(per_dag_per_obs, ctx)
         assert isinstance(out, list)
         assert len(out) == 2
         assert all(isinstance(v, float) for v in out)
 
     def test_reduce_per_observable_matches_independent_runs(self, qc_two_rotations):
-        """When given the same noisy measurement values, the multi-observable
-        reduce produces the same numbers as running QuEPP per observable
-        separately.  (Both modes are observable-specific in path enumeration
-        and η — sharing the target/path DAGs doesn't change the arithmetic.)
-        """
         obs1 = SparsePauliOp.from_list([("IZ", 1.0)])
         obs2 = SparsePauliOp.from_list([("ZZ", 1.0)])
         protocol = QuEPP(sampling="exhaustive", truncation_order=2, n_twirls=0)
@@ -1131,41 +1145,37 @@ class TestQuEPPMultiObservable:
             warnings.simplefilter("ignore")
             _, ctx1 = protocol.expand(circuit_to_dag(qc_two_rotations.copy()), obs1)
             _, ctx2 = protocol.expand(circuit_to_dag(qc_two_rotations.copy()), obs2)
-            dags_multi, ctxs_multi = protocol.expand(
+            dags_multi, ctx_multi = protocol.expand(
                 circuit_to_dag(qc_two_rotations.copy()), (obs1, obs2)
             )
 
-        # Build a noiseless oracle: for the multi-observable case, every
-        # DAG produces a per-observable list of "noisy" values that are
-        # exact classical values for that observable.  Then per-observable
-        # reduce should recover those exact classical values from the
-        # noiseless ensemble (η=1).
         rng = np.random.default_rng(0)
-        # Independent runs: per-observable noisy results (target + ensemble).
         noisy_solo_1 = np.concatenate(
-            [[float(rng.uniform(-1, 1))], np.array(ctx1["classical_values"])]
+            [
+                [float(rng.uniform(-1, 1))],
+                np.array(ctx1["per_obs"][0]["classical_values"]),
+            ]
         )
         noisy_solo_2 = np.concatenate(
-            [[float(rng.uniform(-1, 1))], np.array(ctx2["classical_values"])]
+            [
+                [float(rng.uniform(-1, 1))],
+                np.array(ctx2["per_obs"][0]["classical_values"]),
+            ]
         )
         out1 = protocol.reduce(noisy_solo_1.tolist(), ctx1)
         out2 = protocol.reduce(noisy_solo_2.tolist(), ctx2)
 
-        # Multi run: build a per-DAG list[float] structure where row d's
-        # column 0 is the noisy result for obs1 (when d is in obs1's
-        # dag_indices) and column 1 is for obs2.  For DAGs not in an obs's
-        # ensemble, the value is unused (so we put NaN to assert this).
+        per_obs = ctx_multi["per_obs"]
         n_dags = len(dags_multi)
         rows = [[float("nan"), float("nan")] for _ in range(n_dags)]
-        # obs1 sees dag_indices into rows; assign noisy_solo_1 in order.
-        for slot, d in enumerate(ctxs_multi[0]["dag_indices"]):
+        for slot, d in enumerate(per_obs[0]["dag_indices"]):
             rows[d][0] = noisy_solo_1[slot]
-        for slot, d in enumerate(ctxs_multi[1]["dag_indices"]):
+        for slot, d in enumerate(per_obs[1]["dag_indices"]):
             rows[d][1] = noisy_solo_2[slot]
 
-        out_multi = protocol.reduce(rows, ctxs_multi)
-        assert out_multi[0] == pytest.approx(out1, abs=1e-9)
-        assert out_multi[1] == pytest.approx(out2, abs=1e-9)
+        out_multi = protocol.reduce(rows, ctx_multi)
+        assert out_multi[0] == pytest.approx(out1[0], abs=1e-9)
+        assert out_multi[1] == pytest.approx(out2[0], abs=1e-9)
 
     def test_qscript_to_meta_multi_expval_populates_tuple(self):
         """A multi-measurement qscript with N expvals → meta.observable
@@ -1209,9 +1219,7 @@ class TestQuEPPMultiObservable:
             qp.tape.QuantumScript(ops=ops, measurements=[qp.expval(qp.Z(0))])
         )
         single_meta_2 = qscript_to_meta(
-            qp.tape.QuantumScript(
-                ops=ops, measurements=[qp.expval(qp.Z(0) @ qp.Z(1))]
-            )
+            qp.tape.QuantumScript(ops=ops, measurements=[qp.expval(qp.Z(0) @ qp.Z(1))])
         )
 
         backend_kwargs = dict(
@@ -1248,5 +1256,5 @@ class TestQuEPPMultiObservable:
         # through finite-shot measurement; QWC grouping plus the η rescale
         # produce numbers that agree between modes only up to statistical
         # noise (and tiny numerical drift from the path-DAG dedup).
-        assert multi_out[0] == pytest.approx(solo_1, abs=5e-3)
-        assert multi_out[1] == pytest.approx(solo_2, abs=5e-3)
+        assert multi_out[0] == pytest.approx(solo_1[0], abs=5e-3)
+        assert multi_out[1] == pytest.approx(solo_2[0], abs=5e-3)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,7 @@ def suppress_quepp_warnings():
         warnings.filterwarnings("ignore", message=r"QuEPP:.*shallow circuits")
         warnings.filterwarnings("ignore", message=r"QuEPP:.*signal destroyed")
         warnings.filterwarnings("ignore", message=r"QuEPP Monte Carlo:.*non-diagonal")
+        warnings.filterwarnings("ignore", message=r"QuEPP:.*zero diagonal Pauli paths")
         yield
 
 

--- a/tests/pipeline/stages/test_circuit_spec_stage.py
+++ b/tests/pipeline/stages/test_circuit_spec_stage.py
@@ -99,3 +99,28 @@ class TestCircuitSpecStageReduce:
         # are grouped under (("meas", 0),) as a list.
         assert (("meas", 0),) in reduced
         assert reduced[(("meas", 0),)] == [1.0, 2.0]
+
+
+class TestCircuitSpecStageIntrospect:
+    """Spec: ``introspect()`` reports gate counts plus depth and depth_2q
+    for the sample (first) DAG body — the same surface ``CircuitRunner``
+    exposes at runtime via ``depth_history``.
+    """
+
+    def test_depth_and_depth_2q_in_metadata(self, dummy_expval_backend):
+        # H, then CX, then H — three gates in three layers, exactly one is 2q.
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.h(0)
+        meta = MetaCircuit(circuit_bodies=(((), circuit_to_dag(qc)),))
+
+        stage = CircuitSpecStage()
+        env = PipelineEnv(backend=dummy_expval_backend)
+        batch, token = stage.expand(meta, env)
+
+        info = stage.introspect(batch, env, token)
+        assert info["depth"] == circuit_to_dag(qc).depth()
+        assert info["depth_2q"] == 1
+        assert info["n_1q_gates"] == 2
+        assert info["n_2q_gates"] == 1

--- a/tests/pipeline/stages/test_measurement_stage.py
+++ b/tests/pipeline/stages/test_measurement_stage.py
@@ -529,6 +529,71 @@ class TestMeasurementStageShotDistributionReducePath:
         assert list(reduced.values())[0] == pytest.approx([11.1])
 
 
+class TestMeasurementStageImagCoeffWarning:
+    """Spec: shot allocation drops imaginary parts and warns the user.
+
+    Regression: 4558ceb routed single-observable inputs through
+    ``flatten_observable_tuple`` (which strips imaginary parts via
+    ``np.real``) before ``_allocate_per_group_shots`` could check them,
+    silently bypassing this warning. The check now lives at
+    :class:`MeasurementStage`'s expand boundary so the user's original
+    coefficients are inspected before flattening.
+    """
+
+    @staticmethod
+    def _imag_obs_meta() -> MetaCircuit:
+        # Hermitian: 0.5j * (Z⊗X − X⊗Z). Coefficients are purely imaginary;
+        # ``flatten_observable_tuple`` would otherwise zero out the L1 norms.
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+        observable = SparsePauliOp.from_list([("ZX", 0.5j), ("XZ", -0.5j)])
+        return MetaCircuit(
+            circuit_bodies=(((), circuit_to_dag(qc)),),
+            observable=observable,
+        )
+
+    def test_warns_on_purely_imaginary_coefficients(self):
+        backend = DummySimulator(shots=1000)
+        env = PipelineEnv(backend=backend)
+        pipeline = CircuitPipeline(
+            stages=[
+                DummySpecStage(meta=self._imag_obs_meta()),
+                MeasurementStage(shot_distribution="weighted"),
+            ],
+        )
+        with pytest.warns(UserWarning, match=r"imaginary coefficients"):
+            pipeline.run_forward_pass(initial_spec="ignored", env=env)
+
+    def test_warns_without_shot_distribution(self):
+        # The pre-fix check lived inside ``_allocate_per_group_shots`` and
+        # only fired when ``shot_distribution`` was set.  The new helper
+        # runs unconditionally — verify it does so on the default pipeline.
+        backend = DummySimulator(shots=1000)
+        env = PipelineEnv(backend=backend)
+        pipeline = CircuitPipeline(
+            stages=[
+                DummySpecStage(meta=self._imag_obs_meta()),
+                MeasurementStage(),  # default shot_distribution=None
+            ],
+        )
+        with pytest.warns(UserWarning, match=r"imaginary coefficients"):
+            pipeline.run_forward_pass(initial_spec="ignored", env=env)
+
+    def test_no_warning_for_real_coefficients(self):
+        backend = DummySimulator(shots=1000)
+        env = PipelineEnv(backend=backend)
+        pipeline = CircuitPipeline(
+            stages=[
+                DummySpecStage(meta=_two_term_meta()),
+                MeasurementStage(shot_distribution="weighted"),
+            ],
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            pipeline.run_forward_pass(initial_spec="ignored", env=env)
+
+
 class TestMeasurementStageShotDistributionBackendExpval:
     """Spec: shot_distribution is incompatible with _backend_expval strategy."""
 

--- a/tests/pipeline/stages/test_measurement_stage.py
+++ b/tests/pipeline/stages/test_measurement_stage.py
@@ -865,3 +865,95 @@ class TestAllocatePerGroupShotsHelper:
         assert 2 not in shots
         assert dropped == {2: {0: 0.0}}
         assert surviving == [0, 1]
+
+
+# --------------------------------------------------------------------------- #
+# Multi-observable (tuple) MetaCircuit handling
+# --------------------------------------------------------------------------- #
+
+
+def _tuple_observable_meta() -> MetaCircuit:
+    """Two-qubit Bell circuit with a tuple of two QWC observables."""
+    qc = QuantumCircuit(2)
+    qc.h(0)
+    qc.cx(0, 1)
+    return MetaCircuit(
+        circuit_bodies=(((), circuit_to_dag(qc)),),
+        observable=(
+            SparsePauliOp.from_list([("IZ", 1.0)]),
+            SparsePauliOp.from_list([("ZZ", 1.0)]),
+        ),
+    )
+
+
+class TestMeasurementStageTupleObservable:
+    """When ``meta.observable`` is a tuple of SparsePauliOps the stage takes
+    the multi-observable union-grouping path and emits a list[float]."""
+
+    def test_tuple_observable_yields_list_of_floats(self):
+        from divi.backends import QiskitSimulator
+
+        backend = QiskitSimulator(shots=5000, _deterministic_execution=True)
+        env = PipelineEnv(backend=backend)
+        pipeline = CircuitPipeline(
+            stages=[
+                DummySpecStage(meta=_tuple_observable_meta()),
+                MeasurementStage(),
+            ],
+        )
+        reduced = pipeline.run(initial_spec="ignored", env=env)
+        out = reduced[(("spec", "circ"),)]
+        assert isinstance(out, list)
+        assert len(out) == 2
+        # Bell state |00>+|11>: <Z(0)>=0, <Z(0)Z(1)>=1.
+        # IZ has Z on qubit 0 (qiskit little-endian); ZZ is Z on both qubits.
+        assert out[0] == pytest.approx(0.0, abs=0.05)
+        assert out[1] == pytest.approx(1.0, abs=0.05)
+
+    def test_tuple_observable_suppresses_backend_expval_auto_promotion(
+        self, dummy_expval_backend
+    ):
+        """An expval-supporting backend would normally upgrade qwc →
+        ``_backend_expval`` when every meta carries the same observable.
+        For tuple observables the backend can't evaluate them in one shot,
+        so the auto-promotion must be skipped (no ``ham_ops`` in artifacts)."""
+        env = PipelineEnv(backend=dummy_expval_backend)
+        pipeline = CircuitPipeline(
+            stages=[
+                DummySpecStage(meta=_tuple_observable_meta()),
+                MeasurementStage(),
+            ],
+        )
+        pipeline.run_forward_pass(initial_spec="ignored", env=env)
+        assert "ham_ops" not in env.artifacts
+
+    def test_explicit_backend_expval_strategy_falls_back_to_qwc(
+        self, dummy_expval_backend
+    ):
+        """User-explicit ``_backend_expval`` is incompatible with tuple metas;
+        the stage silently falls back to QWC instead of raising — the user's
+        intent (analytical) is honoured per-observable to the extent possible."""
+        env = PipelineEnv(backend=dummy_expval_backend)
+        pipeline = CircuitPipeline(
+            stages=[
+                DummySpecStage(meta=_tuple_observable_meta()),
+                MeasurementStage(grouping_strategy="_backend_expval"),
+            ],
+        )
+        # No ValueError, no ham_ops artifact (QWC path was taken).
+        pipeline.run_forward_pass(initial_spec="ignored", env=env)
+        assert "ham_ops" not in env.artifacts
+
+    def test_shot_distribution_with_tuple_raises(self):
+        """Adaptive per-group shot distribution requires a single observable
+        to weight by — must be rejected for tuple metas."""
+        backend = DummySimulator(shots=100)
+        env = PipelineEnv(backend=backend)
+        pipeline = CircuitPipeline(
+            stages=[
+                DummySpecStage(meta=_tuple_observable_meta()),
+                MeasurementStage(shot_distribution="uniform"),
+            ],
+        )
+        with pytest.raises(ValueError, match="multi-observable"):
+            pipeline.run_forward_pass(initial_spec="ignored", env=env)

--- a/tests/pipeline/stages/test_measurement_stage.py
+++ b/tests/pipeline/stages/test_measurement_stage.py
@@ -55,7 +55,7 @@ class TestMeasurementStage:
             initial_spec="ignored", env=dummy_pipeline_env, execute_fn=ones_execute_fn
         )
         assert len(reduced) == 1
-        assert list(reduced.values())[0] == pytest.approx(1.3)
+        assert list(reduced.values())[0] == pytest.approx([1.3])
 
 
 class TestMeasurementStageExpvalBackendReduce:
@@ -138,7 +138,7 @@ class TestMeasurementStageExpvalBackendReduce:
         assert len(reduced) == 1
         # With ones_execute_fn each obs group returns 1.0
         # Postprocessing applies coefficients: 0.9 * 1.0 + 0.4 * 1.0 = 1.3
-        assert list(reduced.values())[0] == pytest.approx(1.3)
+        assert list(reduced.values())[0] == pytest.approx([1.3])
 
 
 class TestMeasurementStageResultFormatOverride:
@@ -507,7 +507,7 @@ class TestMeasurementStageShotDistributionReducePath:
         # Surviving groups: 0 (coeff 10) and 1 (coeff 1) each return +1.0.
         # Dropped group 2 (coeff 0.1) contributes 0.
         # Final: 10*1 + 1*1 + 0.1*0 = 11.0
-        assert list(reduced.values())[0] == pytest.approx(11.0)
+        assert list(reduced.values())[0] == pytest.approx([11.0])
 
     def test_reduce_no_drops_works_normally(self):
 
@@ -526,7 +526,7 @@ class TestMeasurementStageShotDistributionReducePath:
             execute_fn=self._counts_returning_plus_one,
         )
         # All 3 terms contribute: 10 + 1 + 0.1 = 11.1
-        assert list(reduced.values())[0] == pytest.approx(11.1)
+        assert list(reduced.values())[0] == pytest.approx([11.1])
 
 
 class TestMeasurementStageShotDistributionBackendExpval:
@@ -816,7 +816,7 @@ class TestAllocatePerGroupShotsHelper:
 
         surviving, dropped, shots = _allocate_per_group_shots(
             "spec_x",
-            meta.observable,
+            meta.observable[0],
             groups,
             partition,
             env,
@@ -835,7 +835,7 @@ class TestAllocatePerGroupShotsHelper:
 
         surviving, dropped, shots = _allocate_per_group_shots(
             "spec_x",
-            meta.observable,
+            meta.observable[0],
             groups,
             partition,
             env,
@@ -856,7 +856,7 @@ class TestAllocatePerGroupShotsHelper:
             warnings.simplefilter("ignore")
             surviving, dropped, shots = _allocate_per_group_shots(
                 "spec_x",
-                meta.observable,
+                meta.observable[0],
                 groups,
                 partition,
                 env,
@@ -890,11 +890,8 @@ class TestMeasurementStageTupleObservable:
     """When ``meta.observable`` is a tuple of SparsePauliOps the stage takes
     the multi-observable union-grouping path and emits a list[float]."""
 
-    def test_tuple_observable_yields_list_of_floats(self):
-        from divi.backends import QiskitSimulator
-
-        backend = QiskitSimulator(shots=5000, _deterministic_execution=True)
-        env = PipelineEnv(backend=backend)
+    def test_tuple_observable_yields_list_of_floats(self, default_test_simulator):
+        env = PipelineEnv(backend=default_test_simulator)
         pipeline = CircuitPipeline(
             stages=[
                 DummySpecStage(meta=_tuple_observable_meta()),
@@ -927,12 +924,11 @@ class TestMeasurementStageTupleObservable:
         pipeline.run_forward_pass(initial_spec="ignored", env=env)
         assert "ham_ops" not in env.artifacts
 
-    def test_explicit_backend_expval_strategy_falls_back_to_qwc(
+    def test_explicit_backend_expval_strategy_raises_for_multi(
         self, dummy_expval_backend
     ):
-        """User-explicit ``_backend_expval`` is incompatible with tuple metas;
-        the stage silently falls back to QWC instead of raising — the user's
-        intent (analytical) is honoured per-observable to the extent possible."""
+        """``_backend_expval`` requires a single observable per MetaCircuit;
+        a multi-observable tuple raises ``NotImplementedError``."""
         env = PipelineEnv(backend=dummy_expval_backend)
         pipeline = CircuitPipeline(
             stages=[
@@ -940,13 +936,12 @@ class TestMeasurementStageTupleObservable:
                 MeasurementStage(grouping_strategy="_backend_expval"),
             ],
         )
-        # No ValueError, no ham_ops artifact (QWC path was taken).
-        pipeline.run_forward_pass(initial_spec="ignored", env=env)
-        assert "ham_ops" not in env.artifacts
+        with pytest.raises(NotImplementedError, match="_backend_expval"):
+            pipeline.run_forward_pass(initial_spec="ignored", env=env)
 
-    def test_shot_distribution_with_tuple_raises(self):
-        """Adaptive per-group shot distribution requires a single observable
-        to weight by — must be rejected for tuple metas."""
+    def test_shot_distribution_with_tuple_works(self):
+        """Adaptive shot allocation operates on the union L1 norm and is
+        well-defined for any tuple length."""
         backend = DummySimulator(shots=100)
         env = PipelineEnv(backend=backend)
         pipeline = CircuitPipeline(
@@ -955,5 +950,63 @@ class TestMeasurementStageTupleObservable:
                 MeasurementStage(shot_distribution="uniform"),
             ],
         )
-        with pytest.raises(ValueError, match="multi-observable"):
-            pipeline.run_forward_pass(initial_spec="ignored", env=env)
+        # No raise: the union has well-defined coefficients for shot weighting.
+        pipeline.run_forward_pass(initial_spec="ignored", env=env)
+        assert "per_group_shots" in env.artifacts
+
+    def test_shot_distribution_with_sign_canceling_observables(self):
+        """Sign-canceling observables must not zero out shot allocation on the
+        shared Pauli — the union uses absolute coefficients."""
+        qc = QuantumCircuit(1)
+        qc.h(0)
+        meta = MetaCircuit(
+            circuit_bodies=(((), circuit_to_dag(qc)),),
+            observable=(
+                SparsePauliOp.from_list([("Z", 1.0)]),
+                SparsePauliOp.from_list([("Z", -1.0)]),
+            ),
+        )
+        backend = DummySimulator(shots=200)
+        env = PipelineEnv(backend=backend)
+        pipeline = CircuitPipeline(
+            stages=[
+                DummySpecStage(meta=meta),
+                MeasurementStage(shot_distribution="weighted"),
+            ],
+        )
+        pipeline.run_forward_pass(initial_spec="ignored", env=env)
+        per_group_shots = env.artifacts["per_group_shots"]
+        spec_key = (("spec", "circ"),)
+        shots = per_group_shots[spec_key]
+        assert all(
+            n > 0 for n in shots.values()
+        ), f"sign-canceling observables zeroed out shot allocation: {shots}"
+
+    def test_sign_canceling_observables_full_reduce_preserves_signs(
+        self, default_test_simulator
+    ):
+        """End-to-end reduce: ``+Z`` and ``-Z`` share one measurement group
+        and must come back as ``[+v, -v]`` — not ``[+v, +v]`` or ``[0, 0]``."""
+        qc = QuantumCircuit(1)
+        qc.h(0)
+        meta = MetaCircuit(
+            circuit_bodies=(((), circuit_to_dag(qc)),),
+            observable=(
+                SparsePauliOp.from_list([("Z", 1.0)]),
+                SparsePauliOp.from_list([("Z", -1.0)]),
+            ),
+        )
+        env = PipelineEnv(backend=default_test_simulator)
+        pipeline = CircuitPipeline(
+            stages=[
+                DummySpecStage(meta=meta),
+                MeasurementStage(shot_distribution="weighted"),
+            ],
+        )
+        reduced = pipeline.run(initial_spec="ignored", env=env)
+        out = reduced[(("spec", "circ"),)]
+        assert isinstance(out, list)
+        assert len(out) == 2
+        # H|0> gives <Z> = 0 in expectation; with finite shots there's noise.
+        # The key invariant: out[1] == -out[0] regardless of the measured value.
+        assert out[1] == pytest.approx(-out[0], abs=1e-9)

--- a/tests/pipeline/stages/test_pce_cost_stage.py
+++ b/tests/pipeline/stages/test_pce_cost_stage.py
@@ -163,7 +163,10 @@ class TestReduceHistogram:
         )
 
         assert len(result) == 1
-        assert isinstance(list(result.values())[0], float)
+        value = list(result.values())[0]
+        assert isinstance(value, list)
+        assert len(value) == 1
+        assert isinstance(value[0], float)
 
     def test_different_histograms_produce_different_energies(self):
         """Different shot distributions yield different energies."""
@@ -182,7 +185,9 @@ class TestReduceHistogram:
             token=None,
         )
 
-        assert list(result_a.values())[0] != pytest.approx(list(result_b.values())[0])
+        assert list(result_a.values())[0][0] != pytest.approx(
+            list(result_b.values())[0][0]
+        )
 
 
 class TestReducePathRouting:
@@ -199,10 +204,10 @@ class TestReducePathRouting:
 
         soft_energy = list(
             soft_stage.reduce({_meas_key(0): histogram}, env, token=None).values()
-        )[0]
+        )[0][0]
         hard_energy = list(
             hard_stage.reduce({_meas_key(0): histogram}, env, token=None).values()
-        )[0]
+        )[0][0]
 
         assert soft_energy != pytest.approx(hard_energy)
 
@@ -222,7 +227,7 @@ class TestReducePathRouting:
 
         x = 0.5 * (1.0 + np.tanh(1.0))  # ≈ 0.8808
         expected = 1.0 * x**2 + 2.0 * x**2  # 3 * x²
-        assert list(result.values())[0] == pytest.approx(expected)
+        assert list(result.values())[0][0] == pytest.approx(expected)
 
     def test_deterministic_histogram_hard_cvar_energy(self):
         """All shots in one bitstring → known CVaR energy.
@@ -237,7 +242,7 @@ class TestReducePathRouting:
 
         result = stage.reduce({_meas_key(0): {"11": 100}}, env, token=None)
 
-        assert list(result.values())[0] == pytest.approx(0.0)
+        assert list(result.values())[0][0] == pytest.approx(0.0)
 
     def test_hard_cvar_selects_low_energy_tail(self):
         """CVaR with alpha_cvar=0.5 selects the lower-energy half of shots.
@@ -256,7 +261,7 @@ class TestReducePathRouting:
 
         result = stage.reduce({_meas_key(0): {"11": 50, "00": 50}}, env, token=None)
 
-        assert list(result.values())[0] == pytest.approx(0.0)
+        assert list(result.values())[0][0] == pytest.approx(0.0)
 
 
 # ---------------------------------------------------------------------------
@@ -281,6 +286,6 @@ class TestReduceMultiParamSet:
         reduced = stage.reduce(results, env, token=None)
 
         assert len(reduced) == 2
-        energies = list(reduced.values())
+        energies = [v[0] for v in reduced.values()]
         # Different histograms must yield different energies
         assert energies[0] != pytest.approx(energies[1])

--- a/tests/pipeline/stages/test_pennylane_spec_stage.py
+++ b/tests/pipeline/stages/test_pennylane_spec_stage.py
@@ -324,4 +324,4 @@ class TestPennyLaneSpecStagePipeline:
 
         # RX(0) RZ(0) |0> = |0>, so <Z> ≈ 1.0
         expval = next(iter(result.values()))
-        assert expval == pytest.approx(1.0, abs=0.05)
+        assert expval == pytest.approx([1.0], abs=0.05)

--- a/tests/pipeline/stages/test_qem_stage.py
+++ b/tests/pipeline/stages/test_qem_stage.py
@@ -43,8 +43,16 @@ class _DummyQEMProtocol(QEMProtocol):
     ) -> tuple[tuple[DAGCircuit, ...], QEMContext]:
         return (dag,), QEMContext()
 
-    def reduce(self, quantum_results: Sequence[float], context: QEMContext) -> float:
-        return float(sum(quantum_results))
+    def reduce(
+        self, quantum_results: Sequence[Any], context: QEMContext
+    ) -> list[float]:
+        if not quantum_results:
+            return []
+        sample = quantum_results[0]
+        if isinstance(sample, (list, tuple)):
+            n_obs = len(sample)
+            return [float(sum(row[i] for row in quantum_results)) for i in range(n_obs)]
+        return [float(sum(quantum_results))]
 
 
 @pytest.fixture
@@ -105,7 +113,7 @@ class TestQEMStage:
             execute_fn=ones_execute_fn,
         )
         assert len(reduced) == 1
-        assert list(reduced.values())[0] == pytest.approx(3.9)
+        assert list(reduced.values())[0] == pytest.approx([3.9])
 
     def test_reduce_handles_multi_obs_expval_dicts(self, dummy_pipeline_env):
         """QEM reduce applies postprocessing per observable when values are {int: float} dicts."""
@@ -150,7 +158,7 @@ class TestQEMStage:
         assert len(reduced) == 1
         key = (("spec", "circ"), ("obs_group", 0))
         assert key in reduced
-        assert reduced[key] == {0: pytest.approx(6.0), 1: pytest.approx(33.0)}
+        assert reduced[key] == {0: pytest.approx([6.0]), 1: pytest.approx([33.0])}
 
     def test_reduce_binds_symbolic_weights_from_param_set_foreign_key(
         self, dummy_pipeline_env
@@ -160,8 +168,13 @@ class TestQEMStage:
         base_key = (("spec", "circ"),)
         contexts = {
             base_key: {
-                "classical_values": np.array([1.0, 0.0]),
-                "weights": np.array([theta.cos(), theta.sin()], dtype=object),
+                "per_obs": [
+                    {
+                        "classical_values": np.array([1.0, 0.0]),
+                        "weights": np.array([theta.cos(), theta.sin()], dtype=object),
+                        "dag_indices": [0, 1, 2],
+                    }
+                ],
                 "symbolic": True,
                 "weight_symbols": [theta],
                 "target_idx": 0,
@@ -181,10 +194,11 @@ class TestQEMStage:
 
         reduced = stage.reduce(results, env, token=contexts)
 
-        assert reduced[base_key] == pytest.approx(0.5)
+        assert reduced[base_key] == pytest.approx([0.5])
         assert contexts[base_key]["symbolic"] is False
-        assert contexts[base_key]["weights"][0] == pytest.approx(1.0)
-        assert contexts[base_key]["weights"][1] == pytest.approx(0.0)
+        bound_weights = contexts[base_key]["per_obs"][0]["weights"]
+        assert bound_weights[0] == pytest.approx(1.0)
+        assert bound_weights[1] == pytest.approx(0.0)
 
 
 class TestPipelineOutputMetaCircuitWithQEM:
@@ -303,7 +317,7 @@ class TestQuEPPLocalEffectiveness:
                 env=dummy_pipeline_env,
                 execute_fn=noisy_execute_fn,
             ).values()
-        )[0]
+        )[0][0]
 
         def build_quepp_execute_fn(with_twirls: bool):
             def execute_fn(trace, env):
@@ -322,8 +336,10 @@ class TestQuEPPLocalEffectiveness:
                         out[branch_key] = noisy_target + twirl_jitter
                     else:
                         path_idx = int(qem_idx) - 1
+                        per_obs_entry = ctx["per_obs"][0]
                         out[branch_key] = (
-                            float(ctx["classical_values"][path_idx]) * noise_scale
+                            float(per_obs_entry["classical_values"][path_idx])
+                            * noise_scale
                             + twirl_jitter
                         )
                 return out
@@ -348,7 +364,7 @@ class TestQuEPPLocalEffectiveness:
                 env=dummy_pipeline_env,
                 execute_fn=build_quepp_execute_fn(with_twirls=False),
             ).values()
-        )[0]
+        )[0][0]
 
         twirl_pipeline = CircuitPipeline(
             stages=[
@@ -369,7 +385,7 @@ class TestQuEPPLocalEffectiveness:
                 env=dummy_pipeline_env,
                 execute_fn=build_quepp_execute_fn(with_twirls=True),
             ).values()
-        )[0]
+        )[0][0]
 
         assert np.isfinite(noisy_result)
         assert np.isfinite(quepp_result)

--- a/tests/pipeline/stages/test_trotter_spec_stage.py
+++ b/tests/pipeline/stages/test_trotter_spec_stage.py
@@ -100,6 +100,22 @@ class TestIntrospect:
         assert info["n_qubits"] == 1
         assert info["n_terms"] >= 1
 
+    def test_exact_trotterization_omits_n_samples(self, dummy_expval_backend):
+        # ExactTrotterization is deterministic — its n_samples is
+        # structurally always 1, so introspect drops the line. Other fields
+        # stay; only n_samples is filtered.
+        stage = TrotterSpecStage(
+            ExactTrotterization(), meta_circuit_factory=_meta_factory
+        )
+        env = PipelineEnv(backend=dummy_expval_backend)
+        batch, token = stage.expand(qp.Z(0), env)
+
+        info = stage.introspect(batch, env, token)
+        assert info["strategy"] == "ExactTrotterization"
+        assert "n_samples" not in info
+        assert info["n_qubits"] == 1
+        assert info["n_terms"] >= 1
+
 
 # ---------------------------------------------------------------------------
 # reduce

--- a/tests/pipeline/stages/test_trotter_spec_stage.py
+++ b/tests/pipeline/stages/test_trotter_spec_stage.py
@@ -126,7 +126,7 @@ class TestReduce:
 
         reduced = pipeline.run(initial_spec=qp.Z(0), env=env, execute_fn=_execute_fn)
         assert len(reduced) >= 1
-        assert any(v == pytest.approx(2.0) for v in reduced.values())
+        assert any(v == pytest.approx([2.0]) for v in reduced.values())
 
     def test_merges_histogram_results(self, dummy_expval_backend):
         """Dict (histogram) results from multiple ham samples are averaged."""

--- a/tests/pipeline/test_core.py
+++ b/tests/pipeline/test_core.py
@@ -13,6 +13,7 @@ from divi.exceptions import ExecutionCancelledError
 from divi.pipeline import (
     CircuitPipeline,
     PipelineEnv,
+    PipelineResult,
     PipelineTrace,
     format_pipeline_tree,
 )
@@ -195,7 +196,7 @@ class TestCircuitPipelineRunForwardPass:
         )
 
         assert len(reduced) == 1
-        assert list(reduced.values())[0] == pytest.approx(3.9)
+        assert list(reduced.values())[0] == pytest.approx([3.9])
 
     def test_force_forward_sweep_recomputes_even_with_cache(self, dummy_pipeline_env):
         pipeline = CircuitPipeline(stages=two_group_pipeline_stages())
@@ -334,7 +335,7 @@ def test_custom_execute_fn_returning_per_key_values_reduces_correctly(
         execute_fn=_execute_fn,
     )
     assert len(reduced) == 1
-    assert list(reduced.values())[0] == pytest.approx(7.8)
+    assert list(reduced.values())[0] == pytest.approx([7.8])
     assert next(iter(reduced)) == (("spec", "circ"),)
 
 
@@ -417,7 +418,10 @@ def test_run_with_default_execute_fn_and_shots_backend_auto_converts_counts(
     assert len(reduced) == 1
     key = next(iter(reduced))
     assert key == (("spec", "circ"),)
-    assert isinstance(reduced[key], (int, float))
+    value = reduced[key]
+    assert isinstance(value, list)
+    assert len(value) == 1
+    assert isinstance(value[0], (int, float))
 
 
 class TestWaitForAsyncResult:
@@ -550,3 +554,33 @@ class TestWaitForAsyncResult:
         _wait_for_async_result(mock_backend, execution_result, env)
 
         assert env.artifacts["run_time"] == 3.5
+
+
+class TestPipelineResultSqueeze:
+    """``.value`` squeezes a length-1 list only when ``_squeeze`` is True
+    (the pipeline disables it when any source MetaCircuit was built with
+    ``_was_multi_obs=True``)."""
+
+    def test_squeeze_unwraps_length_one_list_by_default(self):
+        result = PipelineResult({(): [0.42]})
+        assert result.value == 0.42
+
+    def test_squeeze_preserves_multi_element_list(self):
+        result = PipelineResult({(): [0.1, 0.2, 0.3]})
+        assert result.value == [0.1, 0.2, 0.3]
+
+    def test_squeeze_passes_dict_through_unchanged(self):
+        probs = {"00": 0.5, "11": 0.5}
+        result = PipelineResult({(): probs})
+        assert result.value == probs
+
+    def test_squeeze_disabled_preserves_length_one_list(self):
+        result = PipelineResult({(): [0.42]})
+        result._squeeze = False
+        assert result.value == [0.42]
+
+    def test_squeeze_disabled_does_not_affect_dicts(self):
+        probs = {"00": 1.0}
+        result = PipelineResult({(): probs})
+        result._squeeze = False
+        assert result.value == probs

--- a/tests/pipeline/test_dry_run.py
+++ b/tests/pipeline/test_dry_run.py
@@ -263,8 +263,9 @@ class TestAnalyticDryRun:
         # MeasurementStage surfaces the observable grouping outcome — ZZ
         # and XX don't QWC-commute, so each gets its own group.
         meas = by_name["MeasurementStage"]
-        assert meas.metadata["n_groups"] == len(meta.observable)
-        assert meas.metadata["n_terms"] == len(meta.observable)
+        n_terms = sum(len(o) for o in meta.observable)
+        assert meas.metadata["n_groups"] == n_terms
+        assert meas.metadata["n_terms"] == n_terms
         assert meas.factor == 1.0
 
     def test_env_artifacts_surface_on_dry_run_report(self, dummy_pipeline_env):

--- a/tests/pipeline/test_dry_run.py
+++ b/tests/pipeline/test_dry_run.py
@@ -21,6 +21,7 @@ from divi.circuits.qem import _NoMitigation
 from divi.circuits.quepp import QuEPP
 from divi.pipeline import CircuitPipeline, dry_run_pipeline, format_dry_run
 from divi.pipeline._compilation import _compile_batch
+from divi.pipeline._dry_run import _aggregate_circuit_stats, _two_qubit_depth
 from divi.pipeline.abc import (
     BundleStage,
     ChildResults,
@@ -234,7 +235,7 @@ class TestAnalyticDryRun:
                 # Pin shot_distribution so MeasurementStage stays on the
                 # qwc branch rather than auto-promoting to _backend_expval
                 # on the dummy expval backend — the qwc grouping is what
-                # we want to inspect for n_groups / n_terms.
+                # we want to inspect for n_groups / n_pauli_terms.
                 MeasurementStage(shot_distribution="weighted"),
             ]
         )
@@ -263,9 +264,9 @@ class TestAnalyticDryRun:
         # MeasurementStage surfaces the observable grouping outcome — ZZ
         # and XX don't QWC-commute, so each gets its own group.
         meas = by_name["MeasurementStage"]
-        n_terms = sum(len(o) for o in meta.observable)
-        assert meas.metadata["n_groups"] == n_terms
-        assert meas.metadata["n_terms"] == n_terms
+        n_pauli_terms = sum(len(o) for o in meta.observable)
+        assert meas.metadata["n_groups"] == n_pauli_terms
+        assert meas.metadata["n_pauli_terms"] == n_pauli_terms
         assert meas.factor == 1.0
 
     def test_env_artifacts_surface_on_dry_run_report(self, dummy_pipeline_env):
@@ -776,3 +777,102 @@ class TestDrySafetyFallback:
             pipeline.run_forward_pass(
                 "ignored", dummy_pipeline_env, force_forward_sweep=True, dry=True
             )
+
+
+class TestTwoQubitDepth:
+    """Spec: ``_two_qubit_depth`` returns the longest chain of 2q gates."""
+
+    def test_zero_when_no_two_qubit_gates(self):
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.x(1)
+        qc.s(0)
+        assert _two_qubit_depth(circuit_to_dag(qc)) == 0
+
+    def test_counts_chained_2q_via_shared_qubit(self):
+        # Three CXs all touching qubit 0 → chain of 3 (each follows the previous).
+        qc = QuantumCircuit(3)
+        qc.cx(0, 1)
+        qc.cx(0, 2)
+        qc.cx(0, 1)
+        assert _two_qubit_depth(circuit_to_dag(qc)) == 3
+
+    def test_independent_2q_gates_dont_chain(self):
+        # CX(0,1) and CX(2,3) share no qubits → each contributes a chain of 1.
+        qc = QuantumCircuit(4)
+        qc.cx(0, 1)
+        qc.cx(2, 3)
+        assert _two_qubit_depth(circuit_to_dag(qc)) == 1
+
+    def test_ignores_single_qubit_gates_between_2q(self):
+        # Single-qubit gates extend overall depth but not 2q-depth.
+        qc = QuantumCircuit(2)
+        qc.cx(0, 1)
+        qc.h(0)
+        qc.h(1)
+        qc.cx(0, 1)
+        # depth() includes the H layers; _two_qubit_depth only counts the CXs.
+        assert circuit_to_dag(qc).depth() > 2
+        assert _two_qubit_depth(circuit_to_dag(qc)) == 2
+
+
+class TestCircuitStatsAggregate:
+    """Spec: ``DryRunReport.circuit_stats`` aggregates depth/width over the
+    final batch's DAG bodies, mirroring ``CircuitRunner.depth_history`` semantics.
+    """
+
+    def test_constant_depth_yields_zero_std(self, dummy_pipeline_env):
+        # Single body, fanned out only by Pauli twirling → all variants share
+        # the same parametric structure, so depth/width stats are constant.
+        meta = _parametric_twirlable_meta()
+        dummy_pipeline_env.param_sets = np.asarray([[0.1, 0.2]])
+        pipeline = CircuitPipeline(
+            stages=[
+                DummySpecStage(meta=meta),
+                ParameterBindingStage(),
+                PauliTwirlStage(n_twirls=3, seed=0),
+                MeasurementStage(),
+            ]
+        )
+        trace = pipeline.run_forward_pass(
+            "ignored", dummy_pipeline_env, force_forward_sweep=True, dry=True
+        )
+        report = dry_run_pipeline("t", trace, pipeline.stages, dummy_pipeline_env)
+        stats = report.circuit_stats
+        assert stats, "circuit_stats should be populated when DAG bodies exist"
+        # Catch zeroing bugs: the parametric meta has gates, so mean_depth > 0.
+        assert stats["mean_depth"] > 0
+        assert stats["std_depth"] == 0.0
+        assert stats["min_depth"] == stats["max_depth"]
+        assert stats["min_width"] == stats["max_width"] == 2
+
+    def test_varying_depth_populates_range_stats(self):
+        # Two MetaCircuits with different depths exercise the spread branches
+        # of every stat (min/max/mean/std/2q_depth) — the constant case
+        # collapses all of them to the same number.
+        qc_shallow = QuantumCircuit(2)
+        qc_shallow.cx(0, 1)
+        qc_deep = QuantumCircuit(2)
+        qc_deep.cx(0, 1)
+        qc_deep.cx(0, 1)
+        batch = {
+            (("circuit", 0),): MetaCircuit(
+                circuit_bodies=(((), circuit_to_dag(qc_shallow)),)
+            ),
+            (("circuit", 1),): MetaCircuit(
+                circuit_bodies=(((), circuit_to_dag(qc_deep)),)
+            ),
+        }
+        stats = _aggregate_circuit_stats(batch)
+        assert stats["min_depth"] == 1
+        assert stats["max_depth"] == 2
+        assert stats["mean_depth"] == 1.5
+        assert stats["std_depth"] > 0
+        assert stats["mean_2q_depth"] == 1.5
+        # Width is constant at 2 across both circuits.
+        assert stats["min_width"] == stats["max_width"] == 2
+        assert stats["std_width"] == 0.0
+
+    def test_empty_dict_for_empty_batch(self):
+        # Aggregator returns {} when no MetaCircuits have DAG bodies to read.
+        assert _aggregate_circuit_stats({}) == {}

--- a/tests/pipeline/test_grouping.py
+++ b/tests/pipeline/test_grouping.py
@@ -12,6 +12,7 @@ from divi.pipeline._grouping import (
     _create_postprocessing_fn,
     _wire_grouping_from_labels,
     compute_measurement_groups,
+    compute_multi_observable_measurement_groups,
 )
 
 
@@ -111,6 +112,116 @@ class TestWireGroupingFromLabels:
         assert len(groups) == 2
         assert 0 in groups[0] and 1 in groups[0]
         assert 2 in groups[1]
+
+
+class TestComputeMultiObservableMeasurementGroups:
+    """Union-grouping for multiple observables sharing one shot batch."""
+
+    def test_empty_tuple_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            compute_multi_observable_measurement_groups((), "qwc", 2)
+
+    def test_backend_expval_strategy_rejected(self):
+        """``_backend_expval`` only knows how to evaluate one observable."""
+        obs = SparsePauliOp.from_list([("Z", 1.0)])
+        with pytest.raises(ValueError, match="_backend_expval"):
+            compute_multi_observable_measurement_groups(
+                (obs, obs), "_backend_expval", 1
+            )
+
+    def test_every_observable_empty_raises(self):
+        """An observable with zero Pauli terms can't be measured — guard
+        against silent passes from an all-empty union."""
+        from qiskit.quantum_info import PauliList
+
+        empty = SparsePauliOp(PauliList(["II"])[:0])
+        assert empty.size == 0
+        with pytest.raises(ValueError, match="every observable"):
+            compute_multi_observable_measurement_groups((empty,), "qwc", 2)
+
+    def test_postprocessing_returns_list_in_input_order(self):
+        """One float per input observable, in the order passed."""
+        obs1 = SparsePauliOp.from_list([("IZ", 1.0)])  # Z on qubit 0
+        obs2 = SparsePauliOp.from_list([("ZI", 1.0)])  # Z on qubit 1
+        groups, partition, postproc = compute_multi_observable_measurement_groups(
+            (obs1, obs2), "qwc", 2
+        )
+        # Both QWC-commute → single group, two terms.
+        assert len(groups) == 1
+        # Each measurement group entry returns one expval per partition slot.
+        out = postproc([{0: 0.7, 1: -0.4}])
+        assert isinstance(out, list)
+        assert len(out) == 2
+        assert out == pytest.approx([0.7, -0.4])
+
+    def test_coefficients_applied_per_observable(self):
+        """Postprocessing recovers each observable's full coeff·term sum."""
+        # obs1 = 2·Z(0) + 0.5·X(0)
+        obs1 = SparsePauliOp.from_list([("Z", 2.0), ("X", 0.5)])
+        # obs2 = -1·Z(0)
+        obs2 = SparsePauliOp.from_list([("Z", -1.0)])
+        groups, partition, postproc = compute_multi_observable_measurement_groups(
+            (obs1, obs2), "qwc", 1
+        )
+        # Z and X don't QWC-commute → 2 groups: {Z, Z}, {X}.
+        # Union order: obs1 contributes Z (idx 0), X (idx 1); obs2 contributes Z (idx 2).
+        # The Z's go in one group, the X in its own.
+        n_groups = len(groups)
+        assert n_groups == 2
+        # Build a synthetic per-group result:
+        # for the Z group, the original-index-to-position map is determined
+        # internally; we feed the values keyed by the position in each group.
+        # For determinism, run the same single-observable grouper on the union
+        # to discover positions, then drive postproc with consistent values.
+        union = SparsePauliOp.from_list([("Z", 1.0), ("X", 1.0), ("Z", 1.0)])
+        _, union_partition, _ = compute_measurement_groups(union, "qwc", 1)
+        # union_partition is a list of lists; for each group, position i maps
+        # to original term index union_partition[g][i].
+        # Build per-group dicts that put 1.0 for term Z and 0.0 for term X.
+        per_group_results = []
+        for g_idx, indices in enumerate(union_partition):
+            d = {}
+            for pos, orig_idx in enumerate(indices):
+                # term at orig_idx 0 or 2 → Z, value 1.0; term at orig_idx 1 → X, value 0.5.
+                d[pos] = 1.0 if orig_idx in (0, 2) else 0.5
+            per_group_results.append(d)
+        out = postproc(per_group_results)
+        # obs1 = 2·<Z> + 0.5·<X> = 2·1 + 0.5·0.5 = 2.25
+        # obs2 = -1·<Z> = -1.0
+        assert out[0] == pytest.approx(2.25)
+        assert out[1] == pytest.approx(-1.0)
+
+    def test_qwc_groups_shared_across_observables(self):
+        """When every observable's terms QWC-commute, exactly one group is emitted."""
+        obs1 = SparsePauliOp.from_list([("IZ", 1.0)])
+        obs2 = SparsePauliOp.from_list([("ZI", 1.0)])
+        obs3 = SparsePauliOp.from_list([("ZZ", 1.0)])
+        groups, _, _ = compute_multi_observable_measurement_groups(
+            (obs1, obs2, obs3), "qwc", 2
+        )
+        assert len(groups) == 1
+
+    def test_wires_strategy_supported(self):
+        """The 'wires' strategy works on the union without auto-promotion."""
+        obs1 = SparsePauliOp.from_list([("IZ", 0.5)])
+        obs2 = SparsePauliOp.from_list([("ZI", 1.0)])
+        groups, partition, postproc = compute_multi_observable_measurement_groups(
+            (obs1, obs2), "wires", 2
+        )
+        # Different active qubits → wire-disjoint → single wires group.
+        assert len(groups) == 1
+        out = postproc([{0: 0.4, 1: -0.2}])
+        assert out == pytest.approx([0.5 * 0.4, 1.0 * -0.2])
+
+    def test_wrong_grouped_result_count_raises(self):
+        obs1 = SparsePauliOp.from_list([("IZ", 1.0)])
+        obs2 = SparsePauliOp.from_list([("IX", 1.0)])  # non-QWC with Z on qubit 0
+        groups, _, postproc = compute_multi_observable_measurement_groups(
+            (obs1, obs2), "qwc", 2
+        )
+        assert len(groups) == 2
+        with pytest.raises(RuntimeError, match="Expected 2"):
+            postproc([0.5])  # only one group worth of values
 
 
 class TestPostprocessingFn:

--- a/tests/pipeline/test_grouping.py
+++ b/tests/pipeline/test_grouping.py
@@ -8,73 +8,203 @@ import pytest
 from qiskit.quantum_info import SparsePauliOp
 
 from divi.circuits import measurement_qasms_from_groups, qscript_to_meta
+from divi.circuits._core import flatten_observable_tuple
 from divi.pipeline._grouping import (
-    _create_postprocessing_fn,
     _wire_grouping_from_labels,
     compute_measurement_groups,
-    compute_multi_observable_measurement_groups,
 )
 
 
-class TestComputeMeasurementGroups:
-    """Tests for compute_measurement_groups (SparsePauliOp-native)."""
+def _wrap(obs: SparsePauliOp) -> tuple[SparsePauliOp, ...]:
+    """Wrap a single observable in the canonical 1-tuple form."""
+    return (obs,)
+
+
+class TestComputeMeasurementGroupsSingle:
+    """Single-observable cases (length-1 tuple)."""
 
     def test_single_term_wires(self):
         obs = SparsePauliOp.from_list([("Z", 1.0)])
-        groups, partition, postproc = compute_measurement_groups(obs, "wires", 1)
+        groups, partition, postproc = compute_measurement_groups(_wrap(obs), "wires", 1)
         assert len(groups) == 1
         assert len(groups[0]) == 1
         assert partition == [[0]]
-        assert postproc([0.5]) == pytest.approx(0.5)
+        assert postproc([0.5]) == pytest.approx([0.5])
 
     def test_single_term_qwc(self):
         obs = SparsePauliOp.from_list([("Z", 1.0)])
-        groups, partition, _ = compute_measurement_groups(obs, "qwc", 1)
+        groups, partition, _ = compute_measurement_groups(_wrap(obs), "qwc", 1)
         assert len(groups) == 1
         assert partition == [[0]]
 
     def test_single_term_default(self):
         obs = SparsePauliOp.from_list([("Z", 1.0)])
-        groups, partition, _ = compute_measurement_groups(obs, "default", 1)
+        groups, partition, _ = compute_measurement_groups(_wrap(obs), "default", 1)
         assert len(groups) == 1
         assert partition == [[0]]
 
     def test_single_term_backend_expval(self):
         obs = SparsePauliOp.from_list([("Z", 1.0)])
-        groups, partition, _ = compute_measurement_groups(obs, "_backend_expval", 1)
+        groups, partition, _ = compute_measurement_groups(
+            _wrap(obs), "_backend_expval", 1
+        )
         assert groups == ((),)
         assert partition == [[0]]
 
     def test_single_term_none_strategy(self):
         obs = SparsePauliOp.from_list([("Z", 1.0)])
-        groups, partition, _ = compute_measurement_groups(obs, None, 1)
+        groups, partition, _ = compute_measurement_groups(_wrap(obs), None, 1)
         assert len(groups) == 1
         assert partition == [[0]]
 
     def test_multi_term_postprocessing(self):
         obs = SparsePauliOp.from_list([("IZ", 0.5), ("ZI", 0.3)])
-        groups, partition, postproc = compute_measurement_groups(obs, None, 2)
+        groups, partition, postproc = compute_measurement_groups(_wrap(obs), None, 2)
         assert len(groups) == 2
         assert len(partition) == 2
-        energy = postproc([0.5, 0.3])
-        assert energy == pytest.approx(0.5 * 0.5 + 0.3 * 0.3)
+        out = postproc([0.5, 0.3])
+        assert out == pytest.approx([0.5 * 0.5 + 0.3 * 0.3])
 
     def test_qwc_groups_commuting_terms(self):
-        # ZI and IZ qubit-wise commute → same group.
         obs = SparsePauliOp.from_list([("IZ", 0.5), ("ZI", 0.3)])
-        groups, partition, _ = compute_measurement_groups(obs, "qwc", 2)
-        assert len(groups) == 1  # both in one QWC group
+        groups, _, _ = compute_measurement_groups(_wrap(obs), "qwc", 2)
+        assert len(groups) == 1
 
     def test_qwc_splits_non_commuting(self):
-        # ZI and XI don't qubit-wise commute on qubit 1.
         obs = SparsePauliOp.from_list([("IZ", 0.5), ("IX", 0.3)])
-        groups, _, _ = compute_measurement_groups(obs, "qwc", 2)
+        groups, _, _ = compute_measurement_groups(_wrap(obs), "qwc", 2)
         assert len(groups) == 2
 
     def test_unknown_strategy_raises(self):
         obs = SparsePauliOp.from_list([("Z", 1.0)])
         with pytest.raises(ValueError, match="Unknown grouping strategy"):
-            compute_measurement_groups(obs, "invalid_strategy", 1)
+            compute_measurement_groups(_wrap(obs), "invalid_strategy", 1)
+
+
+class TestComputeMeasurementGroupsMulti:
+    """Cross-observable grouping (length > 1 tuple)."""
+
+    def test_empty_tuple_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            compute_measurement_groups((), "qwc", 2)
+
+    def test_backend_expval_strategy_rejected_for_multi(self):
+        obs = SparsePauliOp.from_list([("Z", 1.0)])
+        with pytest.raises(ValueError, match="_backend_expval"):
+            compute_measurement_groups((obs, obs), "_backend_expval", 1)
+
+    def test_postprocessing_returns_list_in_input_order(self):
+        obs1 = SparsePauliOp.from_list([("IZ", 1.0)])
+        obs2 = SparsePauliOp.from_list([("ZI", 1.0)])
+        groups, partition, postproc = compute_measurement_groups((obs1, obs2), "qwc", 2)
+        assert len(groups) == 1
+        out = postproc([{0: 0.7, 1: -0.4}])
+        assert isinstance(out, list)
+        assert len(out) == 2
+        assert out == pytest.approx([0.7, -0.4])
+
+    def test_coefficients_applied_per_observable(self):
+        obs1 = SparsePauliOp.from_list([("Z", 2.0), ("X", 0.5)])
+        obs2 = SparsePauliOp.from_list([("Z", -1.0)])
+        groups, partition, postproc = compute_measurement_groups((obs1, obs2), "qwc", 1)
+        assert len(groups) == 2
+        slot_value: dict[int, float] = {}
+        for g_idx, indices in enumerate(partition):
+            for pos, slot in enumerate(indices):
+                slot_value[slot] = 1.0 if "Z" in groups[g_idx][pos] else 0.5
+        per_group_results = [
+            {pos: slot_value[slot] for pos, slot in enumerate(indices)}
+            for indices in partition
+        ]
+        out = postproc(per_group_results)
+        # obs1 = 2·<Z> + 0.5·<X> = 2 + 0.25 = 2.25
+        # obs2 = -1·<Z> = -1.0
+        assert out[0] == pytest.approx(2.25)
+        assert out[1] == pytest.approx(-1.0)
+
+    def test_duplicate_paulis_dedup_to_one_union_slot(self):
+        obs1 = SparsePauliOp.from_list([("IZ", 1.0)])
+        obs2 = SparsePauliOp.from_list([("IZ", 1.0)])
+        groups, partition, postproc = compute_measurement_groups((obs1, obs2), "qwc", 2)
+        assert len(groups) == 1
+        assert len(groups[0]) == 1
+        assert sum(len(p) for p in partition) == 1
+        out = postproc([{0: 0.4}])
+        assert out == pytest.approx([0.4, 0.4])
+
+    def test_within_observable_duplicates_collapse(self):
+        obs = SparsePauliOp.from_list([("Z", 0.5), ("Z", 0.25)])
+        groups, partition, postproc = compute_measurement_groups((obs,), "qwc", 1)
+        assert sum(len(p) for p in partition) == 1
+        out = postproc([{0: 0.8}])
+        assert out == pytest.approx([(0.5 + 0.25) * 0.8])
+
+    def test_qwc_groups_shared_across_observables(self):
+        obs1 = SparsePauliOp.from_list([("IZ", 1.0)])
+        obs2 = SparsePauliOp.from_list([("ZI", 1.0)])
+        obs3 = SparsePauliOp.from_list([("ZZ", 1.0)])
+        groups, _, _ = compute_measurement_groups((obs1, obs2, obs3), "qwc", 2)
+        assert len(groups) == 1
+
+    def test_wires_strategy_supported(self):
+        obs1 = SparsePauliOp.from_list([("IZ", 0.5)])
+        obs2 = SparsePauliOp.from_list([("ZI", 1.0)])
+        groups, _, postproc = compute_measurement_groups((obs1, obs2), "wires", 2)
+        assert len(groups) == 1
+        out = postproc([{0: 0.4, 1: -0.2}])
+        assert out == pytest.approx([0.5 * 0.4, 1.0 * -0.2])
+
+    def test_wrong_grouped_result_count_raises(self):
+        obs1 = SparsePauliOp.from_list([("IZ", 1.0)])
+        obs2 = SparsePauliOp.from_list([("IX", 1.0)])
+        groups, _, postproc = compute_measurement_groups((obs1, obs2), "qwc", 2)
+        assert len(groups) == 2
+        with pytest.raises(RuntimeError, match="Expected 2"):
+            postproc([0.5])
+
+    def test_sign_canceling_observables_preserve_per_obs_values(self):
+        obs1 = SparsePauliOp.from_list([("Z", 1.0)])
+        obs2 = SparsePauliOp.from_list([("Z", -1.0)])
+        union, _ = flatten_observable_tuple((obs1, obs2))
+        assert float(np.real(union.coeffs[0])) == pytest.approx(2.0)
+
+        _, _, postproc = compute_measurement_groups((obs1, obs2), "qwc", 1)
+        out = postproc([{0: 0.7}])
+        assert out == pytest.approx([0.7, -0.7])
+
+    def test_purely_imaginary_coeff_yields_zero_union_weight(self):
+        """A non-Hermitian observable with purely imaginary coefficients is
+        coerced to zero real part; the union slot weight is 0.0."""
+        obs = SparsePauliOp.from_list([("Y", 1j)])
+        union, _ = flatten_observable_tuple((obs,))
+        assert float(np.real(union.coeffs[0])) == pytest.approx(0.0)
+
+    def test_cross_obs_qwc_grouping_collapses_diagonal_observables_to_one_group(
+        self,
+    ):
+        """All-Z observables share a single basis — QWC must produce exactly
+        one measurement group across all observables AND the postprocessor
+        must reconstruct each observable's value from the shared shots."""
+        observables = [
+            SparsePauliOp.from_list([("ZIZI", 1.0), ("ZZII", 1.0)]),
+            SparsePauliOp.from_list([("IZIZ", 1.0), ("IIZZ", 1.0)]),
+            SparsePauliOp.from_list([("ZZZZ", 1.0), ("ZIIZ", 1.0)]),
+            SparsePauliOp.from_list([("IZZI", 1.0), ("ZZIZ", 1.0)]),
+            SparsePauliOp.from_list([("ZIZZ", 1.0), ("IZZZ", 1.0)]),
+        ]
+        groups, partition, postproc = compute_measurement_groups(
+            tuple(observables), "qwc", 4
+        )
+        assert len(groups) == 1
+        # All Pauli slots in the union assigned to the single group.
+        # Feed each slot value 1.0 through postproc; expected per-observable
+        # value is the sum of its coefficients (each 1.0, two terms each).
+        slot_values = {pos: 1.0 for pos in range(len(groups[0]))}
+        out = postproc([slot_values])
+        assert isinstance(out, list)
+        assert len(out) == len(observables)
+        for v in out:
+            assert v == pytest.approx(2.0)
 
 
 class TestMetaCircuitWithGrouping:
@@ -86,10 +216,7 @@ class TestMetaCircuitWithGrouping:
         meta = qscript_to_meta(circuit)
         n_qubits = meta.n_qubits
 
-        # Both "wires" with a probs observable (no SparsePauliOp) and
-        # explicit empty group should produce the same measure-all QASM.
         qasms_explicit = measurement_qasms_from_groups(((),), n_qubits)
-        # Empty group → just measure all qubits.
         assert len(qasms_explicit) == 1
         assert "measure" in qasms_explicit[0]
 
@@ -102,7 +229,7 @@ class TestWireGroupingFromLabels:
         assert groups[0] == [0, 1, 2]
 
     def test_overlapping_split(self):
-        labels = ["ZI", "ZI"]  # same qubit active
+        labels = ["ZI", "ZI"]
         groups = _wire_grouping_from_labels(labels)
         assert len(groups) == 2
 
@@ -112,168 +239,3 @@ class TestWireGroupingFromLabels:
         assert len(groups) == 2
         assert 0 in groups[0] and 1 in groups[0]
         assert 2 in groups[1]
-
-
-class TestComputeMultiObservableMeasurementGroups:
-    """Union-grouping for multiple observables sharing one shot batch."""
-
-    def test_empty_tuple_raises(self):
-        with pytest.raises(ValueError, match="empty"):
-            compute_multi_observable_measurement_groups((), "qwc", 2)
-
-    def test_backend_expval_strategy_rejected(self):
-        """``_backend_expval`` only knows how to evaluate one observable."""
-        obs = SparsePauliOp.from_list([("Z", 1.0)])
-        with pytest.raises(ValueError, match="_backend_expval"):
-            compute_multi_observable_measurement_groups(
-                (obs, obs), "_backend_expval", 1
-            )
-
-    def test_every_observable_empty_raises(self):
-        """An observable with zero Pauli terms can't be measured — guard
-        against silent passes from an all-empty union."""
-        from qiskit.quantum_info import PauliList
-
-        empty = SparsePauliOp(PauliList(["II"])[:0])
-        assert empty.size == 0
-        with pytest.raises(ValueError, match="every observable"):
-            compute_multi_observable_measurement_groups((empty,), "qwc", 2)
-
-    def test_postprocessing_returns_list_in_input_order(self):
-        """One float per input observable, in the order passed."""
-        obs1 = SparsePauliOp.from_list([("IZ", 1.0)])  # Z on qubit 0
-        obs2 = SparsePauliOp.from_list([("ZI", 1.0)])  # Z on qubit 1
-        groups, partition, postproc = compute_multi_observable_measurement_groups(
-            (obs1, obs2), "qwc", 2
-        )
-        # Both QWC-commute → single group, two terms.
-        assert len(groups) == 1
-        # Each measurement group entry returns one expval per partition slot.
-        out = postproc([{0: 0.7, 1: -0.4}])
-        assert isinstance(out, list)
-        assert len(out) == 2
-        assert out == pytest.approx([0.7, -0.4])
-
-    def test_coefficients_applied_per_observable(self):
-        """Postprocessing recovers each observable's full coeff·term sum.
-
-        Also exercises the cross-observable Z-dedup: only one Z slot exists
-        in the union even though both observables contribute one.
-        """
-        # obs1 = 2·Z(0) + 0.5·X(0)
-        obs1 = SparsePauliOp.from_list([("Z", 2.0), ("X", 0.5)])
-        # obs2 = -1·Z(0)
-        obs2 = SparsePauliOp.from_list([("Z", -1.0)])
-        groups, partition, postproc = compute_multi_observable_measurement_groups(
-            (obs1, obs2), "qwc", 1
-        )
-        # Z and X don't QWC-commute → 2 groups: {Z}, {X} (Z deduped).
-        n_groups = len(groups)
-        assert n_groups == 2
-        # Drive postproc using the function's own partition_indices so the
-        # test doesn't have to reproduce the dedup logic.  Each union slot
-        # gets a known value; postproc folds that through each obs's coeffs.
-        slot_value = {}  # union slot index -> <P> value
-        for g_idx, indices in enumerate(partition):
-            for pos, slot in enumerate(indices):
-                # Slot label determines value: Z → 1.0, X → 0.5.
-                # We don't know which slot is which without re-grouping, so
-                # rely on the group's basis: a 1-qubit group with a single
-                # diagonal Pauli yields one slot; map by group order.
-                slot_value[slot] = 1.0 if "Z" in groups[g_idx][pos] else 0.5
-        per_group_results = [
-            {pos: slot_value[slot] for pos, slot in enumerate(indices)}
-            for indices in partition
-        ]
-        out = postproc(per_group_results)
-        # obs1 = 2·<Z> + 0.5·<X> = 2·1 + 0.5·0.5 = 2.25
-        # obs2 = -1·<Z> = -1.0
-        assert out[0] == pytest.approx(2.25)
-        assert out[1] == pytest.approx(-1.0)
-
-    def test_duplicate_paulis_dedup_to_one_union_slot(self):
-        """Identical Paulis across observables share a single union slot
-        so postprocessing computes ``<P>`` once per unique Pauli."""
-        obs1 = SparsePauliOp.from_list([("IZ", 1.0)])
-        obs2 = SparsePauliOp.from_list([("IZ", 1.0)])  # same label
-        groups, partition, postproc = compute_multi_observable_measurement_groups(
-            (obs1, obs2), "qwc", 2
-        )
-        # One unique label → one group with one term — not two.
-        assert len(groups) == 1
-        assert len(groups[0]) == 1
-        assert sum(len(p) for p in partition) == 1
-        # Both observables read from the same single slot.
-        out = postproc([{0: 0.4}])
-        assert out == pytest.approx([0.4, 0.4])
-
-    def test_within_observable_duplicates_collapse(self):
-        """Repeated terms inside one observable also share a slot; their
-        coefficients accumulate via ``np.dot`` over the duplicated index."""
-        obs = SparsePauliOp.from_list([("Z", 0.5), ("Z", 0.25)])
-        groups, partition, postproc = compute_multi_observable_measurement_groups(
-            (obs,), "qwc", 1
-        )
-        assert sum(len(p) for p in partition) == 1
-        # 0.5·<Z> + 0.25·<Z> with <Z>=0.8 → (0.5+0.25)·0.8 = 0.6
-        out = postproc([{0: 0.8}])
-        assert out == pytest.approx([0.6])
-
-    def test_qwc_groups_shared_across_observables(self):
-        """When every observable's terms QWC-commute, exactly one group is emitted."""
-        obs1 = SparsePauliOp.from_list([("IZ", 1.0)])
-        obs2 = SparsePauliOp.from_list([("ZI", 1.0)])
-        obs3 = SparsePauliOp.from_list([("ZZ", 1.0)])
-        groups, _, _ = compute_multi_observable_measurement_groups(
-            (obs1, obs2, obs3), "qwc", 2
-        )
-        assert len(groups) == 1
-
-    def test_wires_strategy_supported(self):
-        """The 'wires' strategy works on the union without auto-promotion."""
-        obs1 = SparsePauliOp.from_list([("IZ", 0.5)])
-        obs2 = SparsePauliOp.from_list([("ZI", 1.0)])
-        groups, partition, postproc = compute_multi_observable_measurement_groups(
-            (obs1, obs2), "wires", 2
-        )
-        # Different active qubits → wire-disjoint → single wires group.
-        assert len(groups) == 1
-        out = postproc([{0: 0.4, 1: -0.2}])
-        assert out == pytest.approx([0.5 * 0.4, 1.0 * -0.2])
-
-    def test_wrong_grouped_result_count_raises(self):
-        obs1 = SparsePauliOp.from_list([("IZ", 1.0)])
-        obs2 = SparsePauliOp.from_list([("IX", 1.0)])  # non-QWC with Z on qubit 0
-        groups, _, postproc = compute_multi_observable_measurement_groups(
-            (obs1, obs2), "qwc", 2
-        )
-        assert len(groups) == 2
-        with pytest.raises(RuntimeError, match="Expected 2"):
-            postproc([0.5])  # only one group worth of values
-
-
-class TestPostprocessingFn:
-    def test_missing_indices_raises(self):
-        with pytest.raises(RuntimeError, match="Missing"):
-            _create_postprocessing_fn(
-                coefficients=np.array([1.0, 1.0, 1.0]),
-                partition_indices=[[0, 1]],
-                n_terms=3,
-            )
-
-    def test_wrong_group_count_raises(self):
-        fn = _create_postprocessing_fn(
-            coefficients=np.array([1.0, 1.0]),
-            partition_indices=[[0], [1]],
-            n_terms=2,
-        )
-        with pytest.raises(RuntimeError, match="Expected 2"):
-            fn([0.5])
-
-    def test_correct_dot_product(self):
-        fn = _create_postprocessing_fn(
-            coefficients=np.array([2.0, 3.0]),
-            partition_indices=[[0], [1]],
-            n_terms=2,
-        )
-        assert fn([0.5, -1.0]) == pytest.approx(-2.0)

--- a/tests/pipeline/test_grouping.py
+++ b/tests/pipeline/test_grouping.py
@@ -155,7 +155,11 @@ class TestComputeMultiObservableMeasurementGroups:
         assert out == pytest.approx([0.7, -0.4])
 
     def test_coefficients_applied_per_observable(self):
-        """Postprocessing recovers each observable's full coeff·term sum."""
+        """Postprocessing recovers each observable's full coeff·term sum.
+
+        Also exercises the cross-observable Z-dedup: only one Z slot exists
+        in the union even though both observables contribute one.
+        """
         # obs1 = 2·Z(0) + 0.5·X(0)
         obs1 = SparsePauliOp.from_list([("Z", 2.0), ("X", 0.5)])
         # obs2 = -1·Z(0)
@@ -163,33 +167,57 @@ class TestComputeMultiObservableMeasurementGroups:
         groups, partition, postproc = compute_multi_observable_measurement_groups(
             (obs1, obs2), "qwc", 1
         )
-        # Z and X don't QWC-commute → 2 groups: {Z, Z}, {X}.
-        # Union order: obs1 contributes Z (idx 0), X (idx 1); obs2 contributes Z (idx 2).
-        # The Z's go in one group, the X in its own.
+        # Z and X don't QWC-commute → 2 groups: {Z}, {X} (Z deduped).
         n_groups = len(groups)
         assert n_groups == 2
-        # Build a synthetic per-group result:
-        # for the Z group, the original-index-to-position map is determined
-        # internally; we feed the values keyed by the position in each group.
-        # For determinism, run the same single-observable grouper on the union
-        # to discover positions, then drive postproc with consistent values.
-        union = SparsePauliOp.from_list([("Z", 1.0), ("X", 1.0), ("Z", 1.0)])
-        _, union_partition, _ = compute_measurement_groups(union, "qwc", 1)
-        # union_partition is a list of lists; for each group, position i maps
-        # to original term index union_partition[g][i].
-        # Build per-group dicts that put 1.0 for term Z and 0.0 for term X.
-        per_group_results = []
-        for g_idx, indices in enumerate(union_partition):
-            d = {}
-            for pos, orig_idx in enumerate(indices):
-                # term at orig_idx 0 or 2 → Z, value 1.0; term at orig_idx 1 → X, value 0.5.
-                d[pos] = 1.0 if orig_idx in (0, 2) else 0.5
-            per_group_results.append(d)
+        # Drive postproc using the function's own partition_indices so the
+        # test doesn't have to reproduce the dedup logic.  Each union slot
+        # gets a known value; postproc folds that through each obs's coeffs.
+        slot_value = {}  # union slot index -> <P> value
+        for g_idx, indices in enumerate(partition):
+            for pos, slot in enumerate(indices):
+                # Slot label determines value: Z → 1.0, X → 0.5.
+                # We don't know which slot is which without re-grouping, so
+                # rely on the group's basis: a 1-qubit group with a single
+                # diagonal Pauli yields one slot; map by group order.
+                slot_value[slot] = 1.0 if "Z" in groups[g_idx][pos] else 0.5
+        per_group_results = [
+            {pos: slot_value[slot] for pos, slot in enumerate(indices)}
+            for indices in partition
+        ]
         out = postproc(per_group_results)
         # obs1 = 2·<Z> + 0.5·<X> = 2·1 + 0.5·0.5 = 2.25
         # obs2 = -1·<Z> = -1.0
         assert out[0] == pytest.approx(2.25)
         assert out[1] == pytest.approx(-1.0)
+
+    def test_duplicate_paulis_dedup_to_one_union_slot(self):
+        """Identical Paulis across observables share a single union slot
+        so postprocessing computes ``<P>`` once per unique Pauli."""
+        obs1 = SparsePauliOp.from_list([("IZ", 1.0)])
+        obs2 = SparsePauliOp.from_list([("IZ", 1.0)])  # same label
+        groups, partition, postproc = compute_multi_observable_measurement_groups(
+            (obs1, obs2), "qwc", 2
+        )
+        # One unique label → one group with one term — not two.
+        assert len(groups) == 1
+        assert len(groups[0]) == 1
+        assert sum(len(p) for p in partition) == 1
+        # Both observables read from the same single slot.
+        out = postproc([{0: 0.4}])
+        assert out == pytest.approx([0.4, 0.4])
+
+    def test_within_observable_duplicates_collapse(self):
+        """Repeated terms inside one observable also share a slot; their
+        coefficients accumulate via ``np.dot`` over the duplicated index."""
+        obs = SparsePauliOp.from_list([("Z", 0.5), ("Z", 0.25)])
+        groups, partition, postproc = compute_multi_observable_measurement_groups(
+            (obs,), "qwc", 1
+        )
+        assert sum(len(p) for p in partition) == 1
+        # 0.5·<Z> + 0.25·<Z> with <Z>=0.8 → (0.5+0.25)·0.8 = 0.6
+        out = postproc([{0: 0.8}])
+        assert out == pytest.approx([0.6])
 
     def test_qwc_groups_shared_across_observables(self):
         """When every observable's terms QWC-commute, exactly one group is emitted."""

--- a/tests/pipeline/test_ham_ops.py
+++ b/tests/pipeline/test_ham_ops.py
@@ -149,8 +149,8 @@ class TestHamOpsExpvalBackend:
         assert "ZI" in expval_spy.last_ham_ops
         assert "IZ" in expval_spy.last_ham_ops
 
-    def test_reduce_unpacks_pauli_dict_to_scalar(self, expval_spy):
-        """Pipeline with expval backend reduces {pauli: value} → scalar expval."""
+    def test_reduce_unpacks_pauli_dict_to_per_obs_list(self, expval_spy):
+        """Pipeline with expval backend reduces {pauli: value} → list[float]."""
         env = PipelineEnv(backend=expval_spy)
         pipeline = CircuitPipeline(
             stages=[
@@ -161,7 +161,9 @@ class TestHamOpsExpvalBackend:
         result = pipeline.run(initial_spec="x", env=env)
         assert len(result) == 1
         value = next(iter(result.values()))
-        assert isinstance(value, (int, float))
+        assert isinstance(value, list)
+        assert len(value) == 1
+        assert isinstance(value[0], (int, float))
 
     def test_ham_ops_not_set_for_shots_backend(self, shots_spy):
         """Shots backends don't populate env.artifacts['ham_ops']."""

--- a/tests/pipeline/test_shot_groups_wiring.py
+++ b/tests/pipeline/test_shot_groups_wiring.py
@@ -269,9 +269,9 @@ class TestQiskitSimulatorShotGroups:
         result = pipeline.run(initial_spec="ignored", env=env)
         assert len(result) == 1
         energy = list(result.values())[0]
-        # Energy is a real, finite scalar within the range of |c_i| sums (= 11.1).
-        assert isinstance(energy, float)
-        assert -11.2 <= energy <= 11.2
+        assert isinstance(energy, list) and len(energy) == 1
+        assert isinstance(energy[0], float)
+        assert -11.2 <= energy[0] <= 11.2
 
 
 class TestQiskitSimulatorShotGroupsValidation:

--- a/tests/pipeline/test_transformations.py
+++ b/tests/pipeline/test_transformations.py
@@ -67,6 +67,27 @@ class TestReduceMean:
         out = reduce_mean(grouped)
         assert out == {("a",): 2.0, ("b",): 15.0}
 
+    def test_averages_per_observable_lists_elementwise(self):
+        """When values are per-observable list[float] (multi-observable
+        MeasurementStage output), each observable's mean is preserved."""
+        grouped = {
+            ("a",): [[1.0, 5.0], [3.0, 7.0]],
+            ("b",): [[2.0, 4.0, -2.0], [4.0, 0.0, 2.0]],
+        }
+        out = reduce_mean(grouped)
+        assert out[("a",)] == pytest.approx([2.0, 6.0])
+        assert out[("b",)] == pytest.approx([3.0, 2.0, 0.0])
+
+    def test_mixed_keys_dispatch_independently(self):
+        """Per-key dispatch: scalar key averaged scalar-wise, list key elementwise."""
+        grouped = {
+            ("scalar",): [1.0, 3.0],
+            ("list",): [[1.0, 2.0], [3.0, 4.0]],
+        }
+        out = reduce_mean(grouped)
+        assert out[("scalar",)] == pytest.approx(2.0)
+        assert out[("list",)] == pytest.approx([2.0, 3.0])
+
 
 class TestReducePostprocessOrdered:
     def test_single_postprocess_fn(self):

--- a/tests/qprog/algorithms/test_time_evolution.py
+++ b/tests/qprog/algorithms/test_time_evolution.py
@@ -291,6 +291,145 @@ class TestTimeEvolutionMultiObservable:
         assert te_multi.results[1] == pytest.approx(te_solo_1.results, abs=0.1)
 
 
+class TestTimeEvolutionExpvalAccessor:
+    """``.expval()`` mirrors ``.results`` for both single- and multi-observable
+    runs and rejects only the probability-mode case."""
+
+    def test_expval_returns_scalar_for_single_observable(
+        self, two_qubit_hamiltonian, default_test_simulator
+    ):
+        te = TimeEvolution(
+            hamiltonian=two_qubit_hamiltonian,
+            time=0.5,
+            observable=qp.PauliZ(0),
+            backend=default_test_simulator,
+        )
+        te.run()
+        out = te.expval()
+        assert isinstance(out, float)
+        assert out == te.results
+
+    def test_expval_returns_list_for_multi_observable(
+        self, two_qubit_hamiltonian, default_test_simulator
+    ):
+        te = TimeEvolution(
+            hamiltonian=two_qubit_hamiltonian,
+            time=0.5,
+            observable=[qp.PauliZ(0), qp.PauliZ(1)],
+            backend=default_test_simulator,
+        )
+        te.run()
+        out = te.expval()
+        assert isinstance(out, list)
+        assert len(out) == 2
+        assert all(isinstance(v, float) for v in out)
+        assert out == te.results
+
+    def test_expval_rejects_probability_mode(
+        self, two_qubit_hamiltonian, default_test_simulator
+    ):
+        te = TimeEvolution(
+            hamiltonian=two_qubit_hamiltonian,
+            time=0.5,
+            backend=default_test_simulator,
+        )
+        te.run()
+        with pytest.raises(RuntimeError, match="probability mode"):
+            te.expval()
+
+    def test_expval_returns_list_via_expval_native_backend(
+        self, two_qubit_hamiltonian, dummy_expval_backend, mocker
+    ):
+        """Multi-obs expval() works through an expval-native backend, not just
+        shot-based simulators. Pins the contract for QoroService and Maestro
+        analytical paths."""
+
+        def _deterministic_submit(circuits, **kwargs):
+            ham_ops = kwargs.get("ham_ops", "")
+            ops = ham_ops.split(";") if ham_ops else []
+            payload = {op: 1.0 for op in ops}
+            return ExecutionResult(
+                results=[
+                    {"label": label, "results": payload.copy()}
+                    for label in circuits.keys()
+                ]
+            )
+
+        mocker.patch.object(
+            dummy_expval_backend,
+            "submit_circuits",
+            side_effect=_deterministic_submit,
+        )
+        te = TimeEvolution(
+            hamiltonian=two_qubit_hamiltonian,
+            time=0.5,
+            observable=[qp.PauliZ(0), qp.PauliZ(1)],
+            backend=dummy_expval_backend,
+        )
+        te.run()
+        out = te.expval()
+        assert isinstance(out, list)
+        assert len(out) == 2
+        assert all(isinstance(v, float) for v in out)
+
+    def test_expval_raises_before_run(
+        self, two_qubit_hamiltonian, default_test_simulator
+    ):
+        """``expval()`` before ``run()`` raises a clear runtime error."""
+        te = TimeEvolution(
+            hamiltonian=two_qubit_hamiltonian,
+            observable=qp.PauliZ(0),
+            backend=default_test_simulator,
+        )
+        with pytest.raises(RuntimeError):
+            te.expval()
+
+
+class TestTimeEvolutionSingleItemListPreserved:
+    """``observable=[O]`` (an explicit single-item list) opts the user
+    into the multi-observable API: results stay as a length-1 ``list``
+    rather than being squeezed to a scalar."""
+
+    def test_single_item_list_returns_length_one_list(
+        self, two_qubit_hamiltonian, default_test_simulator
+    ):
+        te = TimeEvolution(
+            hamiltonian=two_qubit_hamiltonian,
+            time=0.5,
+            observable=[qp.PauliZ(0)],
+            backend=default_test_simulator,
+        )
+        te.run()
+        assert isinstance(te.results, list)
+        assert len(te.results) == 1
+        assert isinstance(te.results[0], float)
+
+    def test_bare_observable_returns_scalar(
+        self, two_qubit_hamiltonian, default_test_simulator
+    ):
+        te = TimeEvolution(
+            hamiltonian=two_qubit_hamiltonian,
+            time=0.5,
+            observable=qp.PauliZ(0),
+            backend=default_test_simulator,
+        )
+        te.run()
+        assert isinstance(te.results, float)
+
+    def test_single_item_tuple_returns_length_one_list(
+        self, two_qubit_hamiltonian, default_test_simulator
+    ):
+        te = TimeEvolution(
+            hamiltonian=two_qubit_hamiltonian,
+            time=0.5,
+            observable=(qp.PauliZ(0),),
+            backend=default_test_simulator,
+        )
+        te.run()
+        assert isinstance(te.results, list)
+        assert len(te.results) == 1
+
+
 class TestTimeEvolutionQDrift:
     def test_qdrift_multi_sample_averages_probs(
         self, two_qubit_hamiltonian, default_test_simulator

--- a/tests/qprog/algorithms/test_time_evolution.py
+++ b/tests/qprog/algorithms/test_time_evolution.py
@@ -201,6 +201,96 @@ class TestTimeEvolutionObservable:
         assert te.results == pytest.approx(2.0)
 
 
+class TestTimeEvolutionMultiObservable:
+    """Multiple ``observable`` entries → results is a list[float] in input order."""
+
+    def test_list_observables_normalised_to_tuple(
+        self, two_qubit_hamiltonian, default_test_simulator
+    ):
+        """``observable=[...]`` is normalised to a tuple so downstream
+        ``isinstance(..., tuple)`` checks fire."""
+        te = TimeEvolution(
+            hamiltonian=two_qubit_hamiltonian,
+            time=0.5,
+            observable=[qp.PauliZ(0), qp.PauliZ(1)],
+            backend=default_test_simulator,
+        )
+        assert isinstance(te.observable, tuple)
+        assert len(te.observable) == 2
+
+    def test_tuple_observable_returns_list_of_floats(
+        self, two_qubit_hamiltonian, default_test_simulator
+    ):
+        te = TimeEvolution(
+            hamiltonian=two_qubit_hamiltonian,
+            time=0.5,
+            observable=(qp.PauliZ(0), qp.PauliZ(1)),
+            backend=default_test_simulator,
+        )
+        te.run()
+        assert isinstance(te.results, list)
+        assert len(te.results) == 2
+        for v in te.results:
+            assert isinstance(v, float)
+            assert -1.1 <= v <= 1.1
+
+    def test_single_observable_returns_float(
+        self, two_qubit_hamiltonian, default_test_simulator
+    ):
+        """Single (non-tuple) observable keeps the scalar result contract."""
+        te = TimeEvolution(
+            hamiltonian=two_qubit_hamiltonian,
+            time=0.5,
+            observable=qp.PauliZ(0),
+            backend=default_test_simulator,
+        )
+        te.run()
+        assert isinstance(te.results, float)
+
+    def test_none_observable_returns_probs_dict(
+        self, two_qubit_hamiltonian, default_test_simulator
+    ):
+        """No observable → probs dict (unchanged contract)."""
+        te = TimeEvolution(
+            hamiltonian=two_qubit_hamiltonian,
+            time=0.5,
+            backend=default_test_simulator,
+        )
+        te.run()
+        assert isinstance(te.results, dict)
+
+    def test_multi_observable_matches_per_observable_runs(
+        self, two_qubit_hamiltonian, default_test_simulator
+    ):
+        """For commuting observables on a noiseless backend, the multi
+        run produces (within shot noise) the same per-observable values
+        as one TimeEvolution per observable."""
+        common = dict(
+            hamiltonian=two_qubit_hamiltonian,
+            time=0.5,
+        )
+        te_multi = TimeEvolution(
+            **common,
+            observable=(qp.PauliZ(0), qp.PauliZ(1)),
+            backend=default_test_simulator,
+        )
+        te_multi.run()
+
+        te_solo_0 = TimeEvolution(
+            **common, observable=qp.PauliZ(0), backend=default_test_simulator
+        )
+        te_solo_0.run()
+        te_solo_1 = TimeEvolution(
+            **common, observable=qp.PauliZ(1), backend=default_test_simulator
+        )
+        te_solo_1.run()
+
+        # Loose tolerance: shot noise + any small numerical drift from QWC
+        # grouping vs single-observable measurement.
+        assert te_multi.results[0] == pytest.approx(te_solo_0.results, abs=0.1)
+        assert te_multi.results[1] == pytest.approx(te_solo_1.results, abs=0.1)
+
+
 class TestTimeEvolutionQDrift:
     def test_qdrift_multi_sample_averages_probs(
         self, two_qubit_hamiltonian, default_test_simulator

--- a/tests/qprog/test_ensemble.py
+++ b/tests/qprog/test_ensemble.py
@@ -1137,6 +1137,65 @@ class _ParameterizedEnsemble(ProgramEnsemble):
         return None
 
 
+class _SubmittingProgram(QuantumProgram):
+    """Test program whose ``run()`` actually submits circuits through its
+    backend — used to exercise the end-to-end ensemble → coordinator → flush
+    pipeline (so flush-size assertions reflect real backend calls)."""
+
+    def __init__(self, *, n_circuits: int = 1, backend, **kwargs):
+        super().__init__(backend=backend, **kwargs)
+        self.n_circuits = n_circuits
+        self._ran = False
+
+    def _build_pipelines(self) -> None:
+        pass
+
+    def has_results(self) -> bool:
+        return self._ran
+
+    _MINIMAL_QASM = 'OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[1];\ncreg c[1];\nh q[0];\nmeasure q[0] -> c[0];\n'
+
+    def run(self):
+        circuits = {f"c{i}": self._MINIMAL_QASM for i in range(self.n_circuits)}
+        self.backend.submit_circuits(circuits)
+        self._total_circuit_count = self.n_circuits
+        self._total_run_time = 0.0
+        self._ran = True
+        return self
+
+    def _generate_circuits(self, **kwargs):
+        return []
+
+    def _post_process_results(self, results):
+        pass
+
+
+class _SubmittingEnsemble(ProgramEnsemble):
+    """Ensemble of :class:`_SubmittingProgram` instances; sizes flush
+    integration tests."""
+
+    def __init__(self, backend, n_programs: int, n_circuits_per_program: int = 1):
+        super().__init__(backend)
+        self._n_programs = n_programs
+        self._n_circuits_per_program = n_circuits_per_program
+        self.max_iterations = 1
+
+    def create_programs(self):
+        super().create_programs()
+        self.programs = {
+            f"prog_{i}": _SubmittingProgram(
+                n_circuits=self._n_circuits_per_program,
+                backend=self.backend,
+                program_id=f"prog_{i}",
+            )
+            for i in range(self._n_programs)
+        }
+
+    def aggregate_results(self):
+        super().aggregate_results()
+        return None
+
+
 class TestExecutorSizing:
     """Three-tier executor sizing in :meth:`ProgramEnsemble.run`.
 
@@ -1177,16 +1236,107 @@ class TestExecutorSizing:
         spy.assert_called_once()
         assert spy.call_args.kwargs["max_workers"] >= (os.cpu_count() or 1) + 4
 
-    def test_max_batch_size_uses_bounded_pool(self, dummy_simulator, mocker):
-        """Opting into early-flush keeps the pool at cpu+4 regardless of program count."""
+    def test_max_batch_size_pool_aligns_with_batch(self, dummy_simulator, mocker):
+        """``max_batch_size`` sizes the pool to ``min(max_batch_size, n_programs)``
+        so the barrier predicate can fill the batch in one wave (instead of
+        firing prematurely at ``cpu+4``)."""
         spy = self._spy_executor(mocker)
         ensemble = _ParameterizedEnsemble(backend=dummy_simulator, n_programs=20)
         ensemble.create_programs()
         ensemble.run(blocking=True, batch_config=BatchConfig(max_batch_size=4))
 
         spy.assert_called_once()
-        # Bounded — does NOT scale with program count.
-        assert spy.call_args.kwargs["max_workers"] == (os.cpu_count() or 1) + 4
+        assert spy.call_args.kwargs["max_workers"] == 4
+
+    def test_max_batch_size_pool_capped_at_n_programs(self, dummy_simulator, mocker):
+        """When ``max_batch_size > len(programs)``, the pool falls back to
+        ``len(programs)`` — never spawn more threads than there is work for."""
+        spy = self._spy_executor(mocker)
+        ensemble = _ParameterizedEnsemble(backend=dummy_simulator, n_programs=8)
+        ensemble.create_programs()
+        ensemble.run(blocking=True, batch_config=BatchConfig(max_batch_size=512))
+
+        spy.assert_called_once()
+        assert spy.call_args.kwargs["max_workers"] == 8
+
+    def test_predicate1_flushes_align_with_max_batch_size(
+        self, dummy_simulator, mocker
+    ):
+        """End-to-end: with one circuit per program, the pool-fills predicate
+        (predicate1) fires at exactly ``max_batch_size`` — so each merged
+        backend call carries that many circuits and the flush count matches
+        ``ceil(n_programs / max_batch_size)``.  Regresses the bug where the
+        pool was capped at ``cpu+4`` and flushes fired prematurely."""
+        original = dummy_simulator.submit_circuits
+        merged_sizes: list[int] = []
+
+        def _spy(circuits, **kwargs):
+            merged_sizes.append(len(circuits))
+            return original(circuits, **kwargs)
+
+        mocker.patch.object(dummy_simulator, "submit_circuits", _spy)
+
+        ensemble = _SubmittingEnsemble(backend=dummy_simulator, n_programs=32)
+        ensemble.create_programs()
+        ensemble.run(blocking=True, batch_config=BatchConfig(max_batch_size=8))
+
+        assert sum(merged_sizes) == 32
+        assert all(size == 8 for size in merged_sizes), merged_sizes
+        assert len(merged_sizes) == 4
+
+    def test_predicate2_flush_can_exceed_max_batch_size(self, dummy_simulator, mocker):
+        """``max_batch_size`` is a flush-trigger, not a hard cap.  When
+        each program submits a multi-circuit batch in a single call,
+        the circuit-count predicate (predicate2) fires the moment a
+        program's submission carries pending past the threshold — and
+        the flush takes everything pending, which can exceed
+        ``max_batch_size``.
+
+        Concretely: pool = ``min(10, 8) = 8``, so up to 8 programs run in
+        parallel.  Each program submits 5 circuits in one call.  All 40
+        circuits flush.  The combined merged-call sizes must sum to 40,
+        and the trigger semantics permit (but do not require) any single
+        flush to exceed 10.
+        """
+        original = dummy_simulator.submit_circuits
+        merged_sizes: list[int] = []
+
+        def _spy(circuits, **kwargs):
+            merged_sizes.append(len(circuits))
+            return original(circuits, **kwargs)
+
+        mocker.patch.object(dummy_simulator, "submit_circuits", _spy)
+
+        ensemble = _SubmittingEnsemble(
+            backend=dummy_simulator, n_programs=8, n_circuits_per_program=5
+        )
+        ensemble.create_programs()
+        ensemble.run(blocking=True, batch_config=BatchConfig(max_batch_size=10))
+
+        # All 40 circuits must be flushed across some number of merged calls.
+        assert sum(merged_sizes) == 40
+        # Each program contributes a 5-circuit chunk atomically, so every
+        # flush should be a positive multiple of 5.
+        assert merged_sizes, "expected at least one flush"
+        assert all(size > 0 and size % 5 == 0 for size in merged_sizes), merged_sizes
+
+    def test_minus_one_with_max_batch_size_caps_at_batch_size(
+        self, dummy_simulator, mocker
+    ):
+        """``max_concurrent_programs=-1`` combined with ``max_batch_size`` caps
+        the pool at ``min(max_batch_size, len(programs))`` instead of spawning
+        one thread per program (which can exhaust OS thread limits on large
+        ensembles)."""
+        spy = self._spy_executor(mocker)
+        ensemble = _ParameterizedEnsemble(backend=dummy_simulator, n_programs=300)
+        ensemble.create_programs()
+        ensemble.run(
+            blocking=True,
+            batch_config=BatchConfig(max_concurrent_programs=-1, max_batch_size=64),
+        )
+
+        spy.assert_called_once()
+        assert spy.call_args.kwargs["max_workers"] == 64
 
     def test_off_mode_uses_default_pool(self, dummy_simulator, mocker):
         """``BatchMode.OFF`` has no barrier, so the cpu+4 default is sufficient."""

--- a/tests/qprog/test_variational_quantum_algorithm.py
+++ b/tests/qprog/test_variational_quantum_algorithm.py
@@ -245,8 +245,8 @@ class TestProgram:
             program._cost_pipeline,
             "run",
             return_value={
-                (("param_set", 1),): 2.0,
-                (("param_set", 0),): 1.0,
+                (("param_set", 1),): [2.0],
+                (("param_set", 0),): [1.0],
             },
         )
 

--- a/tutorials/time_evolution.py
+++ b/tutorials/time_evolution.py
@@ -8,7 +8,8 @@ Time evolution with Divi TimeEvolution.
 This tutorial demonstrates:
 1. Probability-mode simulation for a known analytic case.
 2. Expectation-value mode with a user-defined observable (compared to exact).
-3. QDrift multi-sample averaging for randomized Trotterization.
+3. Multi-observable mode: several expectation values from one evolution.
+4. QDrift multi-sample averaging for randomized Trotterization.
 """
 
 import math
@@ -39,6 +40,27 @@ def _print_observable_result(
     print(f"  Exact     ⟨Z₀⟩:  {exact:.6f}")
     print(f"  Error:            {abs(estimated - exact):.6f}")
     print(f"  Circuits executed: {circuit_count}")
+
+
+def _print_multi_observable_result(
+    labels: list[str],
+    estimated: list[float],
+    exact: list[float],
+    multi_circuit_count: int,
+    solo_circuit_count: int,
+) -> None:
+    title = "Example 3 — Multi-observable mode"
+    print(f"\n{title}")
+    print("-" * len(title))
+    for label, est, ex in zip(labels, estimated, exact):
+        print(
+            f"  {label:<8} estimated: {est:+.6f}   "
+            f"exact: {ex:+.6f}   error: {abs(est - ex):.6f}"
+        )
+    print(f"  Multi-observable run circuits: {multi_circuit_count}")
+    print(f"  Three solo runs would use:     {solo_circuit_count}")
+    saved = 1 - multi_circuit_count / solo_circuit_count
+    print(f"  Saved by sharing the evolution: {saved:.0%}")
 
 
 if __name__ == "__main__":
@@ -79,7 +101,44 @@ if __name__ == "__main__":
     exact_z = math.cos(math.sqrt(2) * t2) ** 2
     _print_observable_result(te_expval.expval(), exact_z, te_expval.total_circuit_count)
 
-    # ── Example 3: QDrift randomized Trotterization ──────────────────
+    # ── Example 3: Multi-observable from one evolution ───────────────
+    # H = X₀ + X₁ at t = π/2, |00⟩ → |11⟩ (Example 1's analytic case).
+    # Read three observables from the same evolved state:
+    #   ⟨Z₀⟩ = -1, ⟨Z₁⟩ = -1, ⟨Z₀Z₁⟩ = +1
+    # All three are diagonal in the Z basis and qubit-wise commute, so
+    # MeasurementStage groups them into a single shot batch — the cost
+    # is roughly that of measuring one observable, not three.
+    h3 = qp.PauliX(0) + qp.PauliX(1)
+    observables = [qp.PauliZ(0), qp.PauliZ(1), qp.PauliZ(0) @ qp.PauliZ(1)]
+    te_multi = TimeEvolution(
+        hamiltonian=h3,
+        time=math.pi / 2,
+        observable=observables,
+        backend=backend,
+    )
+    te_multi.run()
+
+    # Apples-to-apples baseline: measure each observable in its own run.
+    solo_circuit_count = 0
+    for obs in observables:
+        te_solo = TimeEvolution(
+            hamiltonian=h3,
+            time=math.pi / 2,
+            observable=obs,
+            backend=backend,
+        )
+        te_solo.run()
+        solo_circuit_count += te_solo.total_circuit_count
+
+    _print_multi_observable_result(
+        labels=["⟨Z₀⟩", "⟨Z₁⟩", "⟨Z₀Z₁⟩"],
+        estimated=te_multi.expval(),
+        exact=[-1.0, -1.0, +1.0],
+        multi_circuit_count=te_multi.total_circuit_count,
+        solo_circuit_count=solo_circuit_count,
+    )
+
+    # ── Example 4: QDrift randomized Trotterization ──────────────────
     # H = X₀ + 0.5·Z₀ + X₁, |00⟩, t = 1.0.
     # QDrift stochastically samples Hamiltonian terms each Trotter step.
     # Starting from |00⟩ the X terms rotate both qubits, producing a
@@ -101,6 +160,6 @@ if __name__ == "__main__":
     )
     te_qdrift.run()
     _print_sorted_probs(
-        "Example 3 — QDrift probability mode", te_qdrift.probabilities()
+        "Example 4 — QDrift probability mode", te_qdrift.probabilities()
     )
     print(f"  Circuits executed: {te_qdrift.total_circuit_count}")


### PR DESCRIPTION
## Summary

  This branch ships two features related to noisy simulation and error mitigation.
                                                                                                                                                                                                                                   
  ### 1. Maestro noisy simulation                                                                                                                                                                                                  
                                                                                                                                                                                                                                   
  `MaestroSimulator` now accepts `noise_model`, `noise_seed`, and                                                                                                                                                                  
  `noise_realizations`. When a noise model is set, sampling submissions
  dispatch to `maestro.noisy_execute` and expval submissions to either                                                                                                                                                             
  `maestro.noisy_estimate` (analytical, when `noise_realizations` is None                                                                                                                                                          
  or 0) or `maestro.noisy_estimate_montecarlo` (when realizations ≥ 1).                                                                                                                                                            
                                                                                                                                                                                                                                   
  Noise is held in a separate `noise_config` rather than folded into                                                                                                                                                               
  `MaestroConfig` because Maestro's C++ API decouples noise models from                                                                                                                                                            
  simulator config — one simulator can be reused across noise models, so                                                                                                                                                           
  forcing them into the frozen config object would be a regression.                                                                                                                                                                
                                                                                                                                                                                                                                   
  ### 2. Multi-observable processing in QEM                                                                                                                                                                               
                                                                                                                                                                                                                                   
  `MetaCircuit.observable` now accepts a `tuple[SparsePauliOp, ...]` for                                                                                                                                                           
  the multi-expval case. Stages branch on `isinstance(meta.observable,
  tuple)`:                                                                                                                                                                                                                         
                  
  - **`MeasurementStage`** groups the *union* of every observable's Pauli                                                                                                                                                          
    terms (new `compute_multi_observable_measurement_groups`), measures
    once, and returns a per-observable `list[float]`. `_backend_expval`                                                                                                                                                            
    auto-promotion is suppressed because Maestro evaluates one observable                                                                                                                                                          
    at a time; explicit `_backend_expval` silently falls back to QWC.                                                                                                                                                              
    Adaptive `shot_distribution` is rejected for tuple metas (no single                                                                                                                                                            
    observable to weight by).                                                                                                                                                                                                      
  - **`QEMProtocol.expand`/`reduce`** accept tuple observables and lists
    of contexts. Each context carries a `dag_indices` field so `reduce`                                                                                                                                                            
    can slice the merged DAG-axis results uniformly, regardless of mode.                                                                                                                                                           
    A reusable `_expand_per_observable_loop` helper does the naive                                                                                                                                                                 
    per-observable expansion for protocols that don't share work.                                                                                                                                                                  
  - **`QuEPP`** overrides the loop helper to share the target DAG (it's                                                                                                                                                            
    observable-independent) and dedupe path DAGs across observables that                                                                                                                                                           
    produce coincident `branches` tuples — matching the paper's per-obs                                                                                                                                                            
    path enumeration while exploiting the work that *can* be shared.                                                                                                                                                               
  - **`PauliTwirlStage`** and `transformations.reduce_mean` now average                                                                                                                                                            
    per-observable lists element-wise so multi-observable values pass                                                                                                                                                              
    through twirl-averaging and Hamiltonian-sample reduction unchanged.                                                                                                                                                            
  - **`TimeEvolution`** accepts `observable=[O1, O2, ...]`; results                                                                                                                                                                
    becomes a `list[float]` in input order.                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  ## Test plan                                                                                                                                                                                                                     
                  
  - [x] `tests/backends/test_maestro_simulator.py` — sampling/expval
    dispatch through `noisy_execute` / `noisy_estimate` /                                                                                                                                                                          
    `noisy_estimate_montecarlo`, default seed (42), realizations fallback                                                                                                                                                          
    to 1, measurements stripped only for expval.                                                                                                                                                                                   
  - [x] `tests/pipeline/test_grouping.py` — multi-observable union                                                                                                                                                                 
    grouping, per-observable coefficients, `_backend_expval` rejection.                                                                                                                                                            
  - [x] `tests/circuits/test_qem.py` — `_NoMitigation` and `ZNE`                                                                                                                                                                   
    multi-observable expand/reduce paths.                                                                                                                                                                                          
  - [x] `tests/circuits/test_quepp.py` — target-DAG sharing, path-DAG                                                                                                                                                              
    dedup, classical-value parity with independent runs, end-to-end QWC                                                                                                                                                            
    parity vs per-observable pipelines.                                                                                                                                                                                            
  - [x] `tests/circuits/test_conversions.py` — `qscript_to_meta` with                                                                                                                                                              
    multi-expval / mixed measurement rejection.                                                                                                                                                                                    
    grouping, per-observable coefficients, `_backend_expval` rejection.
  - [x] `tests/circuits/test_qem.py` — `_NoMitigation` and `ZNE`
    multi-observable expand/reduce paths.
  - [x] `tests/circuits/test_quepp.py` — target-DAG sharing, path-DAG
    dedup, classical-value parity with independent runs, end-to-end QWC
    parity vs per-observable pipelines.
  - [x] `tests/circuits/test_conversions.py` — `qscript_to_meta` with
    multi-expval / mixed measurement rejection.
  - [x] `tests/pipeline/test_transformations.py` &
    `tests/pipeline/stages/test_measurement_stage.py` — element-wise
    averaging and tuple-observable handling in MeasurementStage.
  - [x] `tests/qprog/algorithms/test_time_evolution.py` —
    `TimeEvolution(observable=[...])` returns `list[float]`; multi vs
    solo runs match within shot noise.