### PR TITLE
feat(qprog): community-based QUBO decomposition via CommunityDecomposer

### DIFF
--- a/divi/qprog/problems/__init__.py
+++ b/divi/qprog/problems/__init__.py
@@ -5,8 +5,8 @@
 """Problem classes for QAOA-compatible quantum optimization."""
 
 from ._base import QAOAProblem
-from ._graph_partitioning_utils import GraphPartitioningConfig, draw_partitions
 from ._binary import BinaryOptimizationProblem
+from ._graph_partitioning_utils import GraphPartitioningConfig, draw_partitions
 from ._graphs import (
     MaxCliqueProblem,
     MaxCutProblem,
@@ -20,6 +20,7 @@ from ._matching import (
     check_matching_matrix,
     is_valid_matching,
 )
+from ._qubo_partitioning_utils import CommunityDecomposer
 from ._routing import (
     BinaryBlockConfig,
     CVRPProblem,
@@ -38,6 +39,7 @@ __all__ = [
     "BinaryBlockConfig",
     "BinaryOptimizationProblem",
     "CVRPProblem",
+    "CommunityDecomposer",
     "GraphPartitioningConfig",
     "MaxCliqueProblem",
     "MaxCutProblem",

--- a/divi/qprog/problems/_binary.py
+++ b/divi/qprog/problems/_binary.py
@@ -24,6 +24,7 @@ from divi.hamiltonians import (
     x_mixer,
 )
 from divi.qprog.problems import QAOAProblem
+from divi.qprog.problems._qubo_partitioning_utils import bqm_to_sparse
 
 
 def _merge_substates(_, substates):
@@ -87,6 +88,23 @@ def _combine_polynomial_terms(cost_canonical, penalty_canonical, penalty_weight:
     return terms
 
 
+def _induced_sub_qubo(bqm, variables):
+    """Sub-QUBO induced on ``variables``, relabeled to local indices ``0..m-1``.
+
+    Keeps the linear biases of ``variables`` and the quadratic biases between them;
+    couplings crossing the ``variables`` boundary are dropped.
+    """
+    local = {v: i for i, v in enumerate(variables)}
+    cset = set(variables)
+    linear = {local[v]: bqm.linear[v] for v in variables}
+    quadratic = {
+        (local[u], local[v]): q
+        for (u, v), q in bqm.quadratic.items()
+        if u in cset and v in cset
+    }
+    return dimod.BinaryQuadraticModel(linear, quadratic, 0.0, dimod.Vartype.BINARY)
+
+
 class BinaryOptimizationProblem(QAOAProblem):
     """Generic QUBO or HUBO problem for QAOA.
 
@@ -117,9 +135,11 @@ class BinaryOptimizationProblem(QAOAProblem):
       ``quadratization_strength``; ``None`` picks
       ``2 * max(|hubo coeff|)``.
 
-    Optionally accepts a ``dimod.hybrid`` decomposer/composer pair to
-    enable partitioned solving via :meth:`decompose`. Without one, the
-    decomposition-related methods raise ``RuntimeError``.
+    Optionally accepts a ``dimod.hybrid`` decomposer/composer pair to enable
+    partitioned solving via :meth:`decompose`. For structure-aware decomposition of
+    QUBOs with community structure, pass
+    :class:`~divi.qprog.problems.CommunityDecomposer` as the ``decomposer``.
+    Without a decomposer, the decomposition-related methods raise ``RuntimeError``.
 
     Args:
         problem: Objective/cost QUBO matrix, BQM, HUBO dict, or BinaryPolynomial.
@@ -144,6 +164,9 @@ class BinaryOptimizationProblem(QAOAProblem):
         composer: Optional ``hybrid.traits.SubsamplesComposer`` for
             recombining sub-solutions; defaults to
             ``hybrid.SplatComposer``.
+        local_search: If ``True``, refine each aggregated candidate to a local
+            minimum by greedy single-bit-flip descent against the full QUBO.
+            Works with any ``decomposer``.
 
     Examples:
         >>> import numpy as np
@@ -163,6 +186,7 @@ class BinaryOptimizationProblem(QAOAProblem):
         quadratization_strength: float | None = None,
         decomposer: hybrid.traits.ProblemDecomposer | None = None,
         composer: hybrid.traits.SubsamplesComposer | None = None,
+        local_search: bool = False,
     ):
         if hamiltonian_builder not in ("native", "quadratized"):
             raise ValueError(
@@ -201,7 +225,14 @@ class BinaryOptimizationProblem(QAOAProblem):
         self._mixer_cache: SparsePauliOp | None = None
 
         # Decomposition support (optional)
+        if local_search and decomposer is None:
+            raise ValueError(
+                "local_search requires a decomposer; it polishes the aggregated "
+                "solution produced during partitioned solving."
+            )
         self._decomposer = decomposer
+        self._local_search = bool(local_search)
+        self._polish_cache: tuple | None = None
         self._bqm: dimod.BinaryQuadraticModel | None
         if decomposer is not None:
             _, self._bqm = _sanitize_problem_input(self._raw_problem)
@@ -315,9 +346,8 @@ class BinaryOptimizationProblem(QAOAProblem):
         """Partition the problem using the configured ``hybrid`` decomposer.
 
         Each non-trivial partition becomes its own
-        :class:`BinaryOptimizationProblem` keyed by ``(name, size)``.
-        Partitions with no interactions are tracked internally and
-        skipped during composition.
+        :class:`BinaryOptimizationProblem` keyed by ``(name, size)``. Partitions
+        with no interactions are tracked internally and skipped during composition.
 
         Raises:
             ValueError: If no decomposer was provided at construction.
@@ -354,22 +384,11 @@ class BinaryOptimizationProblem(QAOAProblem):
                 self._trivial_program_ids.add(prog_id)
                 continue
 
-            ldata, (irow, icol, qdata), _ = partition.subproblem.to_numpy_vectors(
-                partition.subproblem.variables
+            sub_problems[prog_id] = BinaryOptimizationProblem(
+                _induced_sub_qubo(
+                    partition.subproblem, list(partition.subproblem.variables)
+                )
             )
-
-            coo_mat = sps.coo_matrix(
-                (
-                    np.r_[ldata, qdata],
-                    (
-                        np.r_[np.arange(len(ldata)), icol],
-                        np.r_[np.arange(len(ldata)), irow],
-                    ),
-                ),
-                shape=(len(ldata), len(ldata)),
-            )
-
-            sub_problems[prog_id] = BinaryOptimizationProblem(coo_mat)
 
         return sub_problems
 
@@ -426,16 +445,23 @@ class BinaryOptimizationProblem(QAOAProblem):
     def postprocess_candidates(
         self, candidates: list[tuple[float, list[int]]], *, strict: bool = False
     ) -> list[tuple[np.ndarray, float]]:
-        """Run global candidate solutions through the configured composer.
+        """Compose global candidate solutions into ``(solution, energy)`` pairs.
+
+        With ``local_search=True`` each candidate is refined to a local minimum by
+        greedy single-bit-flip descent against the full QUBO; otherwise the
+        dwave-hybrid composer is run.
 
         Returns:
-            Tuples ``(composed_solution, energy)`` where
-            ``composed_solution`` is an ``int32`` ndarray of bits and
-            ``energy`` is the objective value computed by the composer.
+            Tuples ``(solution, energy)`` where ``solution`` is an ``int32`` ndarray
+            of bits, sorted ascending by ``energy``.
         """
-        composed = [self._compose_solution(sol) for _score, sol in candidates]
-        composed.sort(key=lambda entry: entry[1])
-        return composed
+        if self._local_search:
+            results = [self._greedy_bit_flip(sol) for _score, sol in candidates]
+        else:
+            results = [self._compose_solution(sol) for _score, sol in candidates]
+
+        results.sort(key=lambda entry: entry[1])
+        return results
 
     def _compose_solution(self, solution):
         """Run a single solution through the hybrid composer pipeline."""
@@ -460,3 +486,49 @@ class BinaryOptimizationProblem(QAOAProblem):
 
         sol, energy, _ = final_state.samples.record[0]
         return np.array(sol, dtype=np.int32), float(energy)
+
+    def _polish_fields(self):
+        """Cache ``(h, J, J_csc, tol)`` for the incremental single-bit-flip polish.
+
+        ``tol`` is a PER-NODE improvement threshold, ``1e-12 * (|h_i| + sum_j
+        |J[i,j]|)``. The incremental field's floating-point drift scales with each
+        node's *local* field magnitude, so a per-node bound stays above the drift
+        where couplings are large without desensitizing low-scale nodes elsewhere
+        (a single global bound would let one huge outlier coupling reject genuine
+        improvements across the whole problem).
+        """
+        if self._polish_cache is None:
+            _variables, h, j = bqm_to_sparse(self._bqm)
+            j_abs = j.copy()
+            j_abs.data = np.abs(j_abs.data)
+            node_scale = np.abs(h) + np.asarray(j_abs.sum(axis=1)).ravel()
+            tol = 1e-12 * np.maximum(1.0, node_scale)
+            self._polish_cache = (h, j, j.tocsc(), tol)
+        return self._polish_cache
+
+    def _greedy_bit_flip(self, solution) -> tuple[np.ndarray, float]:
+        """Greedy single-bit-flip descent to a local minimum of the full BQM.
+
+        Maintains an incremental effective field ``g = h + J @ x`` and updates only a
+        flipped variable's neighbors, so cost scales with the number of couplings. The
+        per-node improvement threshold (see :meth:`_polish_fields`) stays above the
+        incremental field's floating-point drift at any coefficient scale.
+        """
+        h, j, jc, tol = self._polish_fields()
+        x = np.array(solution, dtype=np.float64)
+        g = h + j.dot(x)
+        indptr, indices, data = jc.indptr, jc.indices, jc.data
+
+        improved = True
+        while improved:
+            improved = False
+            for i in range(len(x)):
+                if (1 - 2 * x[i]) * g[i] < -tol[i]:
+                    dx = 1 - 2 * x[i]
+                    x[i] = 1 - x[i]
+                    s, e = indptr[i], indptr[i + 1]
+                    g[indices[s:e]] += data[s:e] * dx
+                    improved = True
+
+        bits = x.astype(np.int32)
+        return bits, self.evaluate_global_solution(bits.tolist())

--- a/divi/qprog/problems/_qubo_partitioning_utils.py
+++ b/divi/qprog/problems/_qubo_partitioning_utils.py
@@ -1,0 +1,393 @@
+# SPDX-FileCopyrightText: 2025-2026 Qoro Quantum Ltd <divi@qoroquantum.de>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Structure-aware QUBO partitioning via signed multi-view spectral clustering.
+
+Operates directly on the sparse *signed interaction matrix* ``Sigma`` of a QUBO
+(``Sigma[i, j]`` = quadratic coefficient of variables ``i, j``), so no graph
+object is constructed. Strongly-coupled variables are grouped together and weak
+inter-cluster couplings are cut, which minimizes the energy lost when a QUBO is
+decomposed into independently-solved sub-problems.
+
+Two clustering methods are provided. The default *modularity* method runs Louvain
+community detection on the coupling-magnitude graph, auto-selecting the community
+count. The *signed multi-view spectral* method splits ``Sigma`` into a positive
+("repulsive") and negative ("attractive") view, builds the normalized Laplacian of
+each, concatenates their leading spectral features, and runs k-means — respecting
+the sign/frustration structure of the couplings.
+
+Exposed as :class:`~divi.qprog.problems.CommunityDecomposer`, a drop-in
+``hybrid`` decomposer for
+:class:`~divi.qprog.problems.BinaryOptimizationProblem` (used exactly like
+D-Wave's ``EnergyImpactDecomposer``).
+"""
+
+from typing import Literal, cast
+
+import numpy as np
+import scipy.sparse as sps
+from hybrid import traits
+from hybrid.core import Runnable
+from hybrid.exceptions import EndOfStream
+from hybrid.utils import bqm_induced_by
+from networkx import Graph
+from networkx.algorithms.community import louvain_communities
+from scipy.sparse.csgraph import connected_components, laplacian
+from scipy.sparse.linalg import ArpackError, ArpackNoConvergence, eigsh
+from sklearn.cluster import KMeans
+
+from divi.qprog.problems._graph_partitioning_utils import GraphPartitioningConfig
+
+_DENSE_EIGH_MAX = 800
+
+
+def bqm_to_sparse(bqm):
+    """Return ``(variables, h, J)``: variable order, linear vector, symmetric coupling.
+
+    ``J[i, j] == J[j, i]`` is the quadratic coefficient of variables ``i, j`` in the
+    ``variables`` order; ``h`` holds the linear biases.
+    """
+    variables = list(bqm.variables)
+    idx = {v: i for i, v in enumerate(variables)}
+    n = len(variables)
+    h = np.zeros(n)
+    for v, bias in bqm.linear.items():
+        h[idx[v]] = bias
+    rows, cols, data = [], [], []
+    for (u, v), q in bqm.quadratic.items():
+        i, j = idx[u], idx[v]
+        rows += [i, j]
+        cols += [j, i]
+        data += [q, q]
+    return variables, h, sps.csr_matrix((data, (rows, cols)), shape=(n, n))
+
+
+def _view_features(W: sps.csr_matrix, k: int) -> np.ndarray | None:
+    """Leading ``k`` eigenvectors of a view's normalized Laplacian.
+
+    Returns ``None`` for an empty view (no couplings of that sign). Uses dense
+    ``eigh`` for moderate sizes and sparse shift-invert ``eigsh`` above
+    :data:`_DENSE_EIGH_MAX`, falling back to dense on solver failure.
+    """
+    if W.nnz == 0:
+        return None
+    # scipy's ``laplacian`` is typed as possibly returning a (matrix, diag) tuple;
+    # with the default return_diag=False it returns just the sparse matrix.
+    L = cast(sps.csr_matrix, laplacian(W, normed=True))
+    m = L.shape[0]
+    k = min(k, m - 1)
+    if k < 1:
+        return None
+
+    if m <= _DENSE_EIGH_MAX:
+        _vals, vecs = np.linalg.eigh(np.asarray(L.todense()))
+        return vecs[:, :k]
+
+    try:
+        vals, vecs = eigsh(L.tocsc(), k=k, sigma=-1e-6, which="LM")
+        return vecs[:, np.argsort(vals)]
+    except (ArpackError, ArpackNoConvergence, np.linalg.LinAlgError):
+        _vals, vecs = np.linalg.eigh(np.asarray(L.todense()))
+        return vecs[:, :k]
+
+
+def _multiview_labels(sigma: sps.csr_matrix, k: int, seed: int) -> np.ndarray:
+    """Signed multi-view spectral clustering into ``k`` groups (arXiv 2502.16212)."""
+    n = sigma.shape[0]
+    if k <= 1:
+        return np.zeros(n, dtype=int)
+    if k >= n:
+        return np.arange(n)
+
+    # Split into positive ("repulsive") and negative ("attractive") views,
+    # keeping only the sign-matching nonzero entries so an all-one-sign block
+    # yields a genuinely empty opposite view (no explicit zeros, which would
+    # otherwise feed a degenerate all-zero Laplacian's identity eigenvectors
+    # into k-means as garbage features).
+    s = sigma.tocoo()
+    pos, neg = s.data > 0, s.data < 0
+    w_pos = sps.csr_matrix((s.data[pos], (s.row[pos], s.col[pos])), shape=sigma.shape)
+    w_neg = sps.csr_matrix((-s.data[neg], (s.row[neg], s.col[neg])), shape=sigma.shape)
+
+    features = [
+        f for f in (_view_features(w_pos, k), _view_features(w_neg, k)) if f is not None
+    ]
+    if not features:
+        return np.zeros(n, dtype=int)
+
+    return KMeans(n_clusters=k, n_init=10, random_state=seed).fit_predict(
+        np.hstack(features)
+    )
+
+
+def _louvain_labels(sigma: sps.csr_matrix, k: int, seed: int) -> np.ndarray:
+    """Community labels from Louvain modularity maximization.
+
+    ``k`` is ignored — Louvain derives the community count from the graph itself.
+    Edge weights are coupling *magnitudes* (Louvain requires non-negative weights),
+    so strongly-coupled variables of either sign are grouped together. A uniform
+    complete (structureless) block collapses to one community, which the caller's
+    balanced-split fallback then handles; non-uniform complete blocks (e.g. rank-1
+    number-partitioning) can still fragment.
+    """
+    n = sigma.shape[0]
+    if n <= 1:
+        return np.zeros(n, dtype=int)
+
+    s = sigma.tocoo()
+    g = Graph()
+    g.add_nodes_from(range(n))
+    for i, j, v in zip(s.row.tolist(), s.col.tolist(), s.data.tolist()):
+        if i < j and v != 0.0:
+            g.add_edge(i, j, weight=abs(v))
+
+    labels = np.empty(n, dtype=int)
+    for lbl, community in enumerate(louvain_communities(g, weight="weight", seed=seed)):
+        for node in community:
+            labels[node] = lbl
+    return labels
+
+
+def _split_to_budget(
+    sigma: sps.csr_matrix,
+    idx: np.ndarray,
+    budget: int,
+    seed: int,
+    labeler=_multiview_labels,
+) -> list[np.ndarray]:
+    """Cluster ``idx`` until every group has at most ``budget`` members.
+
+    Iterative (worklist) bisection-to-budget, mirroring the graph partitioner's
+    size predicate, using ``labeler`` for the clustering step. Falls back to a
+    balanced hard split when the labeler fails to separate or makes no progress.
+    """
+    out: list[np.ndarray] = []
+    stack: list[np.ndarray] = [idx]
+    while stack:
+        cur = stack.pop()
+        if len(cur) <= budget:
+            out.append(cur)
+            continue
+
+        k = int(np.ceil(len(cur) / budget))
+        labels = labeler(cast(sps.csr_matrix, sigma[np.ix_(cur, cur)]), k, seed)
+        groups = [cur[labels == lbl] for lbl in np.unique(labels)]
+        groups = [g for g in groups if len(g) > 0]
+
+        # Degenerate (single group) or no-progress (a group as large as the
+        # input) → balanced hard split, which strictly shrinks and respects the
+        # budget. Iterative worklist avoids any recursion-depth limit. (A tighter
+        # anti-"singleton-peeling" guard was tried and reverted: forcing balance on
+        # near-degenerate/rank-1 single-sign blocks measurably worsened unpolished
+        # number-partitioning results, and local_search erases the difference.)
+        if len(groups) < 2 or max(len(g) for g in groups) == len(cur):
+            step = int(np.ceil(len(cur) / k))
+            groups = [cur[i : i + step] for i in range(0, len(cur), step)]
+
+        stack.extend(groups)
+    return out
+
+
+def _ensure_min_clusters(
+    sigma: sps.csr_matrix,
+    clusters: list[np.ndarray],
+    min_clusters: int,
+    seed: int,
+    labeler=_multiview_labels,
+) -> list[np.ndarray]:
+    """Bisect the largest clusters until at least ``min_clusters`` exist."""
+    clusters = list(clusters)
+    while len(clusters) < min_clusters:
+        splittable = [i for i, c in enumerate(clusters) if len(c) > 1]
+        if not splittable:
+            break
+        i = max(splittable, key=lambda j: len(clusters[j]))
+        idx = clusters.pop(i)
+        labels = labeler(cast(sps.csr_matrix, sigma[np.ix_(idx, idx)]), 2, seed)
+        groups = [idx[labels == lbl] for lbl in np.unique(labels)]
+        groups = [g for g in groups if len(g) > 0]
+        if len(groups) < 2:
+            mid = len(idx) // 2
+            groups = [idx[:mid], idx[mid:]]
+        clusters.extend(groups)
+    return clusters
+
+
+def _partition(
+    sigma: sps.csr_matrix, config: GraphPartitioningConfig, seed: int, labeler
+) -> list[np.ndarray]:
+    """Partition a QUBO's interaction matrix into variable-index clusters.
+
+    Connected components are separated first (a zero-cost exact reduction), then
+    each component is clustered with ``labeler`` to honor ``config``'s
+    ``max_n_nodes_per_cluster`` budget and ``minimum_n_clusters`` floor.
+    """
+    if (
+        config.minimum_n_clusters is not None
+        and config.minimum_n_clusters > sigma.shape[0]
+    ):
+        raise ValueError("minimum_n_clusters is larger than the number of variables.")
+
+    n_comp, comp_labels = connected_components(sigma != 0, directed=False)
+
+    clusters: list[np.ndarray] = []
+    for c in range(n_comp):
+        idx = np.where(comp_labels == c)[0]
+        if config.max_n_nodes_per_cluster is not None:
+            clusters.extend(
+                _split_to_budget(
+                    sigma, idx, config.max_n_nodes_per_cluster, seed, labeler
+                )
+            )
+        else:
+            clusters.append(idx)
+
+    if config.minimum_n_clusters is not None:
+        clusters = _ensure_min_clusters(
+            sigma, clusters, config.minimum_n_clusters, seed, labeler
+        )
+    return clusters
+
+
+def signed_multiview_partition(
+    sigma: sps.csr_matrix, config: GraphPartitioningConfig, *, seed: int = 0
+) -> list[np.ndarray]:
+    """Partition via signed multi-view spectral clustering (arXiv 2502.16212).
+
+    Args:
+        sigma: Symmetric sparse interaction matrix over variables ``0..n-1``.
+        config: Size/cluster-count constraints (``partitioning_algorithm`` ignored).
+        seed: Seed for the k-means step.
+
+    Returns:
+        Integer-index arrays partitioning ``0..n-1``, one per cluster.
+    """
+    return _partition(sigma, config, seed, _multiview_labels)
+
+
+def louvain_partition(
+    sigma: sps.csr_matrix, config: GraphPartitioningConfig, *, seed: int = 0
+) -> list[np.ndarray]:
+    """Partition via Louvain modularity community detection on the interaction graph.
+
+    Same component pre-split and budget/floor handling as
+    :func:`signed_multiview_partition`, but clusters each over-budget component by
+    modularity maximization (coupling-magnitude weights) instead of spectral views.
+
+    Returns:
+        Integer-index arrays partitioning ``0..n-1``, one per cluster.
+    """
+    return _partition(sigma, config, seed, _louvain_labels)
+
+
+class CommunityDecomposer(traits.ProblemDecomposer, traits.SISO, Runnable):
+    """Structure-aware QUBO decomposer that partitions by community structure.
+
+    A drop-in ``hybrid`` decomposer — like D-Wave's ``EnergyImpactDecomposer`` or
+    ``ComponentDecomposer`` — that groups strongly-coupled variables and cuts weak
+    couplings, so little energy is lost at partition boundaries. Connected components
+    are separated first, then each component is clustered to honor the size budget.
+    Successive calls roll through the resulting clusters, one subproblem per iteration.
+
+    Two clustering methods are available via ``method``:
+
+    - ``"modularity"`` (default): Louvain community detection on the
+      coupling-magnitude graph. Auto-picks the community count and is the strongest
+      general-purpose choice across structured, dense, and constrained QUBOs.
+    - ``"spectral"``: signed multi-view spectral clustering (arXiv 2502.16212),
+      which respects coupling signs. It can degenerately peel most variables into
+      singletons on dense/rank-structured inputs, so prefer it mainly for
+      sparse-geometric instances.
+
+    Best on problems with community structure; for featureless (dense, unstructured)
+    QUBOs, D-Wave's ``EnergyImpactDecomposer`` is also a reasonable choice.
+
+    Args:
+        max_cluster_size: Maximum number of variables per subproblem (the qubit
+            budget). At least one of ``max_cluster_size`` / ``min_clusters`` required.
+        min_clusters: Minimum number of clusters (partitions) to produce.
+        method: ``"modularity"`` (default) or ``"spectral"``.
+        seed: Seed for the clustering step (Louvain / k-means).
+        silent_rewind: If ``False``, raise ``hybrid.exceptions.EndOfStream`` once
+            all clusters are exhausted (used by ``hybrid.Unwind``, which is how
+            :meth:`BinaryOptimizationProblem.decompose` drives this decomposer).
+    """
+
+    def __init__(
+        self,
+        *,
+        max_cluster_size: int | None = None,
+        min_clusters: int | None = None,
+        method: Literal["spectral", "modularity"] = "modularity",
+        seed: int = 0,
+        silent_rewind: bool = True,
+        **runopts,
+    ):
+        super().__init__(**runopts)
+        if max_cluster_size is None and min_clusters is None:
+            raise ValueError(
+                "Provide at least one of 'max_cluster_size' or 'min_clusters'."
+            )
+        if method not in ("spectral", "modularity"):
+            raise ValueError(
+                f"method must be 'spectral' or 'modularity', got {method!r}."
+            )
+        self.max_cluster_size = max_cluster_size
+        self.min_clusters = min_clusters
+        self.method = method
+        self.seed = seed
+        self.silent_rewind = silent_rewind
+        self._rolling_bqm = None
+        self._iter_clusters = None
+
+    def __repr__(self):
+        return (
+            f"{self}(max_cluster_size={self.max_cluster_size!r}, "
+            f"min_clusters={self.min_clusters!r}, method={self.method!r}, "
+            f"seed={self.seed!r}, silent_rewind={self.silent_rewind!r})"
+        )
+
+    def _get_iter_clusters(self, bqm):
+        variables, _h, sigma = bqm_to_sparse(bqm)
+        config = GraphPartitioningConfig(
+            max_n_nodes_per_cluster=self.max_cluster_size,
+            minimum_n_clusters=self.min_clusters,
+        )
+        partition = (
+            signed_multiview_partition
+            if self.method == "spectral"
+            else louvain_partition
+        )
+        clusters = partition(sigma, config, seed=self.seed)
+        return iter([[variables[i] for i in cl] for cl in clusters])
+
+    def next(self, state, **runopts):
+        """Emit the next cluster as the subproblem (one hybrid decomposition step)."""
+        silent_rewind = runopts.get("silent_rewind", self.silent_rewind)
+        bqm = state.problem
+
+        if bqm.num_variables <= 1:
+            return state.updated(subproblem=bqm)
+
+        # Roll through the clusters, one subproblem per call. Detect a new problem
+        # by CONTENT equality, not identity: ``hybrid.State.updated()`` deep-copies
+        # the (non-overridden) ``problem`` each iteration, so ``Unwind`` hands us a
+        # fresh-but-equal object every call — an identity check would rebuild the
+        # cluster iterator forever and never reach EndOfStream. On exhaustion,
+        # either rewind or signal EndOfStream.
+        if bqm != self._rolling_bqm:
+            self._rolling_bqm = bqm
+            self._iter_clusters = self._get_iter_clusters(bqm)
+        assert self._iter_clusters is not None  # set above or on a prior call
+        try:
+            cluster = next(self._iter_clusters)
+        except StopIteration:
+            if not silent_rewind:
+                self._rolling_bqm = None
+                raise EndOfStream
+            self._iter_clusters = self._get_iter_clusters(bqm)
+            cluster = next(self._iter_clusters)
+
+        sample = state.samples.change_vartype(bqm.vartype).first.sample
+        return state.updated(subproblem=bqm_induced_by(bqm, cluster, sample))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -169,8 +169,10 @@ nitpick_ignore_regex = [
     (r"py:class", r"cirq\..*"),
     # dimod's inventory lives under the Ocean umbrella.
     (r"py:class", r"dimod\..*"),
-    # dwave-hybrid does not publish a sphinx inventory.
+    # dwave-hybrid does not publish a sphinx inventory. ``show-inheritance``
+    # also renders its base classes (e.g. ``Runnable``) as bare names.
     (r"py:class", r"hybrid\..*"),
+    (r"py:class", r"^Runnable$"),
     # qoro-maestro does not publish a sphinx inventory.
     (r"py:class", r"maestro\..*"),
     # TypeVars in ``Generic[InT, OutT]`` — autodoc emits both object and

--- a/docs/source/user_guide/combinatorial_optimization_qaoa_pce.rst
+++ b/docs/source/user_guide/combinatorial_optimization_qaoa_pce.rst
@@ -694,6 +694,53 @@ and, for the default QAOA path, stitched back together). The helper only groups
 the usual ensemble calls; for progress output, circuit batching, and Ctrl+C
 behavior, see :doc:`program_ensembles`.
 
+Structure-Aware Partitioning (Community Decomposer)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Instead of the hybrid ``EnergyImpactDecomposer``, pass a
+:class:`~divi.qprog.problems.CommunityDecomposer` — a drop-in ``hybrid``
+decomposer that splits the QUBO by the *community structure* of its interaction
+graph, grouping strongly-coupled variables and cutting weak couplings so little
+energy is lost at partition boundaries. This helps most on problems with community
+structure; ``EnergyImpactDecomposer`` remains a fine default for featureless (dense,
+unstructured) QUBOs.
+
+Key parameters:
+
+- ``max_cluster_size`` — the maximum number of variables in any partition (the
+  per-partition qubit budget), analogous to ``EnergyImpactDecomposer(size=...)``.
+- ``min_clusters`` — a floor on the number of partitions produced. At least one of
+  ``max_cluster_size`` / ``min_clusters`` must be given.
+- ``method`` — ``"modularity"`` (default: Louvain community detection, the
+  strongest general-purpose choice across structured, dense, and constrained
+  QUBOs) or ``"spectral"`` (signed multi-view spectral clustering, which respects
+  coupling signs; best on sparse-geometric instances). With the ``local_search``
+  polish the two reach comparable quality.
+
+``local_search=True`` is a :class:`~divi.qprog.problems.BinaryOptimizationProblem`
+option (not part of the decomposer): it adds a greedy single-bit-flip polish of each
+aggregated solution and improves results with **any** decomposer, including
+``EnergyImpactDecomposer``.
+
+.. code-block:: python
+
+   from divi.qprog.problems import CommunityDecomposer
+
+   problem = BinaryOptimizationProblem(
+       large_bqm,
+       decomposer=CommunityDecomposer(max_cluster_size=5),  # method="modularity"
+       composer=hybrid.SplatComposer(),
+       local_search=True,
+   )
+   ensemble = PartitioningProgramEnsemble(
+       problem=problem,
+       n_layers=2,
+       optimizer=optimizer,
+       max_iterations=10,
+       backend=backend,
+   )
+   sol_community, energy_community = run_partitioned(ensemble)
+
 Why Partition?
 --------------
 

--- a/tests/qprog/problems/test_binary.py
+++ b/tests/qprog/problems/test_binary.py
@@ -7,6 +7,7 @@ import hybrid
 import numpy as np
 import pytest
 import scipy.sparse as sps
+from hybrid.exceptions import EndOfStream
 from qiskit.circuit.library import RYGate, RZGate
 
 import divi.qprog.problems._binary as binary_module
@@ -24,7 +25,7 @@ from divi.qprog import (
 )
 from divi.qprog.algorithms import GenericLayerAnsatz
 from divi.qprog.checkpointing import CheckpointConfig
-from divi.qprog.problems import BinaryOptimizationProblem
+from divi.qprog.problems import BinaryOptimizationProblem, CommunityDecomposer
 from divi.qprog.problems._binary import _merge_substates, _sanitize_problem_input
 from divi.qprog.workflows import PartitioningProgramEnsemble
 from tests.qprog._program_contracts import verify_cost_circuit
@@ -1074,4 +1075,226 @@ class TestQUBOPartitioningEnsemble:
         np.testing.assert_array_equal(solution, expected_solution)
 
         assert isinstance(energy, float)
+        assert energy == pytest.approx(-1.5)
+
+
+class TestCommunityDecomposer:
+    """CommunityDecomposer (structure-aware) + local-search polish."""
+
+    def _community_problem(self, source, **kwargs):
+        return BinaryOptimizationProblem(
+            source,
+            decomposer=CommunityDecomposer(max_cluster_size=2),
+            composer=hybrid.SplatComposer(),
+            **kwargs,
+        )
+
+    def test_decomposer_requires_a_size_constraint(self):
+        with pytest.raises(ValueError, match="max_cluster_size.*min_clusters"):
+            CommunityDecomposer()
+
+    def test_community_decompose_populates_variable_maps(self):
+        problem = self._community_problem(make_known_qubo_bqm())
+        sub_problems = problem.decompose()
+
+        assert all(
+            isinstance(p, BinaryOptimizationProblem) for p in sub_problems.values()
+        )
+        mapped = sorted(
+            gi for indices in problem._variable_maps.values() for gi in indices
+        )
+        assert mapped == list(range(problem.initial_solution_size()))
+
+    def test_multiview_decompose_rejects_hubo(self):
+        with pytest.raises(ValueError, match="quadratic"):
+            BinaryOptimizationProblem(
+                HUBO_CUBIC,
+                decomposer=CommunityDecomposer(max_cluster_size=2),
+            )
+
+    def test_greedy_bit_flip_reaches_local_minimum(self):
+        problem = self._community_problem(make_known_qubo_bqm())
+        problem.decompose()
+
+        start = [1, 1, 1, 1]
+        start_energy = problem.evaluate_global_solution(start)
+        bits, energy = problem._greedy_bit_flip(start)
+
+        assert energy <= start_energy
+        for i in range(len(bits)):
+            flipped = bits.copy()
+            flipped[i] = 1 - flipped[i]
+            assert problem.evaluate_global_solution(flipped.tolist()) >= energy - 1e-9
+
+    def test_greedy_bit_flip_large_scale_reaches_optimum(self):
+        # Coefficients ×1e6: the flip tolerance is scaled by coefficient
+        # magnitude, so the descent still terminates at the true optimum instead
+        # of stalling on incremental-field drift.
+        base = make_known_qubo_bqm()
+        scaled = dimod.BinaryQuadraticModel(
+            {v: 1e6 * b for v, b in base.linear.items()},
+            {e: 1e6 * b for e, b in base.quadratic.items()},
+            0.0,
+            dimod.Vartype.BINARY,
+        )
+        problem = self._community_problem(scaled)
+        problem.decompose()
+
+        bits, energy = problem._greedy_bit_flip([1, 1, 1, 1])
+
+        np.testing.assert_array_equal(bits, np.array([1, 1, 0, 0], dtype=np.int32))
+        assert energy == pytest.approx(-1.5e6)
+
+    def test_local_search_polishes_community_path(self):
+        problem = self._community_problem(make_known_qubo_bqm(), local_search=True)
+        problem.decompose()
+
+        raw = problem.evaluate_global_solution([1, 1, 1, 1])
+        ((_bits, energy),) = problem.postprocess_candidates([(0.0, [1, 1, 1, 1])])
+        assert energy < raw
+        assert energy == pytest.approx(-1.5)
+
+    def test_local_search_polishes_energy_impact_path(self):
+        problem = BinaryOptimizationProblem(
+            make_known_qubo_bqm(),
+            decomposer=hybrid.EnergyImpactDecomposer(size=2),
+            local_search=True,
+        )
+        problem.decompose()
+
+        raw = problem.evaluate_global_solution([1, 1, 1, 1])
+        ((_bits, energy),) = problem.postprocess_candidates([(0.0, [1, 1, 1, 1])])
+        assert energy < raw
+        assert energy == pytest.approx(-1.5)
+
+    def test_decompose_min_clusters_exceeding_n_raises(self):
+        problem = BinaryOptimizationProblem(
+            make_known_qubo_bqm(),
+            decomposer=CommunityDecomposer(min_clusters=99),
+            composer=hybrid.SplatComposer(),
+        )
+        with pytest.raises(ValueError, match="larger than the number of variables"):
+            problem.decompose()
+
+    def test_next_rolls_clusters_then_raises_end_of_stream(self):
+        # KNOWN_QUBO has two disconnected 2-variable components → two clusters,
+        # then the decomposer signals EndOfStream (the Unwind contract).
+        decomposer = CommunityDecomposer(max_cluster_size=2)
+        state = hybrid.State.from_problem(make_known_qubo_bqm())
+
+        seen = 0
+        while True:
+            try:
+                state = decomposer.next(state, silent_rewind=False)
+                seen += 1
+            except EndOfStream:
+                break
+
+        assert seen == 2
+
+    def test_decompose_splits_single_component_via_spectral(self):
+        # One connected component (two interleaved blocks + weak bridge) with a
+        # budget below its size forces the spectral-split branch through the full
+        # decompose() wiring, not just the connected-component pre-split.
+        block_a, block_b = [0, 2, 4, 6], [1, 3, 5, 7]
+        q = np.zeros((8, 8))
+        for blk in (block_a, block_b):
+            for x in range(len(blk)):
+                for y in range(x + 1, len(blk)):
+                    q[blk[x], blk[y]] = -5.0
+        q[6, 7] = 0.05  # weak inter-block bridge -> single component
+
+        problem = BinaryOptimizationProblem(
+            q,
+            decomposer=CommunityDecomposer(max_cluster_size=4, method="spectral"),
+            composer=hybrid.SplatComposer(),
+        )
+        sub_problems = problem.decompose()
+
+        assert len(sub_problems) == 2
+        assert all(pid[1] <= 4 for pid in sub_problems)
+        mapped = sorted(
+            gi for indices in problem._variable_maps.values() for gi in indices
+        )
+        assert mapped == list(range(8))
+
+    def test_greedy_bit_flip_polishes_low_scale_amid_huge_coupling(self):
+        # A 1e12 coupling must not desensitize the descent in the O(1) part of the
+        # problem: the per-node tolerance keeps the small linear rewards live.
+        bqm = dimod.BinaryQuadraticModel(
+            {2: -1.0, 3: -1.0},  # O(1) rewards -> want x2 = x3 = 1
+            {(0, 1): 1e12},  # huge, unrelated coupling
+            0.0,
+            dimod.Vartype.BINARY,
+        )
+        problem = BinaryOptimizationProblem(
+            bqm,
+            decomposer=CommunityDecomposer(max_cluster_size=2),
+            composer=hybrid.SplatComposer(),
+        )
+
+        bits, _energy = problem._greedy_bit_flip([0, 0, 0, 0])
+
+        variables = list(problem._bqm.variables)
+        assert bits[variables.index(2)] == 1
+        assert bits[variables.index(3)] == 1
+
+    def test_local_search_without_decomposer_raises(self):
+        with pytest.raises(ValueError, match="local_search requires a decomposer"):
+            BinaryOptimizationProblem(make_known_qubo_bqm(), local_search=True)
+
+    def test_invalid_method_raises(self):
+        with pytest.raises(ValueError, match="spectral.*modularity"):
+            CommunityDecomposer(max_cluster_size=2, method="bogus")
+
+    def test_modularity_method_decomposes_single_component(self):
+        block_a, block_b = [0, 2, 4, 6], [1, 3, 5, 7]
+        q = np.zeros((8, 8))
+        for blk in (block_a, block_b):
+            for x in range(len(blk)):
+                for y in range(x + 1, len(blk)):
+                    q[blk[x], blk[y]] = -5.0
+        q[6, 7] = 0.05
+
+        problem = BinaryOptimizationProblem(
+            q,
+            decomposer=CommunityDecomposer(max_cluster_size=4, method="modularity"),
+            composer=hybrid.SplatComposer(),
+        )
+        sub_problems = problem.decompose()
+
+        assert all(pid[1] <= 4 for pid in sub_problems)
+        mapped = sorted(
+            gi for indices in problem._variable_maps.values() for gi in indices
+        )
+        assert mapped == list(range(8))
+
+    def test_next_passes_through_single_variable_problem(self):
+        bqm = dimod.BinaryQuadraticModel({0: -1.0}, {}, 0.0, dimod.Vartype.BINARY)
+        decomposer = CommunityDecomposer(max_cluster_size=2)
+
+        out = decomposer.next(hybrid.State.from_problem(bqm), silent_rewind=False)
+
+        assert list(out.subproblem.variables) == [0]
+
+    @pytest.mark.e2e
+    def test_community_partitioning_e2e(self, default_test_simulator):
+        """End-to-end QUBO solve via structure-aware decomposition + polish."""
+        default_test_simulator.set_seed(1997)
+
+        problem = self._community_problem(make_known_qubo_bqm(), local_search=True)
+        ensemble = PartitioningProgramEnsemble(
+            problem=problem,
+            n_layers=2,
+            optimizer=ScipyOptimizer(method=ScipyMethod.COBYLA),
+            max_iterations=15,
+            backend=default_test_simulator,
+            seed=1997,
+        )
+
+        ensemble.create_programs()
+        ensemble.run(blocking=True, batch_config=BatchConfig(_sort_programs=True))
+        solution, energy = ensemble.aggregate_results()
+
+        np.testing.assert_array_equal(solution, np.array([1, 1, 0, 0]))
         assert energy == pytest.approx(-1.5)

--- a/tests/qprog/problems/test_qubo_partitioning_utils.py
+++ b/tests/qprog/problems/test_qubo_partitioning_utils.py
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: 2026 Qoro Quantum Ltd <divi@qoroquantum.de>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for signed multi-view spectral QUBO partitioning."""
+
+import dimod
+import numpy as np
+import pytest
+import scipy.sparse as sps
+
+from divi.qprog.problems import GraphPartitioningConfig
+from divi.qprog.problems._qubo_partitioning_utils import (
+    bqm_to_sparse,
+    louvain_partition,
+    signed_multiview_partition,
+)
+
+
+def _block_matrix(blocks, intra, bridges=()):
+    """Symmetric matrix with strong intra-block couplings and optional weak bridges."""
+    n = sum(len(b) for b in blocks)
+    s = np.zeros((n, n))
+    for blk in blocks:
+        for a in range(len(blk)):
+            for b in range(a + 1, len(blk)):
+                s[blk[a], blk[b]] = s[blk[b], blk[a]] = intra
+    for i, j, w in bridges:
+        s[i, j] = s[j, i] = w
+    return sps.csr_matrix(s)
+
+
+def _planted_two_block_sigma(intra_a=5.0, intra_b=5.0, bridge_w=0.05):
+    """Two strongly-coupled blocks joined by one weak bridge (single component).
+
+    Block membership is *interleaved* (``[0,2,4,6]`` / ``[1,3,5,7]``) so a naive
+    contiguous hard-split fallback cannot reproduce the blocks — recovering them
+    forces the spectral clustering to actually do the work. ``intra_a``/``intra_b``
+    take independent signs so a mixed-sign choice exercises both spectral views.
+    """
+    block_a, block_b = [0, 2, 4, 6], [1, 3, 5, 7]
+    s = np.zeros((8, 8))
+    for blk, w in ((block_a, intra_a), (block_b, intra_b)):
+        for x in range(len(blk)):
+            for y in range(x + 1, len(blk)):
+                s[blk[x], blk[y]] = s[blk[y], blk[x]] = w
+    s[6, 7] = s[7, 6] = bridge_w  # weak inter-block bridge
+    return sps.csr_matrix(s), set(block_a), set(block_b)
+
+
+def _assert_recovers_blocks(clusters, block_a, block_b):
+    assert len(clusters) == 2
+    assert sorted(int(i) for cl in clusters for i in cl) == list(range(8))  # cover
+    for cl in clusters:
+        members = {int(i) for i in cl}
+        assert members == block_a or members == block_b
+
+
+def test_negative_sign_block_recovers_communities():
+    # All-NEGATIVE couplings exercise the negative spectral view (positive view
+    # empty), mirroring the positive-sign case; blocks must be recovered exactly.
+    sigma, block_a, block_b = _planted_two_block_sigma(
+        intra_a=-5.0, intra_b=-5.0, bridge_w=-0.05
+    )
+    config = GraphPartitioningConfig(max_n_nodes_per_cluster=4)
+
+    clusters = signed_multiview_partition(sigma, config, seed=0)
+
+    _assert_recovers_blocks(clusters, block_a, block_b)
+
+
+def test_component_presplit_separates_disconnected_blocks():
+    sigma = _block_matrix([[0, 1, 2], [3, 4, 5]], intra=1.0)
+    # No budget pressure: only the connected-component pre-split should act.
+    config = GraphPartitioningConfig(max_n_nodes_per_cluster=100)
+
+    clusters = signed_multiview_partition(sigma, config, seed=0)
+
+    got = sorted(sorted(int(i) for i in cl) for cl in clusters)
+    assert got == [[0, 1, 2], [3, 4, 5]]
+
+
+def test_multiview_respects_budget_and_covers_all():
+    rng = np.random.default_rng(0)
+    a = np.triu(rng.normal(0, 1, (20, 20)), 1)
+    sigma = sps.csr_matrix(a + a.T)
+    config = GraphPartitioningConfig(max_n_nodes_per_cluster=5)
+
+    clusters = signed_multiview_partition(sigma, config, seed=0)
+
+    assert all(len(cl) <= 5 for cl in clusters)
+    flat = [int(i) for cl in clusters for i in cl]
+    assert sorted(flat) == list(range(20))  # exact cover, no duplicates
+
+
+def test_minimum_n_clusters_floor():
+    dense = np.ones((6, 6))
+    np.fill_diagonal(dense, 0)
+    sigma = sps.csr_matrix(dense)
+    config = GraphPartitioningConfig(minimum_n_clusters=3)
+
+    clusters = signed_multiview_partition(sigma, config, seed=0)
+
+    assert len(clusters) >= 3
+    flat = [int(i) for cl in clusters for i in cl]
+    assert sorted(flat) == list(range(6))
+
+
+def test_partition_is_exact_cover_with_mixed_signs():
+    rng = np.random.default_rng(1)
+    a = np.triu(rng.uniform(-3, 3, (15, 15)), 1)
+    sigma = sps.csr_matrix(a + a.T)
+    config = GraphPartitioningConfig(max_n_nodes_per_cluster=4)
+
+    clusters = signed_multiview_partition(sigma, config, seed=0)
+
+    flat = [int(i) for cl in clusters for i in cl]
+    assert sorted(flat) == list(range(15))
+    assert len(flat) == len(set(flat))
+
+
+def test_single_sign_block_recovers_communities():
+    # All-POSITIVE couplings (single-sign): the negative view must be genuinely
+    # empty so no garbage identity eigenvectors are fed to k-means. The blocks
+    # (interleaved) must still be recovered exactly.
+    sigma, block_a, block_b = _planted_two_block_sigma(intra_a=5.0, intra_b=5.0)
+    config = GraphPartitioningConfig(max_n_nodes_per_cluster=4)
+
+    clusters = signed_multiview_partition(sigma, config, seed=0)
+
+    _assert_recovers_blocks(clusters, block_a, block_b)
+
+
+def test_all_positive_partition_is_seed_deterministic():
+    sigma, _a, _b = _planted_two_block_sigma(intra_a=5.0, intra_b=5.0)
+    config = GraphPartitioningConfig(max_n_nodes_per_cluster=4)
+
+    first = signed_multiview_partition(sigma, config, seed=0)
+    second = signed_multiview_partition(sigma, config, seed=0)
+
+    assert [sorted(map(int, c)) for c in first] == [sorted(map(int, c)) for c in second]
+
+
+def test_min_clusters_exceeding_n_raises():
+    sigma = _block_matrix([[0, 1, 2, 3]], intra=1.0)
+    config = GraphPartitioningConfig(minimum_n_clusters=10)  # > 4 variables
+
+    with pytest.raises(ValueError, match="larger than the number of variables"):
+        signed_multiview_partition(sigma, config, seed=0)
+
+
+def test_large_instance_respects_budget_without_recursion_error():
+    rng = np.random.default_rng(3)
+    a = np.triu(rng.normal(0, 1, (200, 200)), 1)
+    sigma = sps.csr_matrix(a + a.T)
+    config = GraphPartitioningConfig(max_n_nodes_per_cluster=6)
+
+    clusters = signed_multiview_partition(sigma, config, seed=0)
+
+    assert all(len(cl) <= 6 for cl in clusters)
+    assert sorted(int(i) for cl in clusters for i in cl) == list(range(200))
+
+
+def test_bqm_to_sparse_handles_string_labels():
+    bqm = dimod.BinaryQuadraticModel(
+        {"a": 1.0, "b": -2.0}, {("a", "b"): 3.0}, 0.0, dimod.Vartype.BINARY
+    )
+
+    variables, h, j = bqm_to_sparse(bqm)
+    idx = {v: i for i, v in enumerate(variables)}
+
+    assert set(variables) == {"a", "b"}
+    assert h[idx["a"]] == 1.0 and h[idx["b"]] == -2.0
+    assert j[idx["a"], idx["b"]] == 3.0 and j[idx["b"], idx["a"]] == 3.0
+
+
+def test_louvain_recovers_planted_communities():
+    sigma, block_a, block_b = _planted_two_block_sigma(intra_a=5.0, intra_b=5.0)
+    config = GraphPartitioningConfig(max_n_nodes_per_cluster=4)
+
+    clusters = louvain_partition(sigma, config, seed=0)
+
+    _assert_recovers_blocks(clusters, block_a, block_b)
+
+
+def test_louvain_respects_budget_and_covers_all():
+    rng = np.random.default_rng(1)
+    a = np.triu(rng.normal(0, 1, (20, 20)), 1)
+    sigma = sps.csr_matrix(a + a.T)
+    config = GraphPartitioningConfig(max_n_nodes_per_cluster=5)
+
+    clusters = louvain_partition(sigma, config, seed=0)
+
+    assert all(len(cl) <= 5 for cl in clusters)
+    assert sorted(int(i) for cl in clusters for i in cl) == list(range(20))
+
+
+def test_louvain_uniform_complete_block_does_not_fragment():
+    # A near-uniform complete (rank-1) block has no community structure, so Louvain
+    # returns a single community and the balanced-split fallback yields sized
+    # clusters rather than a swarm of singletons. (Strongly non-uniform complete
+    # QUBOs can still fragment under modularity — polish equalizes the outcome.)
+    rng = np.random.default_rng(0)
+    a = rng.uniform(1.0, 5.0, 12)
+    q = np.outer(a, a)
+    np.fill_diagonal(q, 0.0)
+    sigma = sps.csr_matrix(np.triu(q, 1) + np.triu(q, 1).T)
+    config = GraphPartitioningConfig(max_n_nodes_per_cluster=6)
+
+    clusters = louvain_partition(sigma, config, seed=0)
+
+    assert all(len(c) <= 6 for c in clusters)
+    assert sum(1 for c in clusters if len(c) == 1) <= 1
+    assert sorted(int(i) for c in clusters for i in c) == list(range(12))

--- a/tutorials/_ci_runner.py
+++ b/tutorials/_ci_runner.py
@@ -85,7 +85,7 @@ TUTORIALS: dict[str, dict] = {
     },
     "optimization/qaoa_partitioning.py": {
         # Three partitioning entry points run sequentially; budget covers
-        # graph (METIS), QUBO (hybrid), and edge-based (Kernighan-Lin).
+        # graph (METIS), QUBO (multi-view + hybrid), and edge-based (Kernighan-Lin).
         "timeout_seconds": 240,
         "patches": [
             ("N_NODES = 30", "N_NODES = 10"),

--- a/tutorials/optimization/qaoa_partitioning.py
+++ b/tutorials/optimization/qaoa_partitioning.py
@@ -10,9 +10,10 @@ This tutorial shows three distinct entry points:
 
 1. **Graph-level partitioning** — split a graph by topology (METIS), solve
    MaxCut on each cluster, then aggregate via greedy/beam search.
-2. **QUBO-level partitioning** — use a decomposer/composer from D-Wave
-   Ocean's ``hybrid`` workflow library to split a random BQM and compare
-   two quantum routines (QAOA vs PCE) on the same partitioned problem.
+2. **QUBO-level partitioning** — split a BQM two ways: the structure-aware
+   ``CommunityDecomposer`` (with a ``local_search`` polish) and D-Wave
+   Ocean's ``hybrid`` ``EnergyImpactDecomposer``; compare two quantum routines
+   (QAOA vs PCE) on the same partitioned problem.
 3. **Edge-based partitioning** — use ``MaxWeightMatchingProblem``'s edge
    budget plus a Kernighan-Lin partitioner to chunk a weighted graph into
    matching-sized sub-instances.
@@ -40,6 +41,7 @@ from divi.qprog.algorithms import GenericLayerAnsatz
 from divi.qprog.optimizers import ScipyMethod, ScipyOptimizer
 from divi.qprog.problems import (
     BinaryOptimizationProblem,
+    CommunityDecomposer,
     GraphPartitioningConfig,
     MaxCutProblem,
     MaxWeightMatchingProblem,
@@ -86,15 +88,9 @@ def _cut_ratio(quantum_solution, classical_cut_size: int, graph: nx.Graph) -> fl
 
 
 def _run_qubo_partitioning(
-    bqm: dimod.BinaryQuadraticModel, engine: str, engine_kwargs: dict
+    problem: BinaryOptimizationProblem, engine: str, engine_kwargs: dict
 ) -> dict:
-    """Run one quantum routine on a hybrid-decomposed BQM."""
-    problem = BinaryOptimizationProblem(
-        bqm,
-        decomposer=hybrid.EnergyImpactDecomposer(size=5),
-        composer=hybrid.SplatComposer(),
-    )
-
+    """Run one quantum routine on a decomposed BQM."""
     ensemble = PartitioningProgramEnsemble(
         problem=problem,
         quantum_routine=engine,
@@ -283,10 +279,28 @@ if __name__ == "__main__":
         bias_generator=partial(np.random.default_rng().uniform, -5, 5),
     )
 
+    # Two decomposition strategies on the same problem:
+    #  - QAOA uses ``CommunityDecomposer``: community-structure-aware clustering of
+    #    the QUBO interaction graph (Louvain modularity by default), plus a greedy
+    #    single-bit-flip ``local_search`` polish of the aggregated solution. This
+    #    shines on problems with community structure.
+    #  - PCE uses the D-Wave hybrid ``EnergyImpactDecomposer``.
+    qaoa_problem = BinaryOptimizationProblem(
+        bqm,
+        decomposer=CommunityDecomposer(max_cluster_size=5),
+        composer=hybrid.SplatComposer(),
+        local_search=True,
+    )
+    pce_problem = BinaryOptimizationProblem(
+        bqm,
+        decomposer=hybrid.EnergyImpactDecomposer(size=5),
+        composer=hybrid.SplatComposer(),
+    )
+
     results_by_engine = {
-        "qaoa": _run_qubo_partitioning(bqm=bqm, engine="qaoa", engine_kwargs={}),
+        "qaoa": _run_qubo_partitioning(qaoa_problem, engine="qaoa", engine_kwargs={}),
         "pce": _run_qubo_partitioning(
-            bqm=bqm,
+            pce_problem,
             engine="pce",
             engine_kwargs={
                 "ansatz": GenericLayerAnsatz([RYGate, RZGate]),


### PR DESCRIPTION
## Summary
Adds `CommunityDecomposer`, a drop-in dwave-`hybrid` `ProblemDecomposer` that partitions a QUBO by the **community structure** of its interaction graph, plus an optional `local_search` greedy-bit-flip polish on `BinaryOptimizationProblem` (usable with any decomposer).

- Two clustering methods: **Louvain modularity** (default) and **signed multi-view spectral** clustering (arXiv 2502.16212).
- Connected-component pre-split, budget-respecting iterative clustering, and a `min_clusters` floor.
- `local_search` polish uses a per-node tolerance and is the biggest, decomposer-agnostic quality lever.

```python
BinaryOptimizationProblem(
    bqm,
    decomposer=CommunityDecomposer(max_cluster_size=6),  # method="modularity"
    composer=hybrid.SplatComposer(),
    local_search=True,
)
```

## Why
Benchmarked (n up to 100, 20 problem families, exact/SA reference) to beat the existing energy-impact decomposer on structured problems. Modularity is best-or-tied across the broadest range and stays robust on constrained/penalty QUBOs where energy-impact collapses; polish closes the remaining gap. Modularity is the default because signed-multi-view spectral degenerately peels most variables into singletons on dense/rank-structured inputs.

## Test plan
- New: `tests/qprog/problems/test_qubo_partitioning_utils.py` and `TestCommunityDecomposer` in `tests/qprog/problems/test_binary.py` (clustering, budget/coverage, `min_clusters`, polish incl. wide coefficient scale, decomposer state machine, e2e QAOA).
- Full unit suite, docs build, and 195 doc snippets pass; `pyrefly` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPUeC2T6QKbNtRMMnFBNc1