### PR TITLE
feat(qprog): QUIVER adaptive directional-gradient optimizer

### DIFF
--- a/divi/pipeline/_core.py
+++ b/divi/pipeline/_core.py
@@ -24,6 +24,7 @@ from ._compilation import (
     _compile_template_batch,
 )
 from ._postprocessing import (
+    _counts_to_cost_variance,
     _counts_to_expvals,
     _counts_to_probs,
     _expval_dicts_to_indexed,
@@ -510,8 +511,15 @@ class CircuitPipeline:
                         None,
                     )
                     if ham_ops is not None:
+                        # Backend-native expval: no shot counts, so a shot-noise
+                        # variance is undefined; cost_variance is left unset and
+                        # consumers default to nan.
                         raw = _expval_dicts_to_indexed(raw, ham_ops)
                     else:
+                        if env.collect_variance:
+                            env.artifacts["cost_variance"] = _counts_to_cost_variance(
+                                raw, plan.final_batch
+                            )
                         raw = _counts_to_expvals(raw, plan.final_batch)
 
             result = PipelineResult(self._reduce(raw, env, plan.stage_tokens))

--- a/divi/pipeline/_postprocessing.py
+++ b/divi/pipeline/_postprocessing.py
@@ -177,6 +177,106 @@ def _counts_to_expvals(
     return out
 
 
+def _observable_coeff_map(
+    node: MetaCircuit,
+) -> dict[str, float] | None:
+    """Big-endian ``{pauli_label: real_coeff}`` for a single-observable cost.
+
+    Returns ``None`` when the node carries multiple observables (a multi-output
+    program), for which a single scalar cost variance is undefined. Labels are
+    padded to ``node.n_qubits`` to match the stored measurement groups.
+    """
+    observable = node.observable
+    if not isinstance(observable, tuple) or len(observable) != 1:
+        return None
+    op = observable[0]
+    le_labels = op.paulis.to_labels()
+    coeffs = np.real(np.asarray(op.coeffs)).astype(np.float64)
+    n_qubits = node.n_qubits
+    coeff_map: dict[str, float] = {}
+    for le_label, coeff in zip(le_labels, coeffs, strict=True):
+        be_label = le_label[::-1].ljust(n_qubits, "I")
+        coeff_map[be_label] = coeff_map.get(be_label, 0.0) + float(coeff)
+    return coeff_map
+
+
+def _counts_to_cost_variance(
+    raw: ChildResults,
+    batch: dict[Any, MetaCircuit],
+) -> dict[tuple, float]:
+    """Estimate the shot-noise variance of each cost value from raw counts.
+
+    For a Hamiltonian ``H = Σ_i c_i P_i`` measured group-wise, the variance of
+    the (group-wise independent) mean estimator is approximated by
+    ``Var(<H>) = Σ_i c_i² (1 − <P_i>²) / M_g``, where ``M_g`` is the shot count
+    for the group containing ``P_i``. This drops intra-group Pauli covariance —
+    a standard, cheap first approximation. Each Pauli's ``<P_i>`` and the group
+    shot count come from the same counts :func:`_counts_to_expvals` consumes.
+
+    Returns ``{base_key: variance}`` summed over a spec's measurement groups,
+    where ``base_key`` is the branch key with the ``obs_group`` axis stripped —
+    matching the post-reduce cost keys. Specs with multiple observables yield
+    ``nan`` (single-scalar variance undefined).
+    """
+    batch_keys = set(batch.keys())
+    labels_by_bk: dict[tuple, dict[int, tuple[object, ...]]] = {}
+    nq_by_bk: dict[tuple, int] = {}
+    coeffs_by_bk: dict[tuple, dict[str, float] | None] = {}
+    for bk, node in batch.items():
+        nq_by_bk[bk] = node.n_qubits
+        labels_by_bk[bk] = {i: g for i, g in enumerate(node.measurement_groups)}
+        coeffs_by_bk[bk] = _observable_coeff_map(node)
+
+    out: dict[tuple, float] = {}
+    for branch_key, counts in raw.items():
+        bk = _find_batch_key(branch_key, batch_keys)
+        base_key = tuple(ax for ax in branch_key if ax[0] != "obs_group")
+        coeff_map = coeffs_by_bk[bk]
+        if coeff_map is None:
+            out[base_key] = float("nan")
+            continue
+
+        axis_values = dict(branch_key)
+        obs_group_idx = int(axis_values.get("obs_group", 0))
+        group_labels = labels_by_bk[bk][obs_group_idx]
+        n_qubits = nq_by_bk[bk]
+
+        if isinstance(counts, Mapping):
+            counts = {bitstring[::-1]: count for bitstring, count in counts.items()}
+            shots = sum(counts.values())
+        else:
+            # Non-count payload (shouldn't reach here on the shot path); skip.
+            out[base_key] = out.get(base_key, 0.0) + float("nan")
+            continue
+
+        if shots <= 0:
+            # Degenerate group with no measurements: invalidate the whole cost
+            # variance (nan) rather than silently omitting it, which would
+            # deflate the summed estimate. Matches the multi-observable and
+            # non-count paths above.
+            out[base_key] = float("nan")
+            continue
+
+        expvals = _batched_expectation(
+            [counts], [str(p) for p in group_labels], n_qubits
+        )[:, 0]
+
+        group_var = 0.0
+        for label, exp in zip(group_labels, expvals, strict=True):
+            coeff = coeff_map.get(str(label), 0.0)
+            if coeff == 0.0:
+                continue
+            # ``exp`` is a convex combination of ±1 eigenvalues, so 1−exp² ≥ 0
+            # mathematically; clamp to guard float rounding when |exp| ≈ 1.
+            group_var += coeff * coeff * max(0.0, 1.0 - float(exp) ** 2) / shots
+
+        prev = out.get(base_key, 0.0)
+        # Once a base key is nan (multi-observable / degenerate group) keep it nan.
+        out[base_key] = prev if np.isnan(prev) else prev + group_var
+
+    return out
+
+
 def _expval_dicts_to_indexed(raw: ChildResults, ham_ops: str) -> ChildResults:
     """Normalise ``{pauli_str: float}`` dicts from expval-native backends.
 

--- a/divi/pipeline/abc.py
+++ b/divi/pipeline/abc.py
@@ -192,6 +192,31 @@ class PipelineEnv:
     ``evaluation_counter`` it gives a stable-within-evaluation seed even when no
     explicit strategy seed is set, so the cost and metric pipelines still agree."""
 
+    shots_override: int | None = None
+    """Per-evaluation shot budget overriding ``backend.shots`` without mutating
+    the immutable backend. Read via :attr:`effective_shots`; set by callers that
+    drive an adaptive shot count (e.g. QUIVER's ``M``-adaptivity). ``None`` falls
+    back to the backend's configured shots."""
+
+    collect_variance: bool = False
+    """When ``True``, measurement stages also estimate the shot-noise variance of
+    each cost value from raw counts and write it to ``artifacts['cost_variance']``
+    (``{param_set_idx: variance}``). Off by default — the estimate costs nothing
+    extra in circuits but adds a small classical post-processing pass."""
+
+    @property
+    def effective_shots(self) -> int:
+        """The shot budget to use for this run.
+
+        Returns :attr:`shots_override` when set, otherwise the backend's
+        configured ``shots``.
+        """
+        return (
+            self.shots_override
+            if self.shots_override is not None
+            else self.backend.shots
+        )
+
 
 class ContractViolation(ValueError):
     """Raised when a stage's positional requirements are not met."""

--- a/divi/pipeline/stages/_measurement_stage.py
+++ b/divi/pipeline/stages/_measurement_stage.py
@@ -101,14 +101,28 @@ def _allocate_per_group_shots(
             or ``None`` when ``shot_distribution`` is not configured.
     """
     n_groups = len(measurement_groups)
-    if shot_distribution is None or n_groups == 0:
+    if n_groups == 0:
         return list(range(n_groups)), {}, None
+
+    if shot_distribution is None:
+        # No distribution: every group gets the full per-evaluation budget. When
+        # an evaluation overrides the shot count (``shots_override``), materialise
+        # it as uniform per-group shots so it reaches the backend via the
+        # ``shot_groups`` submission path (the backend otherwise uses its own
+        # ``shots``); without an override leave allocation to the backend.
+        if env.shots_override is None:
+            return list(range(n_groups)), {}, None
+        return (
+            list(range(n_groups)),
+            {},
+            {i: env.shots_override for i in range(n_groups)},
+        )
 
     coefficients = np.asarray(observable.coeffs).real.astype(np.float64)
     group_norms = _compute_group_l1_norms(coefficients, partition_indices)
     per_group_shots = _compute_shot_distribution(
         group_norms,
-        env.backend.shots,
+        env.effective_shots,
         shot_distribution,
         rng=env.rng,
     )
@@ -235,18 +249,24 @@ class MeasurementStage(BundleStage):
         )
 
     def cache_key_extras(self, env) -> tuple[Hashable, ...]:
-        """Fold ``env.backend.shots`` into the forward-pass cache key.
+        """Fold the effective shot budget / variance flag into the forward-pass
+        cache key.
 
-        Any configured shot distribution (even the deterministic ones) reads
-        ``env.backend.shots`` during :meth:`expand` to compute the per-group
-        allocation. Including the current shot budget in the cache key means
-        a re-run with a different budget triggers fresh allocation rather
-        than replaying the stale one. Returns ``()`` when
-        ``shot_distribution`` is ``None``.
+        A configured shot distribution (even the deterministic ones) reads the
+        shot budget during :meth:`expand` to compute the per-group allocation;
+        so does an active ``shots_override`` (which materialises uniform
+        per-group shots). Including the budget means a re-run with a different
+        one triggers fresh allocation rather than replaying a stale one.
+        ``collect_variance`` is folded in too, since it changes the per-call
+        post-processing. Returns ``()`` in the default case (no distribution, no
+        override, no variance) so caching is unaffected.
         """
-        if self._shot_distribution is None:
-            return ()
-        return (env.backend.shots,)
+        extras: tuple[Hashable, ...] = ()
+        if self._shot_distribution is not None or env.shots_override is not None:
+            extras += (env.effective_shots,)
+        if env.collect_variance:
+            extras += (env.collect_variance,)
+        return extras
 
     def __init__(
         self,
@@ -497,7 +517,12 @@ class MeasurementStage(BundleStage):
                 .set_measurement_groups(measurement_groups)
                 .set_result_format(ResultFormat.EXPVALS)
             )
-            if surviving_shots is not None:
+            # The backend-native expval path evaluates analytically and rejects
+            # per-circuit shot_groups (incompatible with ham_ops). A shots
+            # override is meaningless there, so never materialise group shots on
+            # that path — the override is silently ignored, as analytic expval
+            # ignores shots by definition.
+            if surviving_shots is not None and strategy != "_backend_expval":
                 new_meta = new_meta.set_group_shots(surviving_shots)
             result[key] = new_meta
             postprocess_fn_by_spec[key] = postprocessing_fn

--- a/divi/qprog/__init__.py
+++ b/divi/qprog/__init__.py
@@ -48,6 +48,7 @@ from .optimizers import (
     MonteCarloOptimizer,
     QNGOptimizer,
     QNSPSAOptimizer,
+    QUIVEROptimizer,
     ScipyMethod,
     ScipyOptimizer,
     SPSAOptimizer,

--- a/divi/qprog/optimizers/__init__.py
+++ b/divi/qprog/optimizers/__init__.py
@@ -22,7 +22,11 @@ from divi.qprog.optimizers._monte_carlo import MonteCarloOptimizer, MonteCarloSt
 from divi.qprog.optimizers._pymoo import PymooMethod, PymooOptimizer, PymooState
 from divi.qprog.optimizers._qng import QNGOptimizer
 from divi.qprog.optimizers._scipy import ScipyMethod, ScipyOptimizer
-from divi.qprog.optimizers._spsa import QNSPSAOptimizer, SPSAOptimizer
+from divi.qprog.optimizers._spsa import (
+    QNSPSAOptimizer,
+    QUIVEROptimizer,
+    SPSAOptimizer,
+)
 
 __all__ = [
     "FubiniStudyMetricEstimator",
@@ -37,6 +41,7 @@ __all__ = [
     "PymooState",
     "QNGOptimizer",
     "QNSPSAOptimizer",
+    "QUIVEROptimizer",
     "SPSAOptimizer",
     "ScipyMethod",
     "ScipyOptimizer",

--- a/divi/qprog/optimizers/_spsa.py
+++ b/divi/qprog/optimizers/_spsa.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import inspect
 import warnings
 from collections import deque
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -659,6 +660,352 @@ class QNSPSAOptimizer(_SPSAConfigMixin, Optimizer):
         if self.blocking and current_loss < best_fun:
             best_fun = current_loss
             best_x = theta.copy()
+
+        return OptimizeResult(
+            x=best_x,
+            fun=np.atleast_1d(best_fun),
+            nit=max_iterations,
+            success=True,
+            message="Optimization terminated: reached max_iterations.",
+        )
+
+
+def _cost_fn_supports_variance(cost_fn: Callable) -> bool:
+    """Whether ``cost_fn`` accepts the ``shots``/``return_variance`` kwargs.
+
+    The variational algorithm's cost closure does (so QUIVER can drive adaptive
+    shot budgets and read back measurement variance); a plain callable passed by
+    a direct ``optimize`` call does not, and QUIVER degrades gracefully.
+    """
+    try:
+        params = inspect.signature(cost_fn).parameters
+    except (TypeError, ValueError):
+        return False
+    if any(p.kind == p.VAR_KEYWORD for p in params.values()):
+        return True
+    return "return_variance" in params
+
+
+class QUIVEROptimizer(_SPSAConfigMixin, Optimizer):
+    r"""Adaptive directional (forward) gradients — QUIVER (arXiv 2606.09734).
+
+    Reconstructs the full gradient from ``V`` random Rademacher directional
+    derivatives, independent of the parameter count ``N``:
+
+    .. math::
+        \tilde\nabla^{\mathsf F} f = \frac{1}{V}\sum_{\ell=1}^{V}
+        \Big(\frac{f(\theta+\varepsilon v_\ell) - f(\theta-\varepsilon v_\ell)}
+        {2\varepsilon}\Big)\, v_\ell ,
+        \qquad \theta \leftarrow \theta - a_k\,\tilde\nabla^{\mathsf F} f ,
+
+    costing ``2V`` evaluations per step. This unifies SPSA (``V=1``,
+    finite-difference), random coordinate descent (``V=1``, parameter-shift
+    directional derivative) and the full parameter-shift rule (``V=N``) under one
+    tunable ``V``.
+
+    QUIVER additionally adapts ``V`` and the per-direction shot count ``M`` each
+    step (iCANS/gCANS-style), maximising expected progress per measurement shot:
+
+    * **``V`` from the sample spread (no backend variance needed).** The ``V``
+      i.i.d. directional samples already estimate the forward-gradient variance
+      ``S²``; more directions are spent when the relative gradient variance is
+      high and fewer as the estimate concentrates. This encodes the paper's
+      assumption that measurement noise concentrates uniformly across random
+      directions, so allocation is by *number of directions*, not per-parameter.
+    * **``M`` from the injected measurement variance.** When the variational
+      algorithm's cost closure exposes a shot-noise variance (shot-based
+      backends), QUIVER reads the single-shot cost variance and sets ``M`` to
+      balance derivative noise against the gradient signal. On native-expval
+      backends or a plain ``cost_fn`` (no variance channel) it falls back to a
+      fixed ``M`` and ``V``-from-spread only — still a valid forward-gradient
+      optimizer.
+
+    .. note::
+        A per-evaluation shot budget is delivered to the backend as explicit
+        per-circuit ``shot_groups``, which disables circuit-template batching for
+        that submission. On template-capable backends (e.g. the Qoro cloud) an
+        adapting ``M`` therefore trades template reuse for shot adaptivity; if
+        submission overhead dominates, prefer ``adapt_M=False`` there and keep
+        ``adapt_M`` for local shot-based simulators.
+
+    Single-point optimizer (``n_param_sets == 1``); gradient-free, so any
+    ``jac``/``metric_fn`` supplied by the variational algorithm is ignored.
+
+    Args:
+        learning_rate: Step-size numerator ``a`` (constant by default; the gain
+            schedule reuses Spall's ``a/(A+k+1)**alpha`` with ``alpha=0``).
+        epsilon: Finite-difference step ``ε`` (paper default ``0.1``); for
+            ``derivative_mode='parameter_shift'`` the shift ``π/2`` is used
+            instead.
+        V_init/V_min/V_max: Initial / minimum / maximum number of random
+            directions per step.
+        M_init/M_min/M_max: Initial / minimum / maximum shots per directional
+            evaluation (only adapted on shot-based backends).
+        adapt_V: Adapt the number of directions from the sample spread.
+        adapt_M: Adapt the shot budget from the injected measurement variance.
+        derivative_mode: ``'finite_diff'`` (default, central difference with step
+            ``ε``) or ``'parameter_shift'`` (directional shift ``π/2``; exact only
+            for equal-eigenvalue generators along basis directions, otherwise an
+            approximation).
+        lipschitz: Smoothness constant ``L`` for the gain bound; when ``None`` the
+            optimal step ``a = 1/L`` is taken to be ``learning_rate``.
+        mu: EMA decay for the running gradient / variance estimates.
+        b: Small floor guarding divisions by a vanishing gradient norm.
+        alpha/gamma/A: Spall gain-schedule knobs (default to constant gains).
+        blocking/blocking_history/blocking_tol/exact_loss: Inherited look-ahead
+            blocking and loss-recording behaviour (see :class:`SPSAOptimizer`).
+    """
+
+    def __init__(
+        self,
+        learning_rate: float = 0.1,
+        epsilon: float = 0.1,
+        V_init: int = 1,
+        V_min: int = 1,
+        V_max: int = 50,
+        M_init: int = 100,
+        M_min: int = 10,
+        M_max: int = 10000,
+        adapt_V: bool = True,
+        adapt_M: bool = True,
+        derivative_mode: Literal["finite_diff", "parameter_shift"] = "finite_diff",
+        lipschitz: float | None = None,
+        mu: float = 0.99,
+        b: float = 1e-6,
+        alpha: float = 0.0,
+        gamma: float = 0.0,
+        A: float | None = None,
+        blocking: bool = False,
+        blocking_history: int = 5,
+        blocking_tol: float = 2.0,
+        exact_loss: bool = False,
+    ):
+        super().__init__(
+            learning_rate=learning_rate,
+            c=epsilon,
+            alpha=alpha,
+            gamma=gamma,
+            A=A,
+            resamplings=V_init,
+            blocking=blocking,
+            blocking_history=blocking_history,
+            blocking_tol=blocking_tol,
+            exact_loss=exact_loss,
+        )
+        if not (1 <= V_min <= V_init <= V_max):
+            raise ValueError(
+                "Require 1 <= V_min <= V_init <= V_max, got "
+                f"V_min={V_min}, V_init={V_init}, V_max={V_max}."
+            )
+        if not (1 <= M_min <= M_init <= M_max):
+            raise ValueError(
+                "Require 1 <= M_min <= M_init <= M_max, got "
+                f"M_min={M_min}, M_init={M_init}, M_max={M_max}."
+            )
+        if not (0.0 < mu < 1.0):
+            raise ValueError(f"mu must be in (0, 1), got {mu}.")
+        if lipschitz is not None and lipschitz <= 0:
+            raise ValueError(f"lipschitz must be positive, got {lipschitz}.")
+        if derivative_mode not in ("finite_diff", "parameter_shift"):
+            raise ValueError(
+                "derivative_mode must be 'finite_diff' or 'parameter_shift', "
+                f"got {derivative_mode!r}."
+            )
+
+        self.epsilon = epsilon
+        self.V_init = V_init
+        self.V_min = V_min
+        self.V_max = V_max
+        self.M_init = M_init
+        self.M_min = M_min
+        self.M_max = M_max
+        self.adapt_V = adapt_V
+        self.adapt_M = adapt_M
+        self.derivative_mode = derivative_mode
+        self.lipschitz = lipschitz
+        self.mu = mu
+        self.b = b
+
+    def validate_program(self, program: "VariationalQuantumAlgorithm") -> None:
+        """Warn when ``adapt_M`` is combined with a configured shot distribution.
+
+        ``M``-adaptivity recovers the single-shot cost variance as
+        ``Var(<H>)·M``, which assumes every measurement group received the same
+        ``M`` shots. A shot distribution splits the budget unevenly across
+        groups, so that recovery is miscalibrated — the gradient and loss stay
+        correct, but the adapted ``M`` may be off. Disable ``adapt_M`` or drop
+        the shot distribution to silence this.
+        """
+        if self.adapt_M and getattr(program, "_shot_distribution", None) is not None:
+            warnings.warn(
+                f"{type(self).__name__}: adapt_M=True with a configured "
+                "shot_distribution — the per-direction shot-budget adaptation "
+                "assumes uniform per-group shots and may be miscalibrated. "
+                "Disable adapt_M or remove the shot distribution.",
+                stacklevel=2,
+            )
+
+    def optimize(
+        self,
+        cost_fn: Callable[[npt.NDArray[np.float64]], float | npt.NDArray[np.float64]],
+        initial_params: npt.NDArray[np.float64] | None = None,
+        callback_fn: Callable[[OptimizeResult], Any] | None = None,
+        **kwargs,
+    ) -> OptimizeResult:
+        """Run QUIVER for ``max_iterations`` steps.
+
+        Args:
+            cost_fn: Cost function; called with a two-row batch per directional
+                sample. When it accepts ``shots``/``return_variance`` (the
+                variational algorithm's closure), QUIVER drives the adaptive shot
+                budget and reads the measurement variance for ``M``-adaptivity.
+            initial_params: Starting parameters (1D, or 2D with a single row).
+            callback_fn: Called after each step with an ``OptimizeResult`` whose
+                ``x`` is 2D and ``fun`` is 1D. May raise ``StopIteration``.
+            **kwargs: ``max_iterations`` (default 50, must be >= 1) and ``rng``.
+                ``jac`` and ``metric_fn`` are accepted and ignored (QUIVER is
+                gradient-free).
+        """
+        max_iterations = self._resolve_max_iterations(kwargs)
+        rng = kwargs.pop("rng", None)
+        if rng is None:
+            rng = np.random.default_rng()
+        kwargs.pop("jac", None)
+        kwargs.pop("metric_fn", None)
+
+        if initial_params is None:
+            raise ValueError("QUIVEROptimizer requires initial_params.")
+
+        theta = np.atleast_1d(np.asarray(initial_params, dtype=np.float64).squeeze())
+        A = self.A if self.A is not None else 0.1 * max_iterations
+        shift = (0.5 * np.pi) if self.derivative_mode == "parameter_shift" else None
+
+        supports_variance = _cost_fn_supports_variance(cost_fn)
+        M_k: int | None = self.M_init  # adapted shot budget; read live by cost_only
+        last_variance: npt.NDArray[np.float64] | None = None
+
+        def cost_only(
+            batch: npt.NDArray[np.float64],
+        ) -> npt.NDArray[np.float64]:
+            """Loss-only adapter; stashes the latest measurement variance."""
+            nonlocal last_variance
+            if supports_variance:
+                # The variational algorithm's cost closure accepts these kwargs
+                # and returns (losses, variances); the base ``cost_fn`` type
+                # cannot express that optional contract, so call through Any.
+                losses, variances = cast(Any, cost_fn)(
+                    batch, shots=M_k, return_variance=True
+                )
+                last_variance = np.asarray(variances, dtype=np.float64).reshape(-1)
+                return np.asarray(losses, dtype=np.float64).reshape(-1)
+            return np.asarray(cost_fn(batch), dtype=np.float64).reshape(-1)
+
+        # gCANS optimal step a* = 1/L; default L so that a* == learning_rate.
+        L = self.lipschitz if self.lipschitz is not None else 1.0 / self.learning_rate
+
+        V_k = self.V_init
+        chi = np.zeros_like(theta)  # EMA of the gradient estimate
+        xi = 0.0  # EMA of the scalar gradient-sample variance
+
+        best_x = theta.copy()
+        best_fun = np.inf
+        recent: deque[float] = deque(maxlen=self.blocking_history)
+        current_loss: float = (
+            float(np.asarray(cost_only(theta)).reshape(-1)[0]) if self.blocking else 0.0
+        )
+        reference_loss: float | None = None
+        diverged_warned = False
+        step_size_warned = False
+
+        for k in range(max_iterations):
+            eps_k = shift if shift is not None else _spsa_gain_c(k, self.c, self.gamma)
+            a_k = _spsa_gain_a(k, self.learning_rate, A, self.alpha)
+
+            ghats = []
+            losses = []
+            var_samples: list[float] = []
+            for _ in range(V_k):
+                ghat_l, _, f_plus, f_minus = _spsa_gradient(
+                    cost_only, theta, eps_k, rng
+                )
+                ghats.append(ghat_l)
+                losses.append(0.5 * (f_plus + f_minus))
+                v = last_variance
+                if v is not None and len(v) and np.all(np.isfinite(v)):
+                    # Reported variance is Var(<H>) at M_k shots; recover the
+                    # single-shot cost variance as Var·M.
+                    m_now = M_k if M_k is not None else 1
+                    var_samples.append(float(np.mean(v)) * float(m_now))
+
+            ghat = np.mean(ghats, axis=0)
+
+            # Variance of the single-direction estimator across the V samples
+            # (sum of per-component variances); folds in both direction and
+            # measurement noise. Needs >= 2 samples, else carry the prior EMA.
+            if V_k >= 2:
+                spread = np.stack(ghats) - ghat
+                S2 = float(np.sum(spread * spread) / (V_k - 1))
+            else:
+                S2 = xi  # reuse last estimate when a single direction was drawn
+
+            chi = self.mu * chi + (1.0 - self.mu) * ghat
+            xi = self.mu * xi + (1.0 - self.mu) * S2
+            bias_corr = 1.0 - self.mu ** (k + 1)
+            chi_hat = chi / bias_corr
+            xi_hat = xi / bias_corr
+            g2 = float(chi_hat @ chi_hat) + self.b
+
+            fun = (
+                current_loss
+                if self.blocking
+                else self._step_loss(cost_only, theta, float(np.mean(losses)))
+            )
+            if reference_loss is None:
+                reference_loss = fun
+            diverged_warned = self._warn_if_diverging(
+                fun, reference_loss, diverged_warned
+            )
+
+            recent.append(fun)
+            if fun < best_fun:
+                best_fun = fun
+                best_x = theta.copy()
+            if callback_fn is not None:
+                callback_fn(
+                    OptimizeResult(
+                        x=np.atleast_2d(theta.copy()),
+                        fun=np.atleast_1d(fun),
+                        nit=k + 1,
+                        success=True,
+                        message="Optimization in progress.",
+                    )
+                )
+
+            proposed = theta - a_k * ghat
+            if self.blocking:
+                theta, current_loss = self._block_or_step(
+                    cost_only, theta, proposed, current_loss, recent
+                )
+            else:
+                theta = proposed
+
+            # --- Adapt (V, M) for the next step ---
+            if not step_size_warned and L * a_k >= 2.0:
+                warnings.warn(
+                    f"{type(self).__name__}: L*a_k = {L * a_k:.3g} >= 2 leaves the "
+                    "gCANS stability regime (requires a < 2/L); the (V, M) "
+                    "allocation will saturate at its bounds. Lower learning_rate "
+                    "or raise lipschitz.",
+                    stacklevel=2,
+                )
+                step_size_warned = True
+            kappa = (2.0 * L * a_k) / max(2.0 - L * a_k, self.b)
+            if self.adapt_V:
+                V_k = int(np.clip(np.ceil(kappa * xi_hat / g2), self.V_min, self.V_max))
+            if self.adapt_M and supports_variance and var_samples:
+                sigma2 = float(np.mean(var_samples))
+                M_next = np.ceil(kappa * sigma2 / (2.0 * eps_k * eps_k * g2))
+                M_k = int(np.clip(M_next, self.M_min, self.M_max))
 
         return OptimizeResult(
             x=best_x,

--- a/divi/qprog/optimizers/_spsa.py
+++ b/divi/qprog/optimizers/_spsa.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import inspect
 import warnings
 from collections import deque
 from collections.abc import Callable
@@ -63,6 +62,12 @@ def _spsa_gradient(
     )
     batch = np.vstack([theta + c_k * h, theta - c_k * h])
     values = np.asarray(cost_fn(batch), dtype=np.float64).reshape(-1)
+    if values.size < 2:
+        raise ValueError(
+            "cost_fn must return one value per batch row; the two-row "
+            f"perturbation batch produced {values.size} value(s). Ensure the cost "
+            "function is batch-aware (returns a 1-D array for a 2-D input)."
+        )
     f_plus, f_minus = float(values[0]), float(values[1])
     ghat = (f_plus - f_minus) / (2.0 * c_k) * h
     return ghat, h, f_plus, f_minus
@@ -671,19 +676,16 @@ class QNSPSAOptimizer(_SPSAConfigMixin, Optimizer):
 
 
 def _cost_fn_supports_variance(cost_fn: Callable) -> bool:
-    """Whether ``cost_fn`` accepts the ``shots``/``return_variance`` kwargs.
+    """Whether ``cost_fn`` exposes the shot-variance channel.
 
-    The variational algorithm's cost closure does (so QUIVER can drive adaptive
-    shot budgets and read back measurement variance); a plain callable passed by
-    a direct ``optimize`` call does not, and QUIVER degrades gracefully.
+    Capability is *declared by the producer*, not inferred from the signature: a
+    producer that supports the variance channel sets ``supports_variance = True``
+    on its callable (the variational algorithm's cost closure does). A plain
+    callable from a direct ``optimize`` call carries no such flag, so QUIVER uses
+    the variance path only against a declaring producer and degrades gracefully
+    otherwise — no fragile signature sniffing.
     """
-    try:
-        params = inspect.signature(cost_fn).parameters
-    except (TypeError, ValueError):
-        return False
-    if any(p.kind == p.VAR_KEYWORD for p in params.values()):
-        return True
-    return "return_variance" in params
+    return bool(getattr(cost_fn, "supports_variance", False))
 
 
 class QUIVEROptimizer(_SPSAConfigMixin, Optimizer):
@@ -876,7 +878,17 @@ class QUIVEROptimizer(_SPSAConfigMixin, Optimizer):
         if initial_params is None:
             raise ValueError("QUIVEROptimizer requires initial_params.")
 
-        theta = np.atleast_1d(np.asarray(initial_params, dtype=np.float64).squeeze())
+        # Single-point optimizer: accept 1-D or a single-row (1, n) array, but
+        # reject any other 2-D shape rather than silently flattening a multi-start
+        # array into one long vector (or crashing later on a broadcast mismatch).
+        theta = np.asarray(initial_params, dtype=np.float64)
+        if theta.ndim == 2 and theta.shape[0] == 1:
+            theta = theta[0]
+        if theta.ndim != 1:
+            raise ValueError(
+                "QUIVEROptimizer is a single-point optimizer; initial_params must "
+                f"be 1-D or shape (1, n_params), got shape {theta.shape}."
+            )
         A = self.A if self.A is not None else 0.1 * max_iterations
         shift = (0.5 * np.pi) if self.derivative_mode == "parameter_shift" else None
 
@@ -928,6 +940,14 @@ class QUIVEROptimizer(_SPSAConfigMixin, Optimizer):
                 ghat_l, _, f_plus, f_minus = _spsa_gradient(
                     cost_only, theta, eps_k, rng
                 )
+                if shift is not None:
+                    # ``_spsa_gradient`` divides by ``2·eps_k``; the parameter-shift
+                    # rule for ±π/2 evaluations of an equal-eigenvalue (±½)
+                    # generator uses a ½ prefactor, i.e. divides by 2. Rescale by
+                    # ``eps_k`` so the estimate is the true parameter-shift
+                    # gradient (½(f₊−f₋)·v), not the ``2/π``-scaled value the
+                    # finite-difference normalization would give.
+                    ghat_l = ghat_l * eps_k
                 ghats.append(ghat_l)
                 losses.append(0.5 * (f_plus + f_minus))
                 v = last_variance
@@ -1006,6 +1026,24 @@ class QUIVEROptimizer(_SPSAConfigMixin, Optimizer):
                 sigma2 = float(np.mean(var_samples))
                 M_next = np.ceil(kappa * sigma2 / (2.0 * eps_k * eps_k * g2))
                 M_k = int(np.clip(M_next, self.M_min, self.M_max))
+
+        # Best-iterate tracking runs at the top of the loop, so the iterate
+        # reached by the final step is never tracked. Fold it in:
+        #   * blocking: the accepted step's loss is already measured in
+        #     current_loss, so no extra evaluation is needed.
+        #   * exact_loss (no blocking): the per-step loss is the true f(theta),
+        #     so spend one more exact evaluation on the final iterate to match
+        #     that contract. (The free-proxy path is left as-is: its recorded
+        #     loss is the perturbation average, not f(theta).)
+        if self.blocking:
+            if current_loss < best_fun:
+                best_fun = current_loss
+                best_x = theta.copy()
+        elif self.exact_loss:
+            final_loss = float(np.asarray(cost_only(theta)).reshape(-1)[0])
+            if final_loss < best_fun:
+                best_fun = final_loss
+                best_x = theta.copy()
 
         return OptimizeResult(
             x=best_x,

--- a/divi/qprog/quantum_program.py
+++ b/divi/qprog/quantum_program.py
@@ -86,6 +86,7 @@ class QuantumProgram(ABC):
         self._total_run_time = 0.0
         self._curr_circuits = []
         self._current_execution_result = None
+        self._last_cost_variance = None
         self._cancellation_event = None
         self._evaluation_counter = 0
         # Fixed seed for unseeded stochastic stages: the explicit ``seed`` when
@@ -326,6 +327,7 @@ class QuantumProgram(ABC):
         self._total_circuit_count += env.artifacts.get("circuit_count", 0)
         self._total_run_time += env.artifacts.get("run_time", 0.0)
         self._current_execution_result = env.artifacts.get("_current_execution_result")
+        self._last_cost_variance = env.artifacts.get("cost_variance")
         return result
 
     def _run_pipeline(self, name: str, *, initial_spec: Any = None, **env_overrides):

--- a/divi/qprog/variational_quantum_algorithm.py
+++ b/divi/qprog/variational_quantum_algorithm.py
@@ -889,21 +889,67 @@ class VariationalQuantumAlgorithm(ObservableMeasuringMixin, QuantumProgram):
     # ------------------------------------------------------------------ #
 
     def _evaluate_cost_param_sets(
-        self, param_sets: npt.NDArray[np.float64], **kwargs
+        self,
+        param_sets: npt.NDArray[np.float64],
+        *,
+        shots: int | None = None,
+        collect_variance: bool = False,
+        **kwargs,
     ) -> dict[int, float]:
         """Evaluate the cost pipeline for the provided parameter sets.
+
+        ``shots`` overrides the per-evaluation measurement budget without
+        mutating the immutable backend (see :attr:`PipelineEnv.effective_shots`).
+        ``collect_variance`` asks the pipeline to also estimate the shot-noise
+        variance of each cost value, stashed on ``_last_cost_variance`` and read
+        back via :meth:`_cost_shot_variances`.
 
         Subclasses should prefer overriding the initial-spec hook over
         replacing the full evaluator.
         """
-        result = self._run_pipeline("cost", param_sets=np.atleast_2d(param_sets))
+        env_overrides: dict[str, Any] = {}
+        if shots is not None:
+            env_overrides["shots_override"] = int(shots)
+        if collect_variance:
+            env_overrides["collect_variance"] = True
+
+        result = self._run_pipeline(
+            "cost", param_sets=np.atleast_2d(param_sets), **env_overrides
+        )
 
         constant = 0.0 if self._loss_constant_consumed else self.loss_constant
-        indexed = {
-            _extract_param_set_idx(key): float(value[0]) + constant
-            for key, value in result.items()
-        }
-        return dict(sorted(indexed.items()))
+        return dict(
+            sorted(
+                {
+                    _extract_param_set_idx(key): float(value[0]) + constant
+                    for key, value in result.items()
+                }.items()
+            )
+        )
+
+    def _cost_shot_variances(self, values: dict[int, float]) -> dict[int, float]:
+        """Map the last pipeline run's shot-noise variance to each param-set index.
+
+        The variance is computed at the counts stage with only the obs_group axis
+        stripped. For a plain expval cost (VQE/QAOA/CustomVQA) that leaves exactly
+        the param_set axis, so each index maps to one variance. A pipeline with
+        extra reduce axes (e.g. ZNE scales, a QNN data batch) yields several
+        entries per index; collapsing them to a single scalar would be wrong, so
+        such indices — and any value absent from the artifact (e.g. native-expval
+        backends produce none) — are reported as ``nan`` so the optimizer falls
+        back to its variance-free path.
+        """
+        raw_var = getattr(self, "_last_cost_variance", None) or {}
+        by_idx: dict[int, float] = {}
+        collided: set[int] = set()
+        for key, variance in raw_var.items():
+            idx = _extract_param_set_idx(key)
+            if idx in by_idx:
+                collided.add(idx)
+            by_idx[idx] = variance
+        for idx in collided:
+            by_idx[idx] = float("nan")
+        return {idx: by_idx.get(idx, float("nan")) for idx in values}
 
     def _evaluate_gradient_at(
         self, params: npt.NDArray[np.float64], **kwargs
@@ -1013,23 +1059,27 @@ class VariationalQuantumAlgorithm(ObservableMeasuringMixin, QuantumProgram):
                 UserWarning,
             )
 
-        def cost_fn(params):
+        def cost_fn(params, *, shots=None, return_variance=False):
             self._evaluation_counter += 1
             self.reporter.info(
                 message="💸 Computing Cost 💸", iteration=self.current_iteration
             )
 
-            losses = self._evaluate_cost_param_sets(np.atleast_2d(params), **kwargs)
-
-            losses = np.asarray(
-                [value for value in losses.values()],
-                dtype=np.float64,
+            values_map = self._evaluate_cost_param_sets(
+                np.atleast_2d(params),
+                shots=shots,
+                collect_variance=return_variance,
+                **kwargs,
             )
-
-            if params.ndim > 1:
+            losses = np.asarray(list(values_map.values()), dtype=np.float64)
+            losses = losses if params.ndim > 1 else losses.item()
+            if not return_variance:
                 return losses
-            else:
-                return losses.item()
+
+            var_map = self._cost_shot_variances(values_map)
+            variances = np.asarray(list(var_map.values()), dtype=np.float64)
+            variances = variances if params.ndim > 1 else variances.item()
+            return losses, variances
 
         self._grad_shift_mask = _compute_parameter_shift_mask(
             self.n_layers * self.n_params_per_layer

--- a/divi/qprog/variational_quantum_algorithm.py
+++ b/divi/qprog/variational_quantum_algorithm.py
@@ -1081,6 +1081,10 @@ class VariationalQuantumAlgorithm(ObservableMeasuringMixin, QuantumProgram):
             variances = variances if params.ndim > 1 else variances.item()
             return losses, variances
 
+        # Advertise the shot-variance channel so variance-aware optimizers (e.g.
+        # QUIVER) can use it without sniffing this closure's signature.
+        setattr(cost_fn, "supports_variance", True)
+
         self._grad_shift_mask = _compute_parameter_shift_mask(
             self.n_layers * self.n_params_per_layer
         )

--- a/docs/source/api_reference/qprog/core.rst
+++ b/docs/source/api_reference/qprog/core.rst
@@ -18,7 +18,7 @@ uniform return type for decoded solutions.
    :skip: FeatureMap, AngleEmbedding, ZZFeatureMap
    :skip: InitialState, ZerosState, OnesState, SuperpositionState, CustomPerQubitState, WState
    :skip: ScipyOptimizer, ScipyMethod, MonteCarloOptimizer, GridSearchOptimizer
-   :skip: QNGOptimizer, SPSAOptimizer, QNSPSAOptimizer
+   :skip: QNGOptimizer, SPSAOptimizer, QNSPSAOptimizer, QUIVEROptimizer
    :skip: MetricEstimator, PullbackMetricEstimator, FubiniStudyMetricEstimator, StochasticFidelityMetricEstimator
    :skip: MoleculeTransformer, PartitioningProgramEnsemble, TimeEvolutionTrajectory, VQEHyperparameterSweep
    :skip: ProgramEnsemble, BatchConfig, BatchMode, EarlyStopping

--- a/docs/source/user_guide/optimizers.rst
+++ b/docs/source/user_guide/optimizers.rst
@@ -343,6 +343,61 @@ Use SPSA / QN-SPSA when:
 - *(QN-SPSA)* You want metric-aware updates at a constant per-step circuit cost,
   trading the exact metric for a stochastic estimate.
 
+QUIVER (Adaptive Directional Gradients)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :class:`~divi.qprog.optimizers.QUIVEROptimizer` [#coyle2026]_ reconstructs the
+full gradient from ``V`` random Rademacher (:math:`\pm 1`) directional
+derivatives, independent of the parameter count :math:`N`:
+
+.. math::
+
+   \tilde\nabla^{\mathsf F} f = \frac{1}{V}\sum_{\ell=1}^{V}
+   \frac{f(\theta + \varepsilon v_\ell) - f(\theta - \varepsilon v_\ell)}
+   {2\varepsilon}\, v_\ell,
+   \qquad \theta \leftarrow \theta - a_k\,\tilde\nabla^{\mathsf F} f,
+
+costing :math:`2V` evaluations per step. A single direction (:math:`V = 1`)
+recovers SPSA; :math:`V = N` recovers the full parameter-shift gradient — so
+``V`` dials between cheap-but-noisy and expensive-but-precise gradient estimates.
+
+QUIVER also adapts ``V`` and the per-direction shot count ``M`` each step
+(iCANS/gCANS-style), spending more directions when the gradient estimate is noisy
+relative to its magnitude, and more shots when measurement noise dominates:
+
+- ``V`` is driven by the spread of the ``V`` directional samples — it needs no
+  backend variance, so it adapts on any cost function.
+- ``M`` is driven by the measurement-variance estimate the cost closure exposes
+  on shot-based backends. On native-expectation-value backends (no shot counts)
+  it falls back to a fixed ``M`` and ``V``-from-spread only.
+
+.. code-block:: python
+
+   from divi.qprog.optimizers import QUIVEROptimizer
+
+   optimizer = QUIVEROptimizer(learning_rate=0.1, epsilon=0.1, V_init=2)
+
+Set ``derivative_mode="parameter_shift"`` to use a :math:`\pi/2` directional shift
+instead of the finite-difference step ``epsilon``; set ``adapt_V=False`` /
+``adapt_M=False`` to pin a fixed budget. QUIVER shares SPSA's ``blocking`` and
+``exact_loss`` options, is gradient-free, and does not support checkpointing.
+
+.. note::
+
+   An adapting ``M`` delivers its per-evaluation shot budget to the backend as
+   explicit per-circuit shot groups, which disables circuit-template batching for
+   that submission. On template-capable backends (e.g. the Qoro cloud) this trades
+   template reuse for shot adaptivity — prefer ``adapt_M=False`` there if
+   submission overhead dominates, and reserve ``adapt_M`` for local shot-based
+   simulators. ``adapt_M`` also assumes a uniform per-group shot count, so it is
+   not combined with a configured ``shot_distribution`` (a warning is emitted).
+
+Use QUIVER when:
+
+- You want SPSA's constant-cost appeal but with a tunable accuracy/cost trade-off
+  via ``V``.
+- You want the per-step measurement budget to adapt automatically to shot noise.
+
 Grid Search
 -----------
 
@@ -396,6 +451,9 @@ Choosing the Right Optimizer
   cost; best for many-parameter circuits where exact gradients/metrics are too expensive
 - **SPSA**: Gradient-free with two evaluations per step; best for many-parameter,
   shot-noisy circuits
+- **QUIVER**: Forward-gradient generalization of SPSA with a tunable direction
+  count ``V`` and adaptive shot allocation; best when you want to trade gradient
+  accuracy against measurement budget on shot-based backends
 - **L-BFGS-B**: Best for smooth, differentiable landscapes with good initial parameters
 - **Monte Carlo**: Excellent for exploration and avoiding local minima
 - **COBYLA**: Good for constrained problems or when gradients are unreliable
@@ -408,6 +466,8 @@ Choosing the Right Optimizer
   Hamiltonian expectation loss
 - **QN-SPSA / SPSA**: Best for deep, many-layer QAOA on shot-noisy backends, where
   the constant per-step cost beats parameter-shift gradients
+- **QUIVER**: When you want SPSA's low per-step cost on shot-noisy QAOA but with a
+  tunable direction count and adaptive shot allocation
 - **COBYLA**: Often the best starting point for :class:`~divi.qprog.algorithms.QAOA` problems
 - **Nelder-Mead**: Good for noisy landscapes and parameter initialization
 - **Monte Carlo**: Excellent for global exploration and avoiding barren plateaus
@@ -574,3 +634,5 @@ References
 .. [#spall1992] Spall, J. C. (1992). Multivariate stochastic approximation using a simultaneous perturbation gradient approximation. *IEEE Transactions on Automatic Control*, 37(3), 332–341.
 
 .. [#gacon2021] Gacon, J., Zoufal, C., Carleo, G., & Woerner, S. (2021). Simultaneous perturbation stochastic approximation of the quantum Fisher information. *Quantum*, 5, 567.
+
+.. [#coyle2026] Coyle, B., Raj, S., Umathe, V., Cherrat, E. A., & Kashefi, E. (2026). Adaptive directional gradients for parameterised quantum circuits. *arXiv preprint* arXiv:2606.09734.

--- a/tests/pipeline/test_postprocessing.py
+++ b/tests/pipeline/test_postprocessing.py
@@ -11,6 +11,7 @@ from divi.pipeline import CircuitPipeline
 from divi.pipeline._compilation import _compile_batch
 from divi.pipeline._postprocessing import (
     _batched_expectation,
+    _counts_to_cost_variance,
     _counts_to_expvals,
     _counts_to_probs,
     _expval_dicts_to_indexed,
@@ -107,6 +108,76 @@ class TestCountsToExpvals:
             assert d[0] == pytest.approx(0.4)  # <Z0>
             assert d[1] == pytest.approx(0.6)  # <Z1>
             assert d[2] == pytest.approx(0.8)  # <Z2>
+
+
+class TestCountsToCostVariance:
+    """Spec: _counts_to_cost_variance estimates shot-noise variance of the cost
+    Var(<H>) = Σ_i c_i²(1 − <P_i>²)/M_g from raw counts."""
+
+    def _single_z_trace(self, dummy_pipeline_env):
+        """Forward pass for a single-qubit ``<Z0>`` cost (one measurement group).
+
+        Uses ``wires`` grouping so a real counts-measured group is produced; the
+        default would promote to the backend-native expval path (no counts), on
+        which ``_counts_to_cost_variance`` is never invoked.
+        """
+        qscript = qp.tape.QuantumScript(
+            ops=[qp.Identity(0)],
+            measurements=[qp.expval(qp.Z(0))],
+        )
+        pipeline = CircuitPipeline(
+            stages=[
+                DummySpecStage(meta=qscript_to_meta(qscript)),
+                MeasurementStage(grouping_strategy="wires"),
+            ]
+        )
+        trace = pipeline.run_forward_pass("x", dummy_pipeline_env)
+        _, lineage_by_label = _compile_batch(trace.final_batch)
+        return trace, lineage_by_label
+
+    def test_matches_analytic_formula(self, dummy_pipeline_env):
+        # <Z> = (75 - 25)/100 = 0.5, coeff = 1, M = 100
+        # Var = 1²·(1 - 0.5²)/100 = 0.0075
+        trace, lineage_by_label = self._single_z_trace(dummy_pipeline_env)
+        raw: ChildResults = {bk: {"0": 75, "1": 25} for bk in lineage_by_label.values()}
+        result = _counts_to_cost_variance(raw, trace.final_batch)
+        assert result
+        for v in result.values():
+            assert v == pytest.approx(0.0075)
+
+    def test_zero_shots_returns_nan(self, dummy_pipeline_env):
+        trace, lineage_by_label = self._single_z_trace(dummy_pipeline_env)
+        raw: ChildResults = {bk: {} for bk in lineage_by_label.values()}
+        result = _counts_to_cost_variance(raw, trace.final_batch)
+        assert result
+        assert all(np.isnan(v) for v in result.values())
+
+    def test_saturated_pauli_clamps_to_nonnegative_zero(self, dummy_pipeline_env):
+        # All shots in one eigenstate → <Z> = 1 → 1 − <Z>² = 0 (never negative).
+        trace, lineage_by_label = self._single_z_trace(dummy_pipeline_env)
+        raw: ChildResults = {bk: {"0": 100} for bk in lineage_by_label.values()}
+        result = _counts_to_cost_variance(raw, trace.final_batch)
+        assert result
+        for v in result.values():
+            assert v == pytest.approx(0.0)
+            assert v >= 0.0
+
+    def test_variance_scales_inversely_with_shots(self, dummy_pipeline_env):
+        trace, lineage_by_label = self._single_z_trace(dummy_pipeline_env)
+        raw_low: ChildResults = {
+            bk: {"0": 75, "1": 25} for bk in lineage_by_label.values()
+        }
+        raw_high: ChildResults = {
+            bk: {"0": 750, "1": 250} for bk in lineage_by_label.values()
+        }
+        var_low = next(
+            iter(_counts_to_cost_variance(raw_low, trace.final_batch).values())
+        )
+        var_high = next(
+            iter(_counts_to_cost_variance(raw_high, trace.final_batch).values())
+        )
+        # Same <Z>=0.5, 10× shots → exactly 10× smaller variance.
+        assert var_low == pytest.approx(10.0 * var_high)
 
 
 class TestBatchedExpectation:

--- a/tests/qprog/optimizers/test_quiver.py
+++ b/tests/qprog/optimizers/test_quiver.py
@@ -303,12 +303,144 @@ def _counting_sphere():
 
 
 def test_cost_fn_supports_variance_detection():
-    """Capability sniffing: ``**kwargs`` or an explicit ``return_variance``
-    parameter counts as supporting the variance channel; a plain callable
-    does not."""
-    assert _cost_fn_supports_variance(lambda x, **kwargs: x)
-    assert _cost_fn_supports_variance(lambda x, return_variance=False: x)
+    """Variance capability is declared by the producer via a ``supports_variance``
+    attribute, not inferred from the signature — so a flagged callable is
+    variance-capable while any unflagged callable, whatever its signature shape,
+    is not (no fragile signature sniffing)."""
+
+    def declared(params, *, shots=None, return_variance=False):
+        return params
+
+    setattr(declared, "supports_variance", True)
+    assert _cost_fn_supports_variance(declared)
+
+    # No flag → not variance-capable, regardless of signature.
+    assert not _cost_fn_supports_variance(
+        lambda x, shots=None, return_variance=False: x
+    )
+    assert not _cost_fn_supports_variance(lambda x, **kwargs: x)
     assert not _cost_fn_supports_variance(lambda x: x)
+
+
+def test_quiver_falls_back_for_partial_variance_signatures():
+    """A loss-only callable that merely happens to accept ``**kwargs`` or
+    ``return_variance`` must run via the plain (variance-free) path rather than
+    crashing on the ``shots`` keyword or a bad unpack."""
+    partial_callables = [
+        lambda p: _sphere(p),
+        lambda p, **kw: _sphere(p),
+        lambda p, return_variance=False: _sphere(p),
+    ]
+    for fn in partial_callables:
+        result = QUIVEROptimizer(V_init=2).optimize(
+            fn,
+            initial_params=np.array([1.0, 1.0]),
+            max_iterations=5,
+            rng=np.random.default_rng(0),
+        )
+        assert np.isfinite(result.fun[0])
+
+
+def test_quiver_parameter_shift_uses_half_prefactor():
+    """parameter_shift mode must recover the true parameter-shift gradient
+    (½·(f₊−f₋)), not the 2/π-scaled finite-difference value. On the sinusoidal
+    cost f(θ)=−cos(θ) (a stand-in for a real PQC, unlike the quadratic sphere
+    where ÷2ε is coincidentally exact) the analytic gradient is sin(θ); the
+    first step must move by learning_rate·sin(θ₀)."""
+
+    def cost(params):  # batch-aware: (k, 1) -> (k,)
+        return -np.cos(np.atleast_2d(params)).sum(axis=1)
+
+    theta0 = np.array([1.0])
+    captured = []
+    QUIVEROptimizer(
+        learning_rate=0.5,
+        V_init=1,
+        adapt_V=False,
+        adapt_M=False,
+        derivative_mode="parameter_shift",
+    ).optimize(
+        cost,
+        initial_params=theta0,
+        max_iterations=2,
+        callback_fn=lambda r: captured.append(np.atleast_1d(r.x.squeeze()).copy()),
+        rng=np.random.default_rng(0),
+    )
+    # Callback fires before each step; captured[1] is θ after the first step.
+    ghat = (theta0 - captured[1]) / 0.5
+    np.testing.assert_allclose(ghat, np.sin(theta0), atol=1e-6)
+
+
+def test_quiver_exact_loss_records_final_step():
+    """With exact_loss and no blocking, a final step that lowers the exact loss is
+    returned as best — not the stale start (best-tracking otherwise runs only
+    before each step)."""
+    start = np.array([1.0, 0.3])
+    result = QUIVEROptimizer(
+        learning_rate=0.5, epsilon=0.1, V_init=2, adapt_V=False, exact_loss=True
+    ).optimize(
+        _sphere,
+        initial_params=start,
+        max_iterations=1,
+        rng=np.random.default_rng(0),
+    )
+    assert result.fun[0] < _sphere(start)
+    assert not np.allclose(result.x, start)
+
+
+def test_quiver_clear_error_for_non_batch_aware_cost_fn():
+    """A cost fn that collapses the two-row perturbation batch to a single value
+    raises a clear error instead of a cryptic IndexError (shared SPSA path)."""
+
+    def not_batch_aware(params):
+        return float(np.sum(params**2))
+
+    with pytest.raises(ValueError, match="one value per batch row"):
+        QUIVEROptimizer(V_init=2).optimize(
+            not_batch_aware,
+            initial_params=np.array([1.0, 1.0]),
+            max_iterations=2,
+            rng=np.random.default_rng(0),
+        )
+
+
+def test_quiver_rejects_multistart_initial_params():
+    """Single-point optimizer: a multi-row (m, n) array is rejected with a clear
+    error rather than silently flattened or crashing on a broadcast mismatch."""
+    with pytest.raises(ValueError, match="single-point optimizer"):
+        QUIVEROptimizer(V_init=2).optimize(
+            _sphere,
+            initial_params=np.zeros((3, 2)),
+            max_iterations=2,
+            rng=np.random.default_rng(0),
+        )
+
+
+def test_quiver_accepts_single_row_2d_initial_params():
+    """A (1, n) array is accepted and returns a 1-D parameter vector."""
+    result = QUIVEROptimizer(V_init=2).optimize(
+        _sphere,
+        initial_params=np.array([[1.0, -0.5]]),
+        max_iterations=3,
+        rng=np.random.default_rng(0),
+    )
+    assert result.x.shape == (2,)
+
+
+def test_quiver_blocking_records_final_accepted_step():
+    """A step accepted on the final blocking iteration is returned as best, not
+    the stale starting point (mirrors the SPSA guard)."""
+    start = np.array([1.0, 0.3])
+    result = QUIVEROptimizer(
+        learning_rate=0.5, epsilon=0.1, V_init=2, adapt_V=False, blocking=True
+    ).optimize(
+        _sphere,
+        initial_params=start,
+        max_iterations=1,
+        rng=np.random.default_rng(0),
+    )
+    assert result.fun[0] < _sphere(start)
+    assert not np.allclose(result.x, start)
 
 
 def test_quiver_adapt_v_changes_evaluation_count():
@@ -363,8 +495,9 @@ def test_quiver_blocking_converges_on_sphere():
 
 
 def test_quiver_exact_loss_spends_one_extra_evaluation_per_step():
-    """``exact_loss`` adds one unperturbed cost call per step on top of the
-    ``V`` perturbation calls (V fixed at 2, adaptation off)."""
+    """``exact_loss`` adds one unperturbed cost call per step on top of the ``V``
+    perturbation calls, plus a single final-iterate evaluation after the loop
+    (so best-tracking covers the last step). V fixed at 2, adaptation off."""
     calls_base, fn_base = _counting_sphere()
     QUIVEROptimizer(V_init=2, adapt_V=False, adapt_M=False, exact_loss=False).optimize(
         fn_base,
@@ -380,7 +513,8 @@ def test_quiver_exact_loss_spends_one_extra_evaluation_per_step():
         rng=np.random.default_rng(0),
     )
     assert calls_base["n"] == 2 * 5
-    assert calls_exact["n"] == calls_base["n"] + 5
+    # 5 per-step unperturbed evals + 1 final-iterate eval.
+    assert calls_exact["n"] == calls_base["n"] + 5 + 1
 
 
 def test_quiver_adapt_m_updates_shot_budget_to_backend():

--- a/tests/qprog/optimizers/test_quiver.py
+++ b/tests/qprog/optimizers/test_quiver.py
@@ -1,0 +1,500 @@
+# SPDX-FileCopyrightText: 2025-2026 Qoro Quantum Ltd <divi@qoroquantum.de>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the QUIVER optimizer (forward gradients, arXiv 2606.09734) and the
+per-evaluation shot-budget + measurement-variance channel that powers its
+adaptive ``M`` allocation."""
+
+import networkx as nx
+import numpy as np
+import pytest
+from qiskit.circuit.library import RYGate, RZGate
+from qiskit.quantum_info import SparsePauliOp
+
+from divi.backends import QiskitSimulator
+from divi.qprog import QAOA, VQE, QUIVEROptimizer
+from divi.qprog.algorithms import GenericLayerAnsatz
+from divi.qprog.optimizers._spsa import _cost_fn_supports_variance, _spsa_gradient
+from divi.qprog.problems import MaxCutProblem
+from tests.qprog.optimizers._contracts import sphere_cost_fn_batch_aware as _sphere
+
+# --------------------------------------------------------------------------- #
+# Forward-gradient optimizer
+# --------------------------------------------------------------------------- #
+
+
+def test_quiver_forward_gradient_recovers_gradient():
+    """Averaging V Rademacher directional derivatives converges to ∇f. On the
+    sphere ∇f = 2θ; the V→large forward-gradient estimate approaches it."""
+    theta = np.array([0.5, -1.0, 2.0])
+    rng = np.random.default_rng(0)
+    ghats = [_spsa_gradient(_sphere, theta, 0.1, rng)[0] for _ in range(2000)]
+    estimate = np.mean(ghats, axis=0)
+    np.testing.assert_allclose(estimate, 2.0 * theta, atol=0.1)
+
+
+def test_quiver_converges_on_sphere():
+    opt = QUIVEROptimizer(learning_rate=0.3, epsilon=0.1, V_init=2, V_max=8)
+    result = opt.optimize(
+        _sphere,
+        initial_params=np.array([1.5, -1.2, 0.8]),
+        max_iterations=200,
+        rng=np.random.default_rng(0),
+    )
+    assert result.fun[0] < 0.05
+    assert result.x.shape == (3,)
+    assert result.success
+
+
+def test_quiver_parameter_shift_mode_converges():
+    """The π/2 directional shift drives the parameters to the minimum. The
+    recorded ``fun`` is the perturbation-average proxy, biased by O(shift²) — so
+    convergence is asserted on the recovered parameters, not the proxy value."""
+    opt = QUIVEROptimizer(
+        learning_rate=0.2, V_init=2, V_max=8, derivative_mode="parameter_shift"
+    )
+    result = opt.optimize(
+        _sphere,
+        initial_params=np.array([1.0, -0.8]),
+        max_iterations=200,
+        rng=np.random.default_rng(1),
+    )
+    assert np.linalg.norm(result.x) < 0.1
+
+
+def test_quiver_v_adaptivity_without_variance_handle():
+    """V-adaptivity is driven by the spread of the V samples, so it works (and
+    converges) even when cost_fn exposes no measurement-variance channel."""
+    calls = {"n": 0}
+
+    def counting(params):
+        calls["n"] += 1
+        return _sphere(params)
+
+    result = QUIVEROptimizer(
+        learning_rate=0.3, epsilon=0.1, V_init=2, V_min=1, V_max=10, adapt_V=True
+    ).optimize(
+        counting,
+        initial_params=np.array([1.5, -1.0, 0.7]),
+        max_iterations=60,
+        rng=np.random.default_rng(0),
+    )
+    assert result.fun[0] < 0.1
+    # Each step costs V_k cost calls (one two-row batch per direction); with
+    # V_k >= 1 over 60 steps the run makes at least 60 calls. Whether V grows or
+    # shrinks is landscape-dependent; that adaptivity *moves* V is asserted
+    # separately in test_quiver_adapt_v_changes_evaluation_count.
+    assert calls["n"] >= 60
+
+
+def test_quiver_ignores_jac_and_metric_fn():
+    result = QUIVEROptimizer(learning_rate=0.3, V_init=2).optimize(
+        _sphere,
+        initial_params=np.array([1.0, 1.0]),
+        max_iterations=20,
+        rng=np.random.default_rng(0),
+        jac=lambda x: 1 / 0,  # never called
+        metric_fn=lambda x: 1 / 0,
+    )
+    assert np.isfinite(result.fun[0])
+
+
+def test_quiver_callback_receives_2d_x_and_1d_fun():
+    captured = []
+    QUIVEROptimizer(V_init=2).optimize(
+        _sphere,
+        initial_params=np.array([1.0, 2.0]),
+        callback_fn=lambda res: captured.append((res.x, res.fun)),
+        max_iterations=4,
+        rng=np.random.default_rng(0),
+    )
+    assert len(captured) == 4
+    for x, fun in captured:
+        assert x.shape == (1, 2)
+        assert fun.shape == (1,)
+
+
+def test_quiver_callback_stop_iteration_propagates():
+    def callback(res):
+        if res.nit == 2:
+            raise StopIteration
+
+    with pytest.raises(StopIteration):
+        QUIVEROptimizer().optimize(
+            _sphere,
+            initial_params=np.array([1.0, 2.0]),
+            callback_fn=callback,
+            max_iterations=10,
+            rng=np.random.default_rng(0),
+        )
+
+
+def test_quiver_requires_initial_params():
+    with pytest.raises(ValueError, match="requires initial_params"):
+        QUIVEROptimizer().optimize(_sphere, initial_params=None, max_iterations=3)
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        ({"learning_rate": 0.0}, "learning_rate must be positive"),
+        ({"epsilon": -0.1}, "c must be positive"),
+        ({"V_init": 0}, "resamplings must be >= 1"),
+        ({"V_min": 2, "V_init": 1}, "V_min <= V_init <= V_max"),
+        ({"V_max": 1, "V_init": 2}, "V_min <= V_init <= V_max"),
+        ({"M_min": 5, "M_init": 1}, "M_min <= M_init <= M_max"),
+        ({"mu": 1.0}, "mu must be in"),
+        ({"lipschitz": 0.0}, "lipschitz must be positive"),
+        ({"derivative_mode": "nope"}, "derivative_mode must be"),
+    ],
+)
+def test_quiver_constructor_validation(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        QUIVEROptimizer(**kwargs)
+
+
+def test_quiver_does_not_support_checkpointing(tmp_path):
+    opt = QUIVEROptimizer()
+    assert opt.supports_checkpointing is False
+    with pytest.raises(NotImplementedError):
+        opt.get_config()
+    with pytest.raises(NotImplementedError):
+        opt.save_state(tmp_path)
+    with pytest.raises(NotImplementedError):
+        QUIVEROptimizer.load_state(tmp_path)
+    opt.reset()  # no-op
+
+
+def test_copy_preserves_quiver_config():
+    opt = QUIVEROptimizer(
+        learning_rate=0.05,
+        epsilon=0.2,
+        V_init=3,
+        M_init=250,
+        derivative_mode="parameter_shift",
+    )
+    clone = opt.copy()
+    assert isinstance(clone, QUIVEROptimizer)
+    assert clone.learning_rate == 0.05
+    assert clone.epsilon == 0.2
+    assert clone.V_init == 3
+    assert clone.M_init == 250
+    assert clone.derivative_mode == "parameter_shift"
+    assert clone.adapt_V is True
+    assert clone.adapt_M is True
+
+
+def test_quiver_warns_once_when_step_leaves_stability_regime():
+    """L*a_k >= 2 (here L=2 via lipschitz, a_k=1) leaves the gCANS regime and
+    warns exactly once over the whole run, not once per step."""
+    with pytest.warns(UserWarning, match="gCANS stability") as record:
+        QUIVEROptimizer(learning_rate=1.0, lipschitz=2.0, V_init=2).optimize(
+            _sphere,
+            initial_params=np.array([1.0, 1.0]),
+            max_iterations=3,
+            rng=np.random.default_rng(0),
+        )
+    assert sum("gCANS stability" in str(w.message) for w in record) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Integration with a shot-based VQE — the realistic QUIVER setting
+# --------------------------------------------------------------------------- #
+
+
+def _shot_based_vqe():
+    """A VQE on a shot-based simulator, where the cost closure can expose a
+    measurement-variance estimate and honour a per-evaluation shot budget."""
+    return VQE(
+        hamiltonian=SparsePauliOp.from_list([("ZI", 0.5), ("IZ", -0.3), ("XX", 0.2)]),
+        ansatz=GenericLayerAnsatz([RYGate, RZGate]),
+        n_layers=1,
+        backend=QiskitSimulator(shots=4000, force_sampling=True),
+        seed=1997,
+    )
+
+
+def test_quiver_runs_under_vqe():
+    vqe = _shot_based_vqe()
+    vqe.backend.set_seed(1997)
+    vqe.optimizer = QUIVEROptimizer(learning_rate=0.2, epsilon=0.1, V_init=2)
+    vqe.max_iterations = 8
+    vqe.run(perform_final_computation=False)
+    assert len(vqe.losses_history) == 8
+    assert np.isfinite(vqe.best_loss)
+
+
+# --------------------------------------------------------------------------- #
+# Per-evaluation shot budget + measurement-variance channel
+# --------------------------------------------------------------------------- #
+
+
+def test_shots_override_threads_to_backend_without_mutation():
+    """A per-evaluation ``shots`` budget reaches the backend as ``shot_groups``
+    and never mutates the immutable backend's configured ``shots``."""
+    vqe = _shot_based_vqe()
+    vqe.backend.set_seed(7)
+    theta = np.linspace(0.1, 1.0, vqe.n_layers * vqe.n_params_per_layer)
+
+    captured = {}
+    original = vqe.backend.submit_circuits
+
+    def spy(circuits, **kwargs):
+        captured["shot_groups"] = kwargs.get("shot_groups")
+        return original(circuits, **kwargs)
+
+    vqe.backend.submit_circuits = spy
+
+    vqe._evaluate_cost_param_sets(theta[None, :], shots=512)
+    # Every emitted [start, end, shots] triple carries the override budget.
+    assert captured["shot_groups"] is not None
+    assert all(triple[2] == 512 for triple in captured["shot_groups"])
+    assert vqe.backend.shots == 4000  # unchanged
+
+
+def test_cost_variance_is_positive_and_scales_inversely_with_shots():
+    """The returned shot-noise variance is finite and positive, and shrinks ~1/M
+    as the per-evaluation shot budget grows."""
+    vqe = _shot_based_vqe()
+    vqe.backend.set_seed(7)
+    theta = np.linspace(0.1, 1.0, vqe.n_layers * vqe.n_params_per_layer)
+
+    var_low = vqe._cost_shot_variances(
+        vqe._evaluate_cost_param_sets(theta[None, :], shots=500, collect_variance=True)
+    )
+    var_high = vqe._cost_shot_variances(
+        vqe._evaluate_cost_param_sets(theta[None, :], shots=8000, collect_variance=True)
+    )
+    assert np.isfinite(var_low[0]) and var_low[0] > 0
+    assert np.isfinite(var_high[0]) and var_high[0] > 0
+    # 16× shots → variance drops ~16×; wide band because the estimate is itself
+    # shot-noisy. The exact 1/M coefficient is pinned in
+    # test_counts_to_cost_variance_matches_analytic_formula instead.
+    assert 3.0 < var_low[0] / var_high[0] < 80.0
+
+
+def test_cost_variance_is_nan_on_native_expval_backend():
+    """On a native-expval backend no counts are produced, so the variance is nan
+    and QUIVER falls back to fixed-M (V-from-spread only)."""
+    vqe = VQE(
+        hamiltonian=SparsePauliOp.from_list([("ZI", 0.5), ("IZ", -0.3), ("XX", 0.2)]),
+        ansatz=GenericLayerAnsatz([RYGate, RZGate]),
+        n_layers=1,
+        backend=QiskitSimulator(shots=4000),  # analytic expval, no force_sampling
+        seed=1997,
+    )
+    theta = np.linspace(0.1, 1.0, vqe.n_layers * vqe.n_params_per_layer)
+    variances = vqe._cost_shot_variances(
+        vqe._evaluate_cost_param_sets(theta[None, :], collect_variance=True)
+    )
+    assert np.isnan(variances[0])
+
+
+def _counting_sphere():
+    """A ``_sphere`` wrapper that counts how many times it is called."""
+    calls = {"n": 0}
+
+    def fn(params):
+        calls["n"] += 1
+        return _sphere(params)
+
+    return calls, fn
+
+
+def test_cost_fn_supports_variance_detection():
+    """Capability sniffing: ``**kwargs`` or an explicit ``return_variance``
+    parameter counts as supporting the variance channel; a plain callable
+    does not."""
+    assert _cost_fn_supports_variance(lambda x, **kwargs: x)
+    assert _cost_fn_supports_variance(lambda x, return_variance=False: x)
+    assert not _cost_fn_supports_variance(lambda x: x)
+
+
+def test_quiver_adapt_v_changes_evaluation_count():
+    """Adaptivity moves ``V``: an adaptive run spends a different number of cost
+    evaluations than the fixed-``V`` run it would otherwise match."""
+    calls_fixed, fn_fixed = _counting_sphere()
+    QUIVEROptimizer(
+        learning_rate=0.3, V_init=2, V_max=10, adapt_V=False, adapt_M=False
+    ).optimize(
+        fn_fixed,
+        initial_params=np.array([1.5, -1.0, 0.7]),
+        max_iterations=60,
+        rng=np.random.default_rng(0),
+    )
+    calls_adaptive, fn_adaptive = _counting_sphere()
+    QUIVEROptimizer(
+        learning_rate=0.3, V_init=2, V_min=1, V_max=10, adapt_V=True, adapt_M=False
+    ).optimize(
+        fn_adaptive,
+        initial_params=np.array([1.5, -1.0, 0.7]),
+        max_iterations=60,
+        rng=np.random.default_rng(0),
+    )
+    assert calls_fixed["n"] == 2 * 60  # fixed V_init=2 over 60 steps
+    assert calls_adaptive["n"] != calls_fixed["n"]
+
+
+def test_quiver_fixed_budget_converges_on_sphere():
+    """With both adaptations off QUIVER is a fixed-V forward-gradient method and
+    still converges."""
+    result = QUIVEROptimizer(
+        learning_rate=0.3, V_init=3, adapt_V=False, adapt_M=False
+    ).optimize(
+        _sphere,
+        initial_params=np.array([1.5, -1.2, 0.8]),
+        max_iterations=200,
+        rng=np.random.default_rng(0),
+    )
+    assert result.fun[0] < 0.05
+
+
+def test_quiver_blocking_converges_on_sphere():
+    """Blocking routes the candidate evaluation through the variance-stashing
+    ``cost_only`` adapter; the run must still converge."""
+    result = QUIVEROptimizer(learning_rate=0.3, V_init=2, blocking=True).optimize(
+        _sphere,
+        initial_params=np.array([1.5, -1.2, 0.8]),
+        max_iterations=200,
+        rng=np.random.default_rng(0),
+    )
+    assert result.fun[0] < 0.1
+
+
+def test_quiver_exact_loss_spends_one_extra_evaluation_per_step():
+    """``exact_loss`` adds one unperturbed cost call per step on top of the
+    ``V`` perturbation calls (V fixed at 2, adaptation off)."""
+    calls_base, fn_base = _counting_sphere()
+    QUIVEROptimizer(V_init=2, adapt_V=False, adapt_M=False, exact_loss=False).optimize(
+        fn_base,
+        initial_params=np.array([1.0, 1.0]),
+        max_iterations=5,
+        rng=np.random.default_rng(0),
+    )
+    calls_exact, fn_exact = _counting_sphere()
+    QUIVEROptimizer(V_init=2, adapt_V=False, adapt_M=False, exact_loss=True).optimize(
+        fn_exact,
+        initial_params=np.array([1.0, 1.0]),
+        max_iterations=5,
+        rng=np.random.default_rng(0),
+    )
+    assert calls_base["n"] == 2 * 5
+    assert calls_exact["n"] == calls_base["n"] + 5
+
+
+def test_quiver_adapt_m_updates_shot_budget_to_backend():
+    """The headline feature: with ``adapt_M`` the per-evaluation shot budget
+    forwarded to the backend changes across iterations (the closed loop)."""
+    vqe = _shot_based_vqe()
+    vqe.backend.set_seed(11)
+    vqe.optimizer = QUIVEROptimizer(
+        learning_rate=0.2, epsilon=0.1, V_init=2, M_init=80, M_min=10, M_max=5000
+    )
+    vqe.max_iterations = 10
+
+    seen_shots: list[int] = []
+    original = vqe.backend.submit_circuits
+
+    def spy(circuits, **kwargs):
+        shot_groups = kwargs.get("shot_groups")
+        if shot_groups:
+            seen_shots.extend(triple[2] for triple in shot_groups)
+        return original(circuits, **kwargs)
+
+    vqe.backend.submit_circuits = spy
+    vqe.run(perform_final_computation=False)
+    # M starts at M_init and the adaptation moves it at least once.
+    assert len(set(seen_shots)) >= 2
+
+
+def test_quiver_adapt_m_warns_with_shot_distribution():
+    """``adapt_M`` assumes uniform per-group shots; combining it with a shot
+    distribution is flagged at program-validation time."""
+    vqe = _shot_based_vqe()
+    vqe._shot_distribution = "weighted"
+    with pytest.warns(UserWarning, match="shot_distribution"):
+        QUIVEROptimizer(adapt_M=True).validate_program(vqe)
+
+
+def test_quiver_no_shot_distribution_warning_when_safe(recwarn):
+    """No shot-distribution warning when ``adapt_M`` is off or no distribution
+    is configured."""
+    vqe = _shot_based_vqe()
+    QUIVEROptimizer(adapt_M=True).validate_program(vqe)  # no distribution
+    vqe._shot_distribution = "weighted"
+    QUIVEROptimizer(adapt_M=False).validate_program(vqe)  # adaptation off
+    assert not [w for w in recwarn if "shot_distribution" in str(w.message)]
+
+
+def test_quiver_runs_under_qaoa_with_variance():
+    """QAOA's cost is an expectation measurement, so the variance channel
+    populates and M-adaptation works there as it does for VQE."""
+    qaoa = QAOA(
+        MaxCutProblem(nx.bull_graph()),
+        n_layers=1,
+        optimizer=QUIVEROptimizer(learning_rate=0.2, epsilon=0.1, V_init=2),
+        max_iterations=5,
+        backend=QiskitSimulator(shots=2000, force_sampling=True),
+    )
+    qaoa.run(perform_final_computation=False)
+    assert len(qaoa.losses_history) == 5
+    assert np.isfinite(qaoa.best_loss)
+    assert qaoa._last_cost_variance is not None
+
+
+def test_variance_nan_when_keys_collapse_across_extra_axes(mocker):
+    """A pipeline with reduce axes beyond ``param_set`` (e.g. ZNE scales) yields
+    several variance entries per parameter set; they cannot be collapsed to one
+    scalar, so the variance is reported as nan and the optimizer falls back."""
+    vqe = _shot_based_vqe()
+    fake_result = {(("circuit", 0), ("param_set", 0)): np.array([0.5])}
+    mocker.patch.object(vqe, "_run_pipeline", return_value=fake_result)
+    vqe._last_cost_variance = {
+        (("circuit", 0), ("zne_scale", 1), ("param_set", 0)): 0.01,
+        (("circuit", 0), ("zne_scale", 3), ("param_set", 0)): 0.04,
+    }
+    theta = np.zeros((1, vqe.n_layers * vqe.n_params_per_layer))
+    variances = vqe._cost_shot_variances(
+        vqe._evaluate_cost_param_sets(theta, collect_variance=True)
+    )
+    assert np.isnan(variances[0])
+
+
+def _analytic_vqe():
+    """A VQE on an analytic backend — its cost pipeline promotes to the
+    backend-native expval path (uses ham_ops, ignores shots)."""
+    return VQE(
+        hamiltonian=SparsePauliOp.from_list([("ZI", 0.5), ("IZ", -0.3), ("XX", 0.2)]),
+        ansatz=GenericLayerAnsatz([RYGate, RZGate]),
+        n_layers=1,
+        backend=QiskitSimulator(shots=4000),
+        seed=1997,
+    )
+
+
+def test_shots_override_is_ignored_on_analytic_expval_backend():
+    """A per-evaluation shots override on the backend-native expval path is a
+    no-op (analytic expval ignores shots), not a ham_ops/shot_groups crash."""
+    vqe = _analytic_vqe()
+    theta = np.linspace(0.1, 1.0, vqe.n_layers * vqe.n_params_per_layer)
+    losses = vqe._evaluate_cost_param_sets(
+        theta[None, :], shots=128, collect_variance=True
+    )
+    variances = vqe._cost_shot_variances(losses)
+    assert np.isfinite(losses[0])
+    assert np.isnan(variances[0])
+
+
+def test_quiver_runs_on_analytic_backend():
+    """QUIVER always sends a shots override; on an analytic backend that override
+    must be silently ignored rather than crashing, with variance falling back to
+    nan (fixed-M, V-from-spread only)."""
+    vqe = _analytic_vqe()
+    vqe.optimizer = QUIVEROptimizer(
+        learning_rate=0.2, epsilon=0.1, V_init=2, adapt_M=True
+    )
+    vqe.max_iterations = 6
+    vqe.run(perform_final_computation=False)
+    assert len(vqe.losses_history) == 6
+    assert np.isfinite(vqe.best_loss)


### PR DESCRIPTION
## What

Implements **QUIVER** (arXiv 2606.09734, *Adaptive Directional Gradients for Parameterised Quantum Circuits*) — a forward-gradient optimizer that reconstructs the gradient from `V` random Rademacher directional derivatives (each a 2-eval finite-difference shift), with a closed-form adaptive `(V, M)` allocation. It generalizes SPSA (`V=1`) and the parameter-shift rule (`V=N`) under one tunable `V`.

`QUIVEROptimizer` lives in `divi/qprog/optimizers/_spsa.py` (reusing the SPSA gain/blocking mixin) and is exported from `divi.qprog`.

## Measurement-variance / shots channel

To drive QUIVER's adaptive shot count `M`, the cost pipeline gained an optional per-evaluation channel:

- `PipelineEnv.shots_override` / `collect_variance` + `effective_shots`
- `MeasurementStage` materializes the override as per-group shots and estimates the shot-noise cost variance (`_counts_to_cost_variance`)
- `VariationalQuantumAlgorithm._evaluate_cost_param_sets` gains `shots` / `collect_variance`, with `_cost_shot_variances` mapping variance back to each parameter set

Because QAOA's cost is itself an `EXPVALS` measurement, this covers VQE, CustomVQA, the QNG metric pipeline, **and** QAOA. On analytic / native-expval backends the override is ignored and variance is `nan`, so QUIVER degrades gracefully to fixed-`M`, V-from-spread.

## Validation

- New `tests/qprog/optimizers/test_quiver.py` (convergence, derivative modes, adaptive V/M, blocking, exact_loss, shot-override threading, analytic-backend fallback, key-collapse → nan) and `_counts_to_cost_variance` unit tests in `test_postprocessing.py`.
- Reviewed by the numerical-accuracy, quantum-architect, pythonic, test-quality, and devil's-advocate passes; their findings (numerical guards, the variance-key collapse fallback, the `L·a_k ≥ 2` stability warning, the dual-return cleanup) are addressed.
- Adversarial numerical sweep (VQE/QAOA, exact-Trotter vs QDrift, depolarizing-noise backends, pathological learning rates) confirms descent, robustness, and that the adaptive-`M` loop closes. This surfaced and fixed a crash where QUIVER's shot override conflicted with `ham_ops` on analytic backends.

## Note

`derivative_mode="parameter_shift"` (π/2 directional step) is exact only on quadratic landscapes / basis directions; on real VQE landscapes it is too coarse to descend (stays finite/bounded). `finite_diff` is the default and recommended mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
