### PR TITLE
refactor(qprog): consolidate cancellation across single, pipeline, ensemble runs

### DIFF
--- a/divi/backends/_async_job_backend.py
+++ b/divi/backends/_async_job_backend.py
@@ -9,6 +9,7 @@ work to a remote scheduler and return a job handle, then expose polling,
 result-fetching, and cancellation against that handle.
 """
 
+import logging
 from collections.abc import Callable, Mapping
 from threading import Event
 from typing import Protocol, runtime_checkable
@@ -17,17 +18,48 @@ import requests
 
 from divi.backends import ExecutionResult
 
+logger = logging.getLogger(__name__)
+
 
 @runtime_checkable
 class AsyncJobBackend(Protocol):
-    """A backend whose ``submit_circuits`` returns a job handle to poll."""
+    """Backend that runs circuits as an asynchronous remote job.
+
+    Implementations submit work to a scheduler (cloud HPC, hardware queue,
+    etc.) and return an :class:`~divi.backends.ExecutionResult` carrying a
+    ``job_id`` rather than circuit results. Callers then poll for status via
+    :meth:`poll_job_status`, fetch outcomes with :meth:`get_job_results`,
+    and may :meth:`cancel_job` an in-flight handle.
+    """
 
     @property
-    def shots(self) -> int: ...
+    def shots(self) -> int:
+        """Number of measurement shots applied to sampling-mode circuits."""
+        ...
 
     def submit_circuits(
-        self, circuits: Mapping[str, str], **kwargs
-    ) -> ExecutionResult: ...
+        self,
+        circuits: Mapping[str, str],
+        *,
+        cancellation_event: Event | None = None,
+        **kwargs,
+    ) -> ExecutionResult:
+        """Submit a batch of QASM circuits and return a handle.
+
+        The returned :class:`~divi.backends.ExecutionResult` carries the
+        scheduler-side ``job_id`` but no circuit results; populate it via
+        :meth:`get_job_results` once polling reports a terminal status.
+
+        Args:
+            circuits: Mapping of unique label → OpenQASM source.
+            cancellation_event: When set, the implementation should refuse
+                to dispatch (or short-circuit dispatch) and raise
+                :class:`~divi.exceptions.ExecutionCancelledError`. The same
+                event is honoured by :meth:`poll_job_status` to interrupt
+                an in-flight polling loop.
+            **kwargs: Backend-specific options (``ham_ops``, ``shot_groups``, …).
+        """
+        ...
 
     def poll_job_status(
         self,
@@ -37,8 +69,67 @@ class AsyncJobBackend(Protocol):
         verbose: bool = True,
         progress_callback: Callable[[int, str], None] | None = None,
         cancellation_event: Event | None = None,
-    ): ...
+    ):
+        """Query the scheduler-side job state; optionally block until terminal.
 
-    def get_job_results(self, execution_result: ExecutionResult) -> ExecutionResult: ...
+        Args:
+            execution_result: Handle returned by :meth:`submit_circuits`.
+            loop_until_complete: If ``True``, poll until a terminal status
+                (``COMPLETED`` / ``FAILED`` / ``CANCELLED``); otherwise return
+                after a single query.
+            on_complete: Invoked with the final HTTP response when a terminal
+                status is reached.
+            verbose: When ``True``, log per-poll status. Disable when
+                rendering progress via ``progress_callback`` so user-facing
+                output isn't doubled.
+            progress_callback: Called as ``(poll_attempt, status_str)`` for
+                progress-bar updates.
+            cancellation_event: When set, the loop exits by raising
+                :class:`~divi.exceptions.ExecutionCancelledError`. In-flight
+                HTTP requests are not interrupted — cancellation latency is
+                bounded by the per-request timeout.
 
-    def cancel_job(self, execution_result: ExecutionResult) -> requests.Response: ...
+        Returns:
+            The most recent :class:`~divi.backends.JobStatus`.
+        """
+        ...
+
+    def get_job_results(self, execution_result: ExecutionResult) -> ExecutionResult:
+        """Fetch results for a completed job and return them populated.
+
+        Must only be called after :meth:`poll_job_status` reports a
+        ``COMPLETED`` :class:`~divi.backends.JobStatus`.
+        """
+        ...
+
+    def cancel_job(self, execution_result: ExecutionResult) -> requests.Response:
+        """Request cancellation of an in-flight job.
+
+        Must be idempotent: cancelling a job already in a terminal state is a
+        normal race outcome and should not raise (a 409 from the scheduler
+        is acceptable to either swallow or surface as a recognisable
+        exception that callers can ignore).
+        """
+        ...
+
+
+def _best_effort_cancel_job(backend, execution_result) -> None:
+    """Notify an async backend's scheduler that an in-flight job should stop.
+
+    No-op when ``backend`` is not an :class:`AsyncJobBackend` or when
+    ``execution_result`` lacks a ``job_id``. Swallows the predictable failure
+    modes (409 already-cancelled, network hiccups) at DEBUG so cancellation
+    cleanup never masks the user's original interrupt.
+    """
+    if not isinstance(backend, AsyncJobBackend):
+        return
+    if execution_result is None or getattr(execution_result, "job_id", None) is None:
+        return
+    try:
+        backend.cancel_job(execution_result)
+    except Exception:
+        logger.debug(
+            "Best-effort cancel_job failed for %s",
+            execution_result.job_id,
+            exc_info=True,
+        )

--- a/divi/backends/_circuit_runner.py
+++ b/divi/backends/_circuit_runner.py
@@ -4,6 +4,7 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
+from threading import Event
 
 import numpy as np
 
@@ -65,7 +66,13 @@ class CircuitRunner(ABC):
         """
 
     @abstractmethod
-    def submit_circuits(self, circuits: Mapping[str, str], **kwargs) -> ExecutionResult:
+    def submit_circuits(
+        self,
+        circuits: Mapping[str, str],
+        *,
+        cancellation_event: Event | None = None,
+        **kwargs,
+    ) -> ExecutionResult:
         """
         Submit quantum circuits for execution.
 
@@ -75,6 +82,10 @@ class CircuitRunner(ABC):
         Args:
             circuits (dict[str, str]): Dictionary mapping circuit labels to their
                 OpenQASM string representations.
+            cancellation_event: When set, the backend aborts the batch and
+                raises :class:`~divi.exceptions.ExecutionCancelledError`.
+                Sync backends honour it between items; async backends thread
+                it into their poll loop.
             **kwargs: Additional backend-specific parameters for circuit execution.
 
         Returns:

--- a/divi/backends/_maestro_simulator.py
+++ b/divi/backends/_maestro_simulator.py
@@ -6,11 +6,13 @@ import logging
 import os
 import re
 import weakref
-from collections.abc import Mapping
+from collections.abc import Callable, Iterable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, fields
-from threading import Lock
-from typing import TYPE_CHECKING
+from threading import Event, Lock
+from typing import TYPE_CHECKING, Any
+
+from divi.exceptions import ExecutionCancelledError
 
 if TYPE_CHECKING:
     # For type checkers, assume maestro is always available — runtime code
@@ -46,6 +48,39 @@ def _strip_id_gates(qasm: str) -> str:
     Since identity gates are no-ops, stripping them is safe.
     """
     return re.sub(r"id\s+q\[\d+\]\s*;\n?", "", qasm)
