### PR TITLE
feat(backends): expose noisy_device and noise_realizations on ExecutionConfig

### DIFF
--- a/divi/backends/_config.py
+++ b/divi/backends/_config.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from dataclasses import dataclass, field, fields
+import warnings
+from dataclasses import InitVar, dataclass, field, fields
 from enum import IntEnum
 
 from divi.backends import QPUSystem, SimulatorCluster
@@ -70,6 +71,15 @@ class ExecutionConfig:
     simulation_method: SimulationMethod | None = None
     """Simulation method."""
 
+    noisy_device: str | None = None
+    """Name of a noisy device backend to emulate (e.g. ``"ibm_fake_fez"``)."""
+
+    noise_realizations: int | None = None
+    """Number of noise realizations to average over."""
+
+    noise_scaling_factor: float | None = None
+    """Scaling factor applied to the device noise, between 0 and 1."""
+
     api_meta: dict | None = field(default=None)
     """Runtime pass-through metadata. Forwarded to the cloud runtime;
     unknown keys are rejected server-side. Allowed keys and value types:
@@ -82,6 +92,58 @@ class ExecutionConfig:
     * ``routing_method`` (``str``)
     * ``approximation_degree`` (``int`` or ``float``)
     """
+
+    _validate_input: InitVar[bool] = True
+    """Internal: ``False`` skips input guards on reconstruction paths."""
+
+    def __post_init__(self, _validate_input: bool):
+        """Validates the configuration."""
+        if not _validate_input:
+            return
+
+        if self.bond_dimension is not None and self.bond_dimension <= 0:
+            raise ValueError(
+                f"bond_dimension must be a positive integer. Got {self.bond_dimension}."
+            )
+
+        if self.truncation_threshold is not None and self.truncation_threshold < 0:
+            raise ValueError(
+                f"truncation_threshold must be non-negative. Got {self.truncation_threshold}."
+            )
+
+        if self.noise_realizations is not None and self.noise_realizations <= 0:
+            raise ValueError(
+                f"noise_realizations must be a positive integer. Got {self.noise_realizations}."
+            )
+
+        if self.noise_scaling_factor is not None and not (
+            0 <= self.noise_scaling_factor <= 1
+        ):
+            raise ValueError(
+                f"noise_scaling_factor must be between 0 and 1. Got {self.noise_scaling_factor}."
+            )
+
+        if self.noisy_device is not None and self.noise_scaling_factor == 0:
+            warnings.warn(
+                f"noise_scaling_factor=0 cancels all noise from noisy_device "
+                f"'{self.noisy_device}', producing a noiseless run.",
+                stacklevel=3,
+            )
+
+        mps_only_set = (
+            self.bond_dimension is not None or self.truncation_threshold is not None
+        )
+        if (
+            mps_only_set
+            and self.simulation_method is not None
+            and self.simulation_method != SimulationMethod.MatrixProductState
+        ):
+            warnings.warn(
+                "bond_dimension and truncation_threshold only apply to "
+                f"MatrixProductState simulations; they will be ignored with "
+                f"simulation_method={self.simulation_method.name}.",
+                stacklevel=3,
+            )
 
     def override(self, other: "ExecutionConfig") -> "ExecutionConfig":
         """Creates a new config by overriding attributes with non-None values.
@@ -104,7 +166,7 @@ class ExecutionConfig:
             if other_value is not None:
                 current_attrs[f.name] = other_value
 
-        return ExecutionConfig(**current_attrs)
+        return ExecutionConfig(**current_attrs, _validate_input=False)
 
     def to_payload(self) -> dict:
         """Serialize to the JSON body expected by the API.
@@ -126,6 +188,12 @@ class ExecutionConfig:
             payload["simulator_type"] = int(self.simulator)
         if self.simulation_method is not None:
             payload["simulation_type"] = int(self.simulation_method)
+        if self.noisy_device is not None:
+            payload["noisy_device"] = self.noisy_device
+        if self.noise_realizations is not None:
+            payload["noise_realizations"] = self.noise_realizations
+        if self.noise_scaling_factor is not None:
+            payload["noise_scaling_factor"] = self.noise_scaling_factor
         if self.api_meta is not None:
             payload["api_meta"] = self.api_meta
 
@@ -153,7 +221,11 @@ class ExecutionConfig:
                 if raw_simulation_method is not None
                 else None
             ),
+            noisy_device=data.get("noisy_device"),
+            noise_realizations=data.get("noise_realizations"),
+            noise_scaling_factor=data.get("noise_scaling_factor"),
             api_meta=data.get("api_meta"),
+            _validate_input=False,
         )
 
 

--- a/tests/backends/test_config.py
+++ b/tests/backends/test_config.py
@@ -4,6 +4,8 @@
 
 """Unit tests for :mod:`divi.backends._config`."""
 
+import dataclasses
+
 import pytest
 
 from divi.backends import (
@@ -281,6 +283,9 @@ class TestExecutionConfigOverride:
         assert result.truncation_threshold is None
         assert result.simulator is None
         assert result.simulation_method is None
+        assert result.noisy_device is None
+        assert result.noise_realizations is None
+        assert result.noise_scaling_factor is None
         assert result.api_meta is None
 
     def test_override_api_meta(self):
@@ -301,6 +306,9 @@ class TestExecutionConfigPayload:
             truncation_threshold=1e-8,
             simulator=Simulator.QCSim,
             simulation_method=SimulationMethod.MatrixProductState,
+            noisy_device="ibm_fake_fez",
+            noise_realizations=10,
+            noise_scaling_factor=0.5,
             api_meta={"optimization_level": 2},
         )
         payload = config.to_payload()
@@ -309,6 +317,9 @@ class TestExecutionConfigPayload:
             "truncation_threshold": 1e-8,
             "simulator_type": int(Simulator.QCSim),
             "simulation_type": int(SimulationMethod.MatrixProductState),
+            "noisy_device": "ibm_fake_fez",
+            "noise_realizations": 10,
+            "noise_scaling_factor": 0.5,
             "api_meta": {"optimization_level": 2},
         }
 
@@ -330,7 +341,10 @@ class TestExecutionConfigPayload:
             bond_dimension=128,
             truncation_threshold=1e-6,
             simulator=Simulator.GpuSim,
-            simulation_method=SimulationMethod.TensorNetwork,
+            simulation_method=SimulationMethod.MatrixProductState,
+            noisy_device="ibm_fake_fez",
+            noise_realizations=5,
+            noise_scaling_factor=0.25,
             api_meta={"max_execution_time": 300},
         )
         reconstructed = ExecutionConfig.from_response(original.to_payload())
@@ -343,6 +357,118 @@ class TestExecutionConfigPayload:
         assert config.bond_dimension == 64
         assert config.simulator is None
         assert config.simulation_method is None