+
+
+def _run_with_cancellation(
+    executor: ThreadPoolExecutor,
+    fn: Callable[[Any], Any],
+    items: Iterable[Any],
+    cancellation_event: Event | None,
+) -> list:
+    """Run ``fn`` over ``items`` in order via ``executor`` with cancellation support.
+
+    When ``cancellation_event`` is set between completed items, ``Future.cancel()``
+    is called on every remaining future so unstarted ones never run — the
+    shared per-instance ThreadPoolExecutor doesn't keep draining orphan work
+    behind subsequent ``submit_circuits`` calls. Workers already in maestro's
+    native call cannot be interrupted.
+    """
+    if cancellation_event is None:
+        return list(executor.map(fn, items))
+    futures = [executor.submit(fn, item) for item in items]
+    out: list = []
+    for fut in futures:
+        if cancellation_event.is_set():
+            # Inline the cleanup so a worker exception (any type — including
+            # a hypothetical ExecutionCancelledError from a future Python
+            # callable) propagates from ``fut.result()`` below without being
+            # confused with our event-driven cancel.
+            for f in futures:
+                f.cancel()
+            raise ExecutionCancelledError(
+                "Maestro batch cancelled after partial completion"
+            )
+        out.append(fut.result())
+    return out
 
 
 def _strip_measurements(qasm: str) -> str:
@@ -342,7 +377,7 @@ class MaestroSimulator(CircuitRunner):
         """Maestro executes circuits synchronously."""
         return False
 
-    def set_seed(self, seed: int) -> None:  # noqa: ARG002 — CircuitRunner interface
+    def set_seed(self, seed: int) -> None:
         """No-op — maestro does not yet expose seeding from C++."""
 
     def _get_executor(self) -> ThreadPoolExecutor:
@@ -421,10 +456,12 @@ class MaestroSimulator(CircuitRunner):
     def submit_circuits(
         self,
         circuits: Mapping[str, str],
+        *,
         ham_ops: str | None = None,
         circuit_ham_map: list[list[int]] | None = None,
         shot_groups: list[list[int]] | None = None,
-        **kwargs,  # noqa: ARG002 — accepted for CircuitRunner interface compatibility
+        cancellation_event: Event | None = None,
+        **kwargs,
     ) -> ExecutionResult:
         """Submit quantum circuits for execution on the maestro simulator.
 
@@ -440,6 +477,9 @@ class MaestroSimulator(CircuitRunner):
                 mode only — ignored when ``ham_ops`` is provided because
                 maestro's ``simple_estimate`` computes expectation values
                 analytically.
+            cancellation_event: When set, aborts further dispatch and raises
+                :class:`~divi.exceptions.ExecutionCancelledError`. Workers
+                already in maestro's native call are not interrupted.
             **kwargs: Ignored — accepted so callers using the generic
                 :class:`~divi.backends.CircuitRunner` interface can forward
                 unrelated options without breaking.
@@ -447,6 +487,11 @@ class MaestroSimulator(CircuitRunner):
         Returns:
             ExecutionResult containing either counts (sampling) or expectation values.
         """
+        if cancellation_event is not None and cancellation_event.is_set():
+            raise ExecutionCancelledError(
+                "Maestro batch cancelled before any circuit was dispatched"
+            )
+
         if ham_ops is not None and shot_groups is not None:
             raise ValueError(
                 "shot_groups is incompatible with ham_ops: maestro's "
@@ -520,7 +565,9 @@ class MaestroSimulator(CircuitRunner):
                 (i, label, qasm)
                 for i, (label, qasm) in enumerate(zip(circuit_labels, qasm_strings))
             ]
-            results = list(executor.map(_run_sample, items))
+            results = _run_with_cancellation(
+                executor, _run_sample, items, cancellation_event
+            )
         else:
             # Expectation value mode — strip measurement gates so they don't
             # collapse the statevector before expectation values are computed.
@@ -570,6 +617,8 @@ class MaestroSimulator(CircuitRunner):
                 (i, label, qasm)
                 for i, (label, qasm) in enumerate(zip(circuit_labels, qasm_strings))
             ]
-            results = list(executor.map(_run_estimate, items))
+            results = _run_with_cancellation(
+                executor, _run_estimate, items, cancellation_event
+            )
 
         return ExecutionResult(results=results)

--- a/divi/backends/_qiskit_simulator.py
+++ b/divi/backends/_qiskit_simulator.py
@@ -10,6 +10,7 @@ import threading
 from collections.abc import Mapping, Sequence
 from functools import partial
 from multiprocessing import Pool, current_process
+from threading import Event
 from typing import Any, Literal
 from warnings import warn
 
@@ -31,6 +32,7 @@ from divi.backends._shot_allocation import (
     per_circuit,
     validate,
 )
+from divi.exceptions import ExecutionCancelledError
 
 logger = logging.getLogger(__name__)
 
@@ -445,9 +447,11 @@ class QiskitSimulator(CircuitRunner):
     def submit_circuits(
         self,
         circuits: Mapping[str, str],
+        *,
         ham_ops: str | None = None,
         circuit_ham_map: list[list[int]] | None = None,
         shot_groups: list[list[int]] | None = None,
+        cancellation_event: Event | None = None,
         **kwargs,
     ) -> ExecutionResult:
         """Submit multiple circuits for parallel simulation using Qiskit's built-in parallelism.
@@ -464,11 +468,16 @@ class QiskitSimulator(CircuitRunner):
                 provided, overrides ``self.shots`` for each contiguous range
                 and triggers one ``aer_simulator.run`` call per range.
                 Sampling-mode only — ignored when ``ham_ops`` is provided.
+            cancellation_event: When set before this call, aborts dispatch.
+                Aer's ``.run().result()`` cannot be interrupted mid-batch.
             **kwargs: Additional parameters (unused, accepted for interface compatibility).
 
         Returns:
             ExecutionResult containing either counts (sampling) or expectation values.
         """
+        if cancellation_event is not None and cancellation_event.is_set():
+            raise ExecutionCancelledError("Qiskit batch cancelled before dispatch")
+
         logger.debug(
             f"Simulating {len(circuits)} circuits with {self.n_processes} processes"
         )

--- a/divi/backends/_qoro_service.py
+++ b/divi/backends/_qoro_service.py
@@ -497,12 +497,14 @@ class QoroService(CircuitRunner):
     def submit_circuits(
         self,
         circuits: Mapping[str, str],
+        *,
         ham_ops: str | None = None,
         circuit_ham_map: list[list[int]] | None = None,
         shot_groups: list[list[int]] | None = None,
         job_type: JobType | None = None,
         override_execution_config: ExecutionConfig | None = None,
         override_job_config: JobConfig | None = None,
+        cancellation_event: Event | None = None,
         **kwargs,
     ) -> ExecutionResult:
         """
@@ -542,6 +544,10 @@ class QoroService(CircuitRunner):
             override_job_config (JobConfig | None, optional):
                 Configuration object to override the service's default settings.
                 If not provided, default values are used.
+            cancellation_event (Event | None, optional):
+                Accepted for :class:`~divi.backends.CircuitRunner` interface
+                parity; submission itself is unaffected. Pass the same Event
+                to :meth:`poll_job_status` to interrupt the polling loop.
             **kwargs:
                 Accepted to match the ``CircuitRunner.submit_circuits``
                 signature but not used by this backend. Any extra keyword

--- a/divi/pipeline/_core.py
+++ b/divi/pipeline/_core.py
@@ -3,15 +3,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import signal
+import threading
 import warnings
 from collections import Counter, defaultdict
 from collections.abc import Callable, Hashable, Sequence
+from contextlib import contextmanager
+from threading import Event
 from typing import Any
 
 from rich.console import Console
 from rich.tree import Tree
 
 from divi.backends import JobStatus
+from divi.backends._async_job_backend import _best_effort_cancel_job
 from divi.exceptions import ExecutionCancelledError
 
 from ._compilation import _collapse_to_parent_results, _compile_batch
@@ -126,24 +131,30 @@ def _wait_for_async_result(backend, execution_result, env):
                 float(r.json()["run_time"]) for r in response
             )
 
-    # Poll until complete
     status = backend.poll_job_status(
         execution_result,
         loop_until_complete=True,
         on_complete=_track_runtime,
         verbose=progress_callback is None,
         progress_callback=progress_callback,
+        cancellation_event=env.cancellation_event,
     )
 
     if status == JobStatus.FAILED:
         raise RuntimeError(f"Job {job_id} has failed")
 
     if status == JobStatus.CANCELLED:
-        # If cancellation was requested (e.g., by ProgramEnsemble), raise ExecutionCancelledError
-        # so it's handled gracefully. Otherwise, raise RuntimeError for unexpected cancellation.
-        if env.cancellation_event and env.cancellation_event.is_set():
+        # Distinguish a local cancel (our event was set → user/coordinator
+        # asked) from a scheduler-side cancel (eviction, quota, admin stop).
+        # The former is the graceful user-cancellation path; the latter is
+        # an unexpected interruption that the caller should not confuse with
+        # an intentional shutdown.
+        if env.cancellation_event is not None and env.cancellation_event.is_set():
             raise ExecutionCancelledError(f"Job {job_id} was cancelled")
-        raise RuntimeError(f"Job {job_id} was cancelled")
+        raise RuntimeError(
+            f"Job {job_id} was cancelled by the scheduler "
+            "(no local cancellation requested)"
+        )
 
     if status != JobStatus.COMPLETED:
         raise RuntimeError("Job has not completed yet, cannot post-process results")
@@ -221,13 +232,24 @@ def _default_execute_fn(
         if shot_groups is not None:
             submit_kwargs["shot_groups"] = shot_groups
 
-    result = env.backend.submit_circuits(circuits, **submit_kwargs)
+    if env.cancellation_event is not None and env.cancellation_event.is_set():
+        raise ExecutionCancelledError("Pipeline execution cancelled before dispatch")
+
+    result = env.backend.submit_circuits(
+        circuits, cancellation_event=env.cancellation_event, **submit_kwargs
+    )
 
     # Store for cancellation support (read by cancel_unfinished_job)
     env.artifacts["_current_execution_result"] = result
 
-    if result.is_async():
-        result = _wait_for_async_result(env.backend, result, env)
+    try:
+        if result.is_async():
+            result = _wait_for_async_result(env.backend, result, env)
+    except (ExecutionCancelledError, KeyboardInterrupt):
+        # KeyboardInterrupt covers hosts where our SIGINT funnel cannot install
+        # (Jupyter, embedded). Without it the cloud job is orphaned.
+        _best_effort_cancel_job(env.backend, result)
+        raise
 
     if result.results is None:
         raise RuntimeError("Backend returned no results")
@@ -235,6 +257,47 @@ def _default_execute_fn(
     raw_by_label = {r["label"]: r["results"] for r in result.results}
 
     return _collapse_to_parent_results(raw_by_label, lineage_by_label)
+
+
+@contextmanager
+def _sigint_to_event(event: Event):
+    """Funnel SIGINT into ``event``: first press sets the event, second
+    re-raises :class:`KeyboardInterrupt`. No-op outside the main thread
+    or when a non-default SIGINT handler is already installed."""
+    if threading.current_thread() is not threading.main_thread():
+        yield
+        return
+
+    existing = signal.getsignal(signal.SIGINT)
+    if existing not in (signal.default_int_handler, signal.SIG_DFL):
+        yield
+        return
+
+    press_count = 0
+
+    def _handler(signum, frame):
+        nonlocal press_count
+        press_count += 1
+        if press_count >= 2:
+            signal.signal(signal.SIGINT, existing)
+            raise KeyboardInterrupt
+        event.set()
+
+    signal.signal(signal.SIGINT, _handler)
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGINT, existing)
+
+
+@contextmanager
+def _sigint_to_cancellation(env: "PipelineEnv"):
+    """Pipeline-scoped wrapper around :func:`_sigint_to_event` that ensures
+    ``env.cancellation_event`` exists."""
+    if env.cancellation_event is None:
+        env.cancellation_event = Event()
+    with _sigint_to_event(env.cancellation_event):
+        yield
 
 
 def _has_custom_dry_expand(stage: Stage) -> bool:
@@ -407,7 +470,8 @@ class CircuitPipeline:
         # the spinner shows only execution/polling state from here on.
         _report_pipeline_stage(env, None)
 
-        raw = execute_fn(plan, env)
+        with _sigint_to_cancellation(env):
+            raw = execute_fn(plan, env)
 
         # Convert raw backend results into the canonical format declared
         # by the measurement stage during expand.  This runs *before* the

--- a/divi/qprog/ensemble.py
+++ b/divi/qprog/ensemble.py
@@ -15,8 +15,10 @@ from warnings import warn
 
 from rich.console import Console
 from rich.panel import Panel
+from rich.traceback import Traceback
 
 from divi.backends import CircuitRunner
+from divi.exceptions import ExecutionCancelledError
 
 # Direct import of ``BatchConfig``/``BatchMode`` from the defining module:
 # ``ensemble.py`` is itself loaded by ``divi.qprog.__init__`` to populate
@@ -691,10 +693,20 @@ class ProgramEnsemble(ABC):
                     except Exception:
                         exc = True  # defensive; treat as failed
                     if exc is not None:
+                        # Workers that raised ExecutionCancelledError were
+                        # cooperating with the user's cancel; everything
+                        # else is a real failure.
+                        if isinstance(exc, ExecutionCancelledError):
+                            status, message = (
+                                TerminalStatus.CANCELLED,
+                                "Cancelled by user",
+                            )
+                        else:
+                            status, message = failed_status, failed_message
                         self._emit_progress_message(
                             program.program_id,
-                            final_status=failed_status,
-                            message=failed_message,
+                            final_status=status,
+                            message=message,
                         )
                 continue
 
@@ -752,6 +764,52 @@ class ProgramEnsemble(ABC):
             running_status=TerminalStatus.ABORTED,
             running_message="Stopped after current iteration",
         )
+        self._report_failed_programs()
+
+    def _report_failed_programs(self) -> None:
+        """Render a Rich panel + traceback for any future that finished with
+        a non-cancellation exception.
+
+        Called from the cancellation path so users still see what crashed
+        — otherwise the failure detail disappears into the progress row.
+        Failures that happened before the cancel was requested still get
+        the same panel treatment the no-cancel failure path produces.
+        """
+        failures: list[tuple[QuantumProgram, BaseException]] = []
+        for future, program in self._future_to_program.items():
+            if not future.done() or future.cancelled():
+                continue
+            try:
+                exc = future.exception()
+            except Exception:
+                continue
+            if exc is None or isinstance(exc, ExecutionCancelledError):
+                continue
+            failures.append((program, exc))
+
+        if not failures:
+            return
+
+        console = (
+            self._progress_bar.console
+            if self._progress_bar is not None
+            else Console(stderr=True)
+        )
+        for program, exc in failures:
+            label = (
+                f" (Program {program.program_id})"
+                if program.program_id is not None
+                else ""
+            )
+            console.print(
+                Panel(
+                    f"[bold]{type(exc).__name__}[/bold]: {exc}",
+                    title=f"[bold red]Program Failure{label}[/bold red]",
+                    subtitle="[dim]Traceback follows[/dim]",
+                    border_style="red",
+                )
+            )
+            console.print(Traceback.from_exception(type(exc), exc, exc.__traceback__))
 
     def _handle_failure(self, failed_future: Future | None) -> None:
         """Handle a program failure by stopping remaining programs.

--- a/divi/qprog/quantum_program.py
+++ b/divi/qprog/quantum_program.py
@@ -3,17 +3,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABC, abstractmethod
-from http import HTTPStatus
+from contextlib import contextmanager
 from queue import Queue
 from threading import Event
 from typing import Any
 from warnings import warn
 
-import requests
-
 from divi.backends import AsyncJobBackend, CircuitRunner
+from divi.backends._async_job_backend import _best_effort_cancel_job
 from divi.circuits.qem import _NoMitigation
 from divi.pipeline import CircuitPipeline, DryRunReport, PipelineEnv, dry_run_pipeline
+from divi.pipeline._core import _sigint_to_event
 from divi.reporting import (
     LoggingProgressReporter,
     ProgressReporter,
@@ -105,6 +105,20 @@ class QuantumProgram(ABC):
         """
         self._cancellation_event = event
 
+    @contextmanager
+    def _install_cancellation_handler(self):
+        """Funnel SIGINT into :attr:`_cancellation_event` for the duration of ``run()``.
+
+        First Ctrl+C sets the event; second Ctrl+C hard-aborts via
+        ``KeyboardInterrupt``. No-op outside the main thread or when a
+        non-default SIGINT handler is already installed — defers to
+        debuggers, Jupyter, and enclosing ensemble handlers.
+        """
+        if self._cancellation_event is None:
+            self._cancellation_event = Event()
+        with _sigint_to_event(self._cancellation_event):
+            yield
+
     @property
     def total_circuit_count(self) -> int:
         """Get the total number of circuits executed.
@@ -151,26 +165,7 @@ class QuantumProgram(ABC):
             )
             return
 
-        try:
-            self.backend.cancel_job(result)
-        except requests.exceptions.HTTPError as e:
-            # Check if this is an expected error (job already completed/failed/cancelled)
-            if (
-                hasattr(e, "response")
-                and e.response is not None
-                and e.response.status_code == HTTPStatus.CONFLICT
-            ):
-                # 409 Conflict means job is already in a terminal state - this is expected
-                # in race conditions where job completes before we can cancel it.
-                self.reporter.info(
-                    f"Job {result.job_id} already completed or cancelled"
-                )
-            else:
-                # Unexpected error (403 Forbidden, 404 Not Found, etc.) - report it
-                self.reporter.info(f"Failed to cancel job {result.job_id}: {e}")
-        except Exception as e:
-            # Other unexpected errors - report them
-            self.reporter.info(f"Failed to cancel job {result.job_id}: {e}")
+        _best_effort_cancel_job(self.backend, result)
 
     # ------------------------------------------------------------------ #
     # Pipeline

--- a/divi/qprog/variational_quantum_algorithm.py
+++ b/divi/qprog/variational_quantum_algorithm.py
@@ -1337,39 +1337,51 @@ class VariationalQuantumAlgorithm(QuantumProgram):
 
         resolved_initial_params = self._resolve_initial_param_sets(initial_params)
 
-        try:
-            self.optimize_result = self.optimizer.optimize(
-                cost_fn=cost_fn,
-                initial_params=resolved_initial_params,
-                callback_fn=_iteration_counter,
-                jac=grad_fn,
-                max_iterations=self.max_iterations,
-                rng=self._rng,
-            )
-        except (ExecutionCancelledError, StopIteration) as exc:
-            if isinstance(exc, ExecutionCancelledError):
-                message = "Optimization cancelled."
-            else:
+        with self._install_cancellation_handler():
+            try:
+                self.optimize_result = self.optimizer.optimize(
+                    cost_fn=cost_fn,
+                    initial_params=resolved_initial_params,
+                    callback_fn=_iteration_counter,
+                    jac=grad_fn,
+                    max_iterations=self.max_iterations,
+                    rng=self._rng,
+                )
+            except StopIteration:
                 reason = self._stop_reason.value if self._stop_reason else "Stopped"
-                message = f"Early stopping: {reason}"
+                self.optimize_result = OptimizeResult(
+                    x=np.atleast_2d(self._best_params),
+                    fun=np.atleast_1d(self._best_loss),
+                    nit=self.current_iteration,
+                    success=False,
+                    message=f"Early stopping: {reason}",
+                )
+            except ExecutionCancelledError as exc:
+                # ``KeyboardInterrupt`` is deliberately NOT caught here:
+                # the second Ctrl+C re-raises ``KeyboardInterrupt`` from
+                # the signal handler as the documented hard-abort path,
+                # and intercepting it would defeat that.
+                message = "Cancelled by user"
+                self.optimize_result = OptimizeResult(
+                    x=np.atleast_2d(self._best_params),
+                    fun=np.atleast_1d(self._best_loss),
+                    nit=self.current_iteration,
+                    success=False,
+                    message=message,
+                )
+                # The pipeline already best-effort-cancelled the in-flight
+                # job when it raised; no redundant call needed here.
+                self.reporter.info(
+                    message=message, final_status=TerminalStatus.CANCELLED
+                )
+                raise ExecutionCancelledError(message) from exc
+            else:
+                self.optimize_result.success = True
+                self.optimize_result.message = "Optimization converged."
 
-            self.optimize_result = OptimizeResult(
-                x=np.atleast_2d(self._best_params),
-                fun=np.atleast_1d(self._best_loss),
-                nit=self.current_iteration,
-                success=False,
-                message=message,
-            )
-
-            if isinstance(exc, ExecutionCancelledError):
-                return self
-        else:
-            self.optimize_result.success = True
-            self.optimize_result.message = "Optimization converged."
-
-            # Set _best_params from final result (source of truth)
-            x = np.atleast_2d(self.optimize_result.x)
-            self._best_params = x[np.argmin(self.optimize_result.fun)].copy()
+                # Set _best_params from final result (source of truth)
+                x = np.atleast_2d(self.optimize_result.x)
+                self._best_params = x[np.argmin(self.optimize_result.fun)].copy()
 
         self._final_params = self.optimize_result.x
 

--- a/tests/backends/test_maestro_simulator.py
+++ b/tests/backends/test_maestro_simulator.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import fields
 from threading import Event, Thread
 