+
+
+@pytest.mark.parametrize("invalid_value", [0, -1, -10])
+def test_bond_dimension_rejects_non_positive(invalid_value):
+    """bond_dimension must be a positive integer."""
+    with pytest.raises(ValueError, match="bond_dimension must be a positive integer"):
+        ExecutionConfig(bond_dimension=invalid_value)
+
+
+@pytest.mark.parametrize("invalid_value", [-1e-8, -0.5, -10])
+def test_truncation_threshold_rejects_negative(invalid_value):
+    """truncation_threshold must be non-negative."""
+    with pytest.raises(ValueError, match="truncation_threshold must be non-negative"):
+        ExecutionConfig(truncation_threshold=invalid_value)
+
+
+@pytest.mark.parametrize("invalid_value", [0, -1, -10])
+def test_noise_realizations_rejects_non_positive(invalid_value):
+    """noise_realizations must be a positive integer."""
+    with pytest.raises(
+        ValueError, match="noise_realizations must be a positive integer"
+    ):
+        ExecutionConfig(noise_realizations=invalid_value)
+
+
+@pytest.mark.parametrize("field", ["bond_dimension", "truncation_threshold"])
+def test_mps_only_fields_warn_with_non_mps_method(field):
+    """MPS-only fields warn when paired with an explicit non-MPS method."""
+    value = 64 if field == "bond_dimension" else 1e-8
+    with pytest.warns(UserWarning, match="only apply to MatrixProductState"):
+        ExecutionConfig(
+            simulation_method=SimulationMethod.Statevector, **{field: value}
+        )
+
+
+def test_mps_only_fields_silent_with_mps_method(recwarn):
+    """No warning when MPS-only fields pair with MatrixProductState."""
+    ExecutionConfig(
+        bond_dimension=64,
+        truncation_threshold=1e-8,
+        simulation_method=SimulationMethod.MatrixProductState,
+    )
+    assert len(recwarn) == 0
+
+
+def test_mps_only_fields_silent_with_no_method(recwarn):
+    """No warning when simulation_method is unset (server auto-picks)."""
+    ExecutionConfig(bond_dimension=64, truncation_threshold=1e-8)
+    assert len(recwarn) == 0
+
+
+@pytest.mark.parametrize("invalid_value", [-0.1, 1.1, 2.0, -5])
+def test_noise_scaling_factor_rejects_out_of_range(invalid_value):
+    """noise_scaling_factor must lie between 0 and 1."""
+    with pytest.raises(
+        ValueError, match="noise_scaling_factor must be between 0 and 1"
+    ):
+        ExecutionConfig(noise_scaling_factor=invalid_value)
+
+
+@pytest.mark.parametrize("valid_value", [0, 0.5, 1])
+def test_noise_scaling_factor_accepts_unit_interval(valid_value):
+    """Boundary and interior values in [0, 1] are accepted."""
+    assert (
+        ExecutionConfig(noise_scaling_factor=valid_value).noise_scaling_factor
+        == valid_value
+    )
+
+
+def test_noise_scaling_factor_zero_with_device_warns():
+    """Scaling a named device's noise to zero warns about the noiseless run."""
+    with pytest.warns(UserWarning, match="cancels all noise from noisy_device"):
+        ExecutionConfig(noisy_device="ibm_fake_fez", noise_scaling_factor=0)
+
+
+def test_noise_scaling_factor_zero_without_device_is_silent(recwarn):
+    """Scaling to zero with no device set is a valid baseline, no warning."""
+    ExecutionConfig(noise_scaling_factor=0)
+    assert len(recwarn) == 0
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"bond_dimension": 0},
+        {"noise_realizations": 0},
+        {"truncation_threshold": -1e-8},
+        {"noise_scaling_factor": 2.0},
+    ],
+)
+def test_from_response_skips_input_validation(data):
+    """Reading server state must round-trip even if it predates a guard."""
+    config = ExecutionConfig.from_response(data)
+    field, value = next(iter(data.items()))
+    assert getattr(config, field) == value
+
+
+def test_override_skips_validation_and_warnings(recwarn):
+    """Merging two individually-valid configs neither raises nor warns."""
+    base = ExecutionConfig(bond_dimension=64)
+    other = ExecutionConfig(simulation_method=SimulationMethod.Statevector)
+    result = base.override(other)
+    assert result.bond_dimension == 64
+    assert result.simulation_method == SimulationMethod.Statevector
+    assert len(recwarn) == 0
+
+
+def test_validate_input_flag_excluded_from_fields_and_payload():
+    """The private _validate_input InitVar must not leak into fields or payload."""
+    field_names = {f.name for f in dataclasses.fields(ExecutionConfig)}
+    assert "_validate_input" not in field_names
+    assert "_validate_input" not in ExecutionConfig(bond_dimension=64).to_payload()
 
 
 def test_frozen():

--- a/tests/backends/test_qoro_service.py
+++ b/tests/backends/test_qoro_service.py
@@ -2492,6 +2492,18 @@ class TestQoroServiceWithApiKey:
         assert retrieved.simulation_method == SimulationMethod.MatrixProductState
         assert retrieved.api_meta == {"optimization_level": 1}
 
+    def test_set_and_get_noise_config(self, qoro_service, circuits):
+        """Noise fields (noisy_device, noise_realizations) round-trip."""
+        single_circuit = {"circuit_1": circuits["circuit_0"]}
+        result = qoro_service.submit_circuits(single_circuit)
+
+        config = ExecutionConfig(noisy_device="ibm_fake_fez", noise_realizations=4)
+        qoro_service.set_execution_config(result, config)
+
+        retrieved = qoro_service.get_execution_config(result)
+        assert retrieved.noisy_device == "ibm_fake_fez"
+        assert retrieved.noise_realizations == 4
+
     def test_submit_with_inline_execution_config(self, qoro_service, circuits):
         """Tests attaching execution config directly in submit_circuits."""
         single_circuit = {"circuit_1": circuits["circuit_0"]}

--- a/uv.lock
+++ b/uv.lock
@@ -2901,7 +2901,7 @@ wheels = [
 
 [[package]]
 name = "qoro-divi"
-version = "0.12.0"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "basis-set-exchange" },


### PR DESCRIPTION
Add two new optional fields to ExecutionConfig:
- noisy_device: name of a noisy device backend to emulate
- noise_realizations: number of noise realizations to average over

Both fields are serialized in to_payload(), deserialized in from_response(), and covered by existing test cases.