@@ -10,7 +11,8 @@ import pytest
 
 import divi.backends._maestro_simulator as maestro_module
 from divi.backends import MaestroConfig, MaestroSimulator
-from divi.backends._maestro_simulator import _strip_measurements
+from divi.backends._maestro_simulator import _run_with_cancellation, _strip_measurements
+from divi.exceptions import ExecutionCancelledError
 from tests.backends import circuit_runner_contracts as contracts
 from tests.backends.circuit_runner_contracts import QASM_DEPTH_2, QASM_DEPTH_3
 
@@ -663,6 +665,120 @@ class TestParallelExecution:
 # ---------------------------------------------------------------------------
 # Expectation value mode
 # ---------------------------------------------------------------------------
+
+
+class TestRunWithCancellation:
+    """Direct unit tests for the cancellation-aware executor consumer.
+
+    Production callers (``MaestroSimulator.submit_circuits``) test it through
+    a ``ThreadPoolExecutor`` whose scheduling is non-deterministic; here we
+    exercise the helper with the real executor but synchronously, so the
+    event check between items is observable without timing races."""
+
+    def test_event_none_returns_all_results(self):
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            out = _run_with_cancellation(executor, lambda x: x * 2, [1, 2, 3], None)
+        assert out == [2, 4, 6]
+
+    def test_event_preset_raises_after_dispatch_with_no_results(self):
+        event = Event()
+        event.set()
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            with pytest.raises(ExecutionCancelledError):
+                _run_with_cancellation(executor, lambda x: x * 2, [1, 2, 3, 4], event)
+
+    def test_event_set_mid_batch_calls_cancel_on_remaining_futures(self, mocker):
+        """When the event flips between items, every remaining future has
+        :meth:`Future.cancel` called on it. Whether each ``cancel()`` actually
+        succeeds depends on whether the executor has already pulled the
+        future into a worker — that's an executor scheduling property, not
+        ours to control. The contract we own is: we always *ask* to cancel
+        every remaining future."""
+        event = Event()
+
+        def fn(x):
+            if x == 0:
+                event.set()
+            return x
+
+        executor = ThreadPoolExecutor(max_workers=1)
+        original_submit = executor.submit
+        submitted_futures: list = []
+
+        def tracking_submit(*args, **kwargs):
+            fut = original_submit(*args, **kwargs)
+            mocker.spy(fut, "cancel")
+            submitted_futures.append(fut)
+            return fut
+
+        mocker.patch.object(executor, "submit", side_effect=tracking_submit)
+
+        try:
+            with pytest.raises(ExecutionCancelledError):
+                _run_with_cancellation(executor, fn, list(range(5)), event)
+        finally:
+            executor.shutdown(wait=True)
+
+        assert len(submitted_futures) == 5
+        # Every future submitted should have had cancel() invoked on the
+        # cleanup path — even ones that were already done.
+        for fut in submitted_futures:
+            fut.cancel.assert_called()
+
+
+class TestCancellation:
+    """``cancellation_event`` is honored before dispatch and between items."""
+
+    def test_event_set_before_submit_aborts_without_dispatch(self, mocker):
+        fake = _make_fake_maestro(mocker)
+        sim = _make_simulator(mocker, fake)
+
+        event = Event()
+        event.set()
+
+        with pytest.raises(
+            ExecutionCancelledError, match="before any circuit was dispatched"
+        ):
+            sim.submit_circuits(
+                {"c0": QASM_DEPTH_2, "c1": QASM_DEPTH_3},
+                cancellation_event=event,
+            )
+
+        fake.simple_execute.assert_not_called()
+
+    def test_event_set_mid_batch_stops_consuming(self, mocker):
+        """When the event flips between item completions, the consumer
+        aborts and raises ExecutionCancelledError. Items the executor has
+        already pre-dispatched may still complete in the worker pool —
+        maestro itself has no mid-circuit cancel hook — but no more
+        results are appended to the batch output."""
+        fake = _make_fake_maestro(mocker, counts={"00": 1})
+        sim = _make_simulator(mocker, fake)
+
+        event = Event()
+        call_count = {"n": 0}
+        original_return = fake.simple_execute.return_value
+
+        def flip_then_return(*args, **kwargs):
+            # Set the event after the first item completes; the next
+            # consumer iteration will see it set.
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                event.set()
+            return original_return
+
+        fake.simple_execute.side_effect = flip_then_return
+
+        with pytest.raises(ExecutionCancelledError, match="partial completion"):
+            sim.submit_circuits(
+                {
+                    "c0": QASM_DEPTH_2,
+                    "c1": QASM_DEPTH_3,
+                    "c2": QASM_DEPTH_3,
+                    "c3": QASM_DEPTH_3,
+                },
+                cancellation_event=event,
+            )
 
 
 class TestExpvalSubmission:

--- a/tests/backends/test_qiskit_simulator.py
+++ b/tests/backends/test_qiskit_simulator.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings
+from threading import Event
 
 import pytest
 from qiskit import QuantumCircuit
@@ -15,6 +16,7 @@ from divi.backends._qiskit_simulator import (
     _default_n_processes,
     _find_best_fake_backend,
 )
+from divi.exceptions import ExecutionCancelledError
 from tests.backends import circuit_runner_contracts as contracts
 
 
@@ -352,6 +354,34 @@ class TestQiskitSimulatorSubmitCircuits:
         assert result.results is not None
         assert len(result.results) == 1
         assert result.results[0]["label"] == "test_circuit"
+
+
+class TestQiskitSimulatorCancellation:
+    """Aer's underlying call enters native code and cannot be interrupted,
+    so QiskitSimulator only honors ``cancellation_event`` at the
+    submit boundary — that's enough to abort the next iteration of an
+    optimizer loop without dispatching a wasted batch."""
+
+    def test_pre_set_event_raises_before_dispatch(self, mocker):
+        mock_aer = mocker.Mock()
+        mocker.patch(
+            "divi.backends._qiskit_simulator.AerSimulator",
+            return_value=mock_aer,
+        )
+        sim = QiskitSimulator(shots=10)
+
+        event = Event()
+        event.set()
+
+        qasm = (
+            'OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[1];\n'
+            "creg c[1];\nh q[0];\nmeasure q[0] -> c[0];\n"
+        )
+
+        with pytest.raises(ExecutionCancelledError, match="before dispatch"):
+            sim.submit_circuits({"c0": qasm}, cancellation_event=event)
+
+        mock_aer.run.assert_not_called()
 
 
 class TestQiskitSimulatorDepthTracker:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ class DummySimulator(CircuitRunner):
     def supports_expval(self):
         return False
 
-    def submit_circuits(self, circuits):
+    def submit_circuits(self, circuits, **kwargs):
         res = []
         for label, qasm in circuits.items():
             match = re.search(r"qreg q\[(\d+)\]", qasm)

--- a/tests/pipeline/test_core.py
+++ b/tests/pipeline/test_core.py
@@ -4,11 +4,14 @@
 
 """Tests for divi.pipeline._core: validation, CircuitPipeline, compile_batch, format_pipeline_tree."""
 
+import signal
+import threading
 from threading import Event
 
 import pytest
 
-from divi.backends import ExecutionResult, JobStatus
+from divi.backends import AsyncJobBackend, ExecutionResult, JobStatus
+from divi.backends._async_job_backend import _best_effort_cancel_job
 from divi.exceptions import ExecutionCancelledError
 from divi.pipeline import (
     CircuitPipeline,
@@ -23,6 +26,7 @@ from divi.pipeline._compilation import (
 )
 from divi.pipeline._core import (
     _scope_token,
+    _sigint_to_cancellation,
     _validate_stage_order,
     _wait_for_async_result,
 )
@@ -443,7 +447,10 @@ class TestWaitForAsyncResult:
             _wait_for_async_result(mock_backend, execution_result, env)
 
     def test_cancelled_without_event_raises_runtime_error(self, mocker):
-        """When job is CANCELLED without cancellation event, raises RuntimeError."""
+        """Backend-reported CANCELLED without a local cancellation request
+        is a scheduler-side eviction, not a user cancel. It must surface as
+        ``RuntimeError`` so eviction-driven failures aren't disguised as
+        intentional shutdowns."""
         mock_backend = mocker.Mock()
         mock_backend.poll_job_status.return_value = JobStatus.CANCELLED
         mock_backend.max_retries = 100
@@ -452,7 +459,7 @@ class TestWaitForAsyncResult:
 
         execution_result = ExecutionResult(job_id="test_job")
 
-        with pytest.raises(RuntimeError, match="Job test_job was cancelled"):
+        with pytest.raises(RuntimeError, match="cancelled by the scheduler"):
             _wait_for_async_result(mock_backend, execution_result, env)
 
     def test_missing_job_id_raises_value_error(self):
@@ -513,7 +520,13 @@ class TestWaitForAsyncResult:
 
         # Capture the on_complete callback, then invoke it with a dict response
         def fake_poll(
-            er, *, loop_until_complete, on_complete, verbose, progress_callback
+            er,
+            *,
+            loop_until_complete,
+            on_complete,
+            verbose,
+            progress_callback,
+            cancellation_event=None,
         ):
             on_complete({"run_time": 3.5})
             return JobStatus.COMPLETED
@@ -526,6 +539,24 @@ class TestWaitForAsyncResult:
         _wait_for_async_result(mock_backend, execution_result, env)
 
         assert env.artifacts["run_time"] == 3.5
+
+    def test_cancellation_event_is_forwarded_to_backend(self, mocker):
+        """The env's cancellation_event must reach backend.poll_job_status
+        so the polling loop can exit promptly when the user signals cancel."""
+        mock_backend = mocker.Mock()
+        mock_backend.poll_job_status.return_value = JobStatus.COMPLETED
+        mock_backend.max_retries = 100
+        mock_backend.get_job_results.return_value = ExecutionResult(
+            results=[], job_id="job"
+        )
+
+        event = Event()
+        env = PipelineEnv(backend=mock_backend, cancellation_event=event)
+
+        _wait_for_async_result(mock_backend, ExecutionResult(job_id="job"), env)
+
+        _, kwargs = mock_backend.poll_job_status.call_args
+        assert kwargs["cancellation_event"] is event
 
     def test_runtime_tracking_list_response(self, mocker):
         """on_complete callback accumulates run_time from a list of responses."""
@@ -541,7 +572,13 @@ class TestWaitForAsyncResult:
         resp2.json.return_value = {"run_time": 2.0}
 
         def fake_poll(
-            er, *, loop_until_complete, on_complete, verbose, progress_callback
+            er,
+            *,
+            loop_until_complete,
+            on_complete,
+            verbose,
+            progress_callback,
+            cancellation_event=None,
         ):
             on_complete([resp1, resp2])
             return JobStatus.COMPLETED
@@ -554,6 +591,133 @@ class TestWaitForAsyncResult:
         _wait_for_async_result(mock_backend, execution_result, env)
 
         assert env.artifacts["run_time"] == 3.5
+
+
+def _noop_handler(signum, frame):
+    pass
+
+
+class TestBestEffortCancelJob:
+    """Tests for the helper that funnels in-flight async-job cancellation."""
+
+    def test_calls_backend_cancel_for_async_backend_with_job_id(self, mocker):
+        backend = mocker.Mock(spec=AsyncJobBackend)
+        _best_effort_cancel_job(backend, ExecutionResult(job_id="job_x"))
+        backend.cancel_job.assert_called_once()
+
+    def test_noop_for_sync_backend(self, mocker):
+        sync_backend = mocker.Mock(spec=[])
+        _best_effort_cancel_job(sync_backend, ExecutionResult(job_id="job_y"))
+
+    def test_noop_when_no_job_id(self, mocker):
+        backend = mocker.Mock(spec=AsyncJobBackend)
+        _best_effort_cancel_job(backend, ExecutionResult(results=[]))
+        backend.cancel_job.assert_not_called()
+
+    def test_swallows_cancel_job_exception(self, mocker):
+        backend = mocker.Mock(spec=AsyncJobBackend)
+        backend.cancel_job.side_effect = RuntimeError("server says no")
+        # Must not propagate — the user's CTRL-C should not be masked by
+        # network/server hiccups during the courtesy cancel.
+        _best_effort_cancel_job(backend, ExecutionResult(job_id="job_z"))
+
+
+class TestSigintToCancellation:
+    """Tests for the SIGINT → cancellation_event funnel."""
+
+    def test_noop_outside_main_thread(self):
+        """``signal.signal`` rejects non-main threads; the context manager
+        must yield without installing a handler."""
+        before = signal.getsignal(signal.SIGINT)
+        observed: dict = {}
+
+        def runner():
+            env = PipelineEnv(backend=object())
+            with _sigint_to_cancellation(env):
+                observed["installed"] = signal.getsignal(signal.SIGINT)
+
+        t = threading.Thread(target=runner)
+        t.start()
+        t.join()
+        assert observed["installed"] is before
+
+    def test_creates_event_when_missing(self):
+        env = PipelineEnv(backend=object())
+        with _sigint_to_cancellation(env):
+            assert env.cancellation_event is not None
+
+    def test_first_sigint_sets_event(self):
+        env = PipelineEnv(backend=object())
+        with _sigint_to_cancellation(env):
+            assert env.cancellation_event is not None
+            handler = signal.getsignal(signal.SIGINT)
+            handler(signal.SIGINT, None)
+            assert env.cancellation_event.is_set()
+
+    def test_second_sigint_raises_keyboard_interrupt(self):
+        env = PipelineEnv(backend=object())
+        with pytest.raises(KeyboardInterrupt):
+            with _sigint_to_cancellation(env):
+                handler = signal.getsignal(signal.SIGINT)
+                handler(signal.SIGINT, None)
+                handler(signal.SIGINT, None)
+
+    def test_defers_to_existing_non_default_handler(self):
+        env = PipelineEnv(backend=object())
+        prev = signal.signal(signal.SIGINT, _noop_handler)
+        try:
+            with _sigint_to_cancellation(env):
+                assert signal.getsignal(signal.SIGINT) is _noop_handler
+        finally:
+            signal.signal(signal.SIGINT, prev)
+
+
+class TestDefaultExecuteFnCancellation:
+    """End-to-end: when the poll loop raises, the backend is told to cancel."""
+
+    def _async_backend(self, mocker, *, raise_on_poll):
+        backend = mocker.Mock(spec=AsyncJobBackend)
+        backend.supports_expval = False
+        backend.max_retries = 1
+        backend.submit_circuits.return_value = ExecutionResult(job_id="job_42")
+        if raise_on_poll:
+            backend.poll_job_status.side_effect = ExecutionCancelledError(
+                "Polling cancelled for job job_42."
+            )
+        return backend
+
+    def test_cancel_during_poll_calls_backend_cancel_once(self, mocker):
+        backend = self._async_backend(mocker, raise_on_poll=True)
+        env = PipelineEnv(backend=backend, cancellation_event=Event())
+        pipeline = CircuitPipeline(
+            stages=[
+                DummySpecStage(meta=two_group_meta()),
+                MeasurementStage(),
+            ]
+        )
+        with pytest.raises(ExecutionCancelledError):
+            pipeline.run(initial_spec="x", env=env)
+
+        # The submitted result should be passed back to cancel_job exactly once.
+        submitted = backend.submit_circuits.return_value
+        backend.cancel_job.assert_called_once_with(submitted)
+
+    def test_keyboard_interrupt_during_poll_also_cancels_backend(self, mocker):
+        """Hosts with their own SIGINT handler (Jupyter, debuggers) raise
+        plain KeyboardInterrupt mid-poll — the cleanup must still fire."""
+        backend = self._async_backend(mocker, raise_on_poll=False)
+        backend.poll_job_status.side_effect = KeyboardInterrupt
+        env = PipelineEnv(backend=backend, cancellation_event=Event())
+        pipeline = CircuitPipeline(
+            stages=[
+                DummySpecStage(meta=two_group_meta()),
+                MeasurementStage(),
+            ]
+        )
+        with pytest.raises(KeyboardInterrupt):
+            pipeline.run(initial_spec="x", env=env)
+
+        backend.cancel_job.assert_called_once()
 
 
 class TestPipelineResultSqueeze:

--- a/tests/qprog/test_ensemble.py
+++ b/tests/qprog/test_ensemble.py
@@ -12,10 +12,13 @@ from threading import Event as ThreadingEvent
 from threading import Lock, Thread
 
 import pytest
+from rich.panel import Panel
 from rich.progress import Progress
+from rich.traceback import Traceback
 
 import divi.qprog.ensemble as ensemble_module
 from divi.backends import AsyncJobBackend, ExecutionResult
+from divi.exceptions import ExecutionCancelledError
 from divi.qprog._batch_coordinator import _BatchCoordinator
 from divi.qprog.ensemble import BatchConfig, BatchMode, ProgramEnsemble
 from divi.qprog.quantum_program import QuantumProgram
@@ -552,6 +555,140 @@ class TestProgramEnsemble:
         assert "Cancelled by user" in messages
         assert "Finishing... ⏳" in messages
         assert "Stopped after current iteration" in messages
+
+    def test_failed_future_with_execution_cancelled_error_emits_cancelled(
+        self, program_ensemble, mocker
+    ):
+        """A future that finished with ``ExecutionCancelledError`` is the
+        cooperative result of a user cancel propagating from the worker,
+        not a real failure — it must show ``CANCELLED``, not ``FAILED``."""
+        program_ensemble.create_programs()
+        spy = mocker.spy(program_ensemble, "_emit_progress_message")
+        program_ensemble._pb_task_map = {"prog1": 1}
+        program_ensemble._cancellation_event = mocker.MagicMock()
+
+        failed_future = Future()
+        failed_future.set_exception(ExecutionCancelledError("Cancelled by user"))
+
+        program_ensemble.futures = [failed_future]
+        program_ensemble._future_to_program = {
+            failed_future: program_ensemble.programs["prog1"]
+        }
+        mocker.patch("divi.qprog.ensemble.as_completed", return_value=[])
+
+        program_ensemble._handle_cancellation()
+
+        cancelled_emits = [
+            call
+            for call in spy.call_args_list
+            if call.kwargs.get("final_status") is TerminalStatus.CANCELLED
+        ]
+        assert cancelled_emits, (
+            "expected at least one CANCELLED emit for an ExecutionCancelledError "
+            f"future, got {[c.kwargs for c in spy.call_args_list]}"
+        )
+
+    def test_failed_future_with_runtime_error_still_emits_failed(
+        self, program_ensemble, mocker
+    ):
+        """A future that crashed for a non-cancellation reason must still
+        show ``FAILED`` even when reaped during cancellation cleanup —
+        masking it as CANCELLED would hide real bugs from the user."""
+        program_ensemble.create_programs()
+        spy = mocker.spy(program_ensemble, "_emit_progress_message")
+        program_ensemble._pb_task_map = {"prog1": 1}
+        program_ensemble._cancellation_event = mocker.MagicMock()
+
+        failed_future = Future()
+        failed_future.set_exception(RuntimeError("boom"))
+
+        program_ensemble.futures = [failed_future]
+        program_ensemble._future_to_program = {
+            failed_future: program_ensemble.programs["prog1"]
+        }
+        mocker.patch("divi.qprog.ensemble.as_completed", return_value=[])
+
+        program_ensemble._handle_cancellation()
+
+        statuses = [
+            call.kwargs.get("final_status")
+            for call in spy.call_args_list
+            if call.kwargs.get("final_status") is not None
+        ]
+        assert TerminalStatus.FAILED in statuses
+        assert TerminalStatus.CANCELLED not in statuses
+
+    def test_failed_future_panel_printed_during_cancellation(
+        self, program_ensemble, mocker
+    ):
+        """When cancellation reaps a future that crashed for a non-
+        cancellation reason, the exception detail must still surface — a
+        red Rich panel with a traceback, mirroring the no-cancel failure
+        path. Otherwise the user only sees a red progress row and never
+        learns what went wrong."""
+        program_ensemble.create_programs()
+        program_ensemble._pb_task_map = {"prog1": 1, "prog2": 2}
+        program_ensemble._cancellation_event = mocker.MagicMock()
+        mock_progress_bar = mocker.MagicMock()
+        program_ensemble._progress_bar = mock_progress_bar
+
+        failed_future = Future()
+        failed_future.set_exception(RuntimeError("boom"))
+        cancelled_future = Future()
+        cancelled_future.set_exception(ExecutionCancelledError("Cancelled by user"))
+
+        program_ensemble.futures = [failed_future, cancelled_future]
+        program_ensemble._future_to_program = {
+            failed_future: program_ensemble.programs["prog1"],
+            cancelled_future: program_ensemble.programs["prog2"],
+        }
+        mocker.patch("divi.qprog.ensemble.as_completed", return_value=[])
+
+        program_ensemble._handle_cancellation()
+
+        printed = [
+            call.args[0] for call in mock_progress_bar.console.print.call_args_list
+        ]
+        panels = [p for p in printed if isinstance(p, Panel)]
+        tracebacks = [p for p in printed if isinstance(p, Traceback)]
+        # One failure → exactly one summary panel and one traceback render.
+        assert len(panels) == 1
+        assert len(tracebacks) == 1
+
+        panel_text = str(panels[0].renderable)
+        assert "RuntimeError" in panel_text
+        assert "boom" in panel_text
+        # The cancelled program is not rendered as a failure.
+        assert "ExecutionCancelledError" not in panel_text
+        # Failed program is identified by id.
+        prog1_id = program_ensemble.programs["prog1"].program_id
+        assert prog1_id in str(panels[0].title)
+
+    def test_cancellation_without_failures_prints_no_failure_panels(
+        self, program_ensemble, mocker
+    ):
+        """When every program either ran cleanly or cancelled cooperatively,
+        no Rich failure panels should be printed — only the existing
+        progress-row status updates."""
+        program_ensemble.create_programs()
+        program_ensemble._pb_task_map = {"prog1": 1}
+        program_ensemble._cancellation_event = mocker.MagicMock()
+        mock_progress_bar = mocker.MagicMock()
+        program_ensemble._progress_bar = mock_progress_bar
+
+        cancelled_future = Future()
+        cancelled_future.set_exception(ExecutionCancelledError("Cancelled by user"))
+
+        program_ensemble.futures = [cancelled_future]
+        program_ensemble._future_to_program = {
+            cancelled_future: program_ensemble.programs["prog1"]
+        }
+        mocker.patch("divi.qprog.ensemble.as_completed", return_value=[])
+
+        program_ensemble._handle_cancellation()
+
+        # No Panel/Traceback emission should have happened on the console.
+        assert mock_progress_bar.console.print.call_count == 0
 
     def test_handle_cancellation_unstoppable_futures(self, program_ensemble, mocker):
         """Test cancellation handling with unstoppable futures."""

--- a/tests/qprog/test_quantum_program.py
+++ b/tests/qprog/test_quantum_program.py
@@ -177,8 +177,11 @@ class TestQuantumProgramJobManagement:
             program._current_execution_result
         )
 
-    def test_cancel_unfinished_job_409_conflict(self, mocker):
-        """Test cancel_unfinished_job handles 409 Conflict gracefully."""
+    def test_cancel_unfinished_job_409_conflict_is_silently_swallowed(self, mocker):
+        """409 from the scheduler means the job already reached a terminal
+        state — a normal race outcome of CTRL-C arriving as the job finishes.
+        The error must not propagate and must not spam the user-facing
+        reporter; it is logged at DEBUG for developers only."""
         mock_backend = mocker.Mock(spec=AsyncJobBackend)
         mock_response = mocker.Mock()
         mock_response.status_code = HTTPStatus.CONFLICT
@@ -192,12 +195,14 @@ class TestQuantumProgramJobManagement:
 
         program.cancel_unfinished_job()
 
-        program.reporter.info.assert_called_once_with(
-            "Job test_job_123 already completed or cancelled"
-        )
+        mock_backend.cancel_job.assert_called_once()
+        program.reporter.info.assert_not_called()
 
-    def test_cancel_unfinished_job_other_error(self, mocker):
-        """Test cancel_unfinished_job reports other errors."""
+    def test_cancel_unfinished_job_other_error_is_silently_swallowed(self, mocker):
+        """Non-409 HTTP errors (403, 404, network) during cleanup are
+        diagnostic-only — they belong in ``logger.debug``, not on the
+        user-facing reporter that's currently displaying cancellation
+        status."""
         mock_backend = mocker.Mock(spec=AsyncJobBackend)
         mock_response = mocker.Mock()
         mock_response.status_code = HTTPStatus.FORBIDDEN
@@ -211,10 +216,8 @@ class TestQuantumProgramJobManagement:
 
         program.cancel_unfinished_job()
 
-        program.reporter.info.assert_called_once()
-        assert "Failed to cancel job test_job_123" in str(
-            program.reporter.info.call_args[0][0]
-        )
+        mock_backend.cancel_job.assert_called_once()
+        program.reporter.info.assert_not_called()
 
     def test_cancel_unfinished_job_no_reporter(self, mocker):
         """Test cancel_unfinished_job works without reporter."""

--- a/tests/qprog/test_variational_quantum_algorithm.py
+++ b/tests/qprog/test_variational_quantum_algorithm.py
@@ -531,7 +531,10 @@ class TestRunIntegration(BaseVariationalQuantumAlgorithmTest):
         np.testing.assert_allclose(full[1], row1)
 
     def test_run_method_cancellation_handling(self, mocker):
-        """Test run method exits gracefully when a cancellation event is set."""
+        """Cancellation now halts the script at ``run()``: ``ExecutionCancelledError``
+        re-raises after the partial ``optimize_result`` is recorded, so any
+        downstream aggregate that depended on the return value never sees an
+        empty/half-set state."""
         program = self._create_program_with_mock_optimizer(mocker)
         program.max_iterations = 1
         mock_event = mocker.MagicMock()
@@ -541,11 +544,27 @@ class TestRunIntegration(BaseVariationalQuantumAlgorithmTest):
             "Cancellation requested"
         )
 
-        result = program.run()
+        with pytest.raises(ExecutionCancelledError, match="Cancelled by user"):
+            program.run()
 
-        assert result is program
-        assert program.total_circuit_count == program._total_circuit_count
-        assert program.total_run_time == program._total_run_time
+        # The bookkeeping side-effects (totals, the recorded partial result)
+        # still happen — only the return is replaced by the raise.
+        assert program.optimize_result is not None
+        assert program.optimize_result.success is False
+        assert program.optimize_result.message == "Cancelled by user"
+
+    def test_run_method_keyboard_interrupt_propagates_as_hard_abort(self, mocker):
+        """A KeyboardInterrupt escaping the optimizer (e.g. the documented
+        second-press hard-abort path, or a host with its own SIGINT handler)
+        must propagate unchanged. VQA only translates the cooperative
+        ExecutionCancelledError; KeyboardInterrupt is the user's request to
+        bypass graceful shutdown."""
+        program = self._create_program_with_mock_optimizer(mocker)
+        program.max_iterations = 1
+        program.optimizer.optimize.side_effect = KeyboardInterrupt()
+
+        with pytest.raises(KeyboardInterrupt):
+            program.run()
 
     def _setup_program_for_final_computation_test(self, mocker):
         """Helper to set up program with mocks for final computation tests."""


### PR DESCRIPTION
## Summary

- `QuantumProgram.run()` now raises a typed `ExecutionCancelledError` that halts the caller on CTRL-C, instead of letting the script cascade past `run()` into the next aggregate with empty results.
- Cancellation cleanup lives at the pipeline + backend protocol layer: `_default_execute_fn` best-effort cancels the in-flight remote job on either `ExecutionCancelledError` or `KeyboardInterrupt`, covering the SIGINT-funnel path and Jupyter / embedded hosts where Python's default handler runs.
- `ProgramEnsemble._handle_cancellation` now renders a red Rich panel + traceback for any worker that crashed for a non-cancellation reason before the user pressed CTRL-C; previously those failures only showed as a red progress row.
- `MaestroSimulator` and `QiskitSimulator` honour `cancellation_event` (between dispatched items / before dispatch); `AsyncJobBackend.submit_circuits` declares it as a first-class keyword-only parameter.

## Test plan

- [x] `uv run pytest -n auto` — 2901 passed, 27 skipped
- [x] `uv run pyrefly check` on touched files — 0 errors
- [x] `python -m tutorials._ci_runner` — 17/17 patched tutorials pass against `--local-maestro`
- [x] `cd docs && make clean && make build` — succeeded, no Sphinx warnings