### PR TITLE
feat(qprog): checkpoint program ensembles

### DIFF
--- a/divi/qprog/_ensemble_checkpoint.py
+++ b/divi/qprog/_ensemble_checkpoint.py
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: 2025-2026 Qoro Quantum Ltd <divi@qoroquantum.de>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Private state models and path helpers for ensemble checkpoints."""
+
+from __future__ import annotations
+
+import math
+import re
+from pathlib import Path
+from typing import Any, Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from .checkpointing import (
+    CheckpointCorruptedError,
+    CheckpointNotFoundError,
+    _load_and_validate_pydantic_model,
+)
+
+ROUND_PREFIX = "round_"
+ROUND_START_FILE = "round_start.json"
+ROUND_COMPLETION_FILE = "round_completion.json"
+PROGRAM_COMPLETION_FILE = "program_completion.json"
+_ROUND_PATTERN = re.compile(r"^round_(\d+)$")
+
+
+class ProgramRoundRecord(BaseModel):
+    """State needed to recover one child after an interrupted round."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    program_id: dict[str, Any]
+    program_type: str = Field(min_length=1)
+    circuit_count_at_round_start: int = Field(ge=0)
+    run_time_at_round_start: float = Field(ge=0, allow_inf_nan=False)
+
+
+class RoundCheckpoint(BaseModel):
+    """State saved at an interrupted or completed ensemble round boundary."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    version: Literal["1.0"] = "1.0"
+    kind: Literal["round_start", "round_completion"]
+    ensemble_type: str = Field(min_length=1)
+    round_index: int = Field(ge=1)
+    ensemble_state: dict[str, Any]
+    programs: list[ProgramRoundRecord] | None = None
+    round_history: list[dict[str, Any]] | None = None
+    total_circuit_count: int | None = Field(default=None, ge=0)
+    total_run_time: float | None = Field(default=None, ge=0, allow_inf_nan=False)
+
+    @model_validator(mode="after")
+    def _validate_kind(self) -> Self:
+        interrupted_fields = (self.programs,)
+        completed_fields = (
+            self.round_history,
+            self.total_circuit_count,
+            self.total_run_time,
+        )
+        if self.kind == "round_start":
+            valid = all(value is not None for value in interrupted_fields) and all(
+                value is None for value in completed_fields
+            )
+        else:
+            valid = all(value is None for value in interrupted_fields) and all(
+                value is not None for value in completed_fields
+            )
+        if not valid:
+            raise ValueError(f"round checkpoint fields do not match kind {self.kind!r}")
+        return self
+
+    def round_start_data(self) -> list[ProgramRoundRecord]:
+        """Return fields guaranteed by the interrupted kind."""
+        if self.kind != "round_start" or self.programs is None:
+            raise ValueError("round checkpoint is not interrupted")
+        return self.programs
+
+    def round_completion_data(self) -> tuple[list[dict[str, Any]], int, float]:
+        """Return fields guaranteed by the completed kind."""
+        if (
+            self.kind != "round_completion"
+            or self.round_history is None
+            or self.total_circuit_count is None
+            or self.total_run_time is None
+        ):
+            raise ValueError("round checkpoint is not completed")
+        return (
+            self.round_history,
+            self.total_circuit_count,
+            self.total_run_time,
+        )
+
+
+def _round_dir(root: Path, round_index: int) -> Path:
+    """Return the zero-padded directory for ``round_index``."""
+    return root / f"{ROUND_PREFIX}{round_index:03d}"
+
+
+def _program_checkpoint_path(round_path: Path, slot: int) -> Path:
+    return round_path / f"program_{slot:03d}"
+
+
+def _encode_program_id(value: Any) -> dict[str, Any]:
+    """Encode supported hashable program IDs without losing their Python type."""
+    if value is None:
+        return {"kind": "none"}
+    if isinstance(value, bool):
+        return {"kind": "bool", "value": value}
+    if isinstance(value, int):
+        return {"kind": "int", "value": value}
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise TypeError("checkpoint program ID floats must be finite")
+        return {"kind": "float", "value": value}
+    if isinstance(value, str):
+        return {"kind": "str", "value": value}
+    if isinstance(value, tuple):
+        return {
+            "kind": "tuple",
+            "items": [_encode_program_id(item) for item in value],
+        }
+    raise TypeError(
+        "checkpoint program ID must contain only stable scalar or tuple values; "
+        f"got {type(value).__name__}"
+    )
+
+
+def _round_index(path: Path) -> int | None:
+    match = _ROUND_PATTERN.fullmatch(path.name)
+    return int(match.group(1)) if match is not None else None
+
+
+def _state_artifacts_exist(payload: Any, round_dir: Path) -> bool:
+    """Validate artifact references embedded in a workflow-state payload."""
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            if key == "artifact":
+                if not isinstance(value, str):
+                    return False
+                artifact = Path(value)
+                if artifact.is_absolute() or ".." in artifact.parts:
+                    return False
+                if not (round_dir / artifact).is_file():
+                    return False
+            elif not _state_artifacts_exist(value, round_dir):
+                return False
+    elif isinstance(payload, list):
+        return all(_state_artifacts_exist(value, round_dir) for value in payload)
+    return True
+
+
+def _load_round(path: Path) -> RoundCheckpoint | None:
+    round_index = _round_index(path)
+    if round_index is None or not path.is_dir():
+        return None
+
+    for filename, kind, error_context in (
+        (ROUND_COMPLETION_FILE, "round_completion", "Ensemble state"),
+        (ROUND_START_FILE, "round_start", "Interrupted ensemble round"),
+    ):
+        checkpoint_path = path / filename
+        if not checkpoint_path.is_file():
+            continue
+        try:
+            state = _load_and_validate_pydantic_model(
+                checkpoint_path,
+                RoundCheckpoint,
+                required_fields=["kind", "ensemble_type", "round_index"],
+                error_context=error_context,
+            )
+        except (CheckpointNotFoundError, CheckpointCorruptedError):
+            continue
+        if (
+            state.kind == kind
+            and state.round_index == round_index
+            and _state_artifacts_exist(state.ensemble_state, path)
+        ):
+            return state
+
+    return None
+
+
+def _resolve_ensemble_checkpoint(
+    root: Path | str, subdirectory: str | None = None
+) -> RoundCheckpoint:
+    """Resolve the latest valid ensemble round or an explicit subdirectory."""
+    main_dir = Path(root)
+    if subdirectory is not None:
+        candidates = [main_dir / subdirectory]
+    elif main_dir.is_dir():
+        candidates = sorted(
+            (
+                child
+                for child in main_dir.iterdir()
+                if child.is_dir() and _round_index(child) is not None
+            ),
+            key=lambda child: _round_index(child) or -1,
+            reverse=True,
+        )
+    else:
+        candidates = []
+
+    for candidate in candidates:
+        resolved = _load_round(candidate)
+        if resolved is not None:
+            return resolved
+
+    raise CheckpointNotFoundError(
+        f"No valid ensemble checkpoint found in {main_dir}.",
+        main_dir=main_dir,
+        available_directories=[path.name for path in candidates],
+    )

--- a/divi/qprog/_program_checkpoint.py
+++ b/divi/qprog/_program_checkpoint.py
@@ -10,17 +10,98 @@ the optimizer).
 """
 
 import pickle
+from collections.abc import Collection
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, Self
 
 import numpy as np
 import numpy.typing as npt
-from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
 
 from divi.qprog.early_stopping import StopReason
 
 if TYPE_CHECKING:
+    from divi.qprog.quantum_program import QuantumProgram
     from divi.qprog.variational_quantum_algorithm import VariationalQuantumAlgorithm
+
+
+class _ProgramAttributeView:
+    """Expose program attributes while treating exclusions as absent fields."""
+
+    def __init__(
+        self,
+        program: "QuantumProgram",
+        excluded_attributes: Collection[str] = (),
+        values: dict[str, Any] | None = None,
+    ):
+        self._program = program
+        self._excluded_attributes = frozenset(excluded_attributes)
+        self._values = values or {}
+
+    def __getattr__(self, name: str) -> Any:
+        if name in self._excluded_attributes:
+            raise AttributeError(name)
+        if name in self._values:
+            return self._values[name]
+        if name == "_serialized_program_type":
+            return type(self._program).__name__
+        return getattr(self._program, name)
+
+
+class ProgramCheckpoint(BaseModel):
+    """Metadata shared by program checkpoints."""
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        from_attributes=True,
+        populate_by_name=True,
+    )
+
+    version: Literal["1.0"] = "1.0"
+    program_type: str = Field(min_length=1, validation_alias="_serialized_program_type")
+    total_circuit_count: int = Field(ge=0, validation_alias="_total_circuit_count")
+    total_run_time: float = Field(
+        ge=0, allow_inf_nan=False, validation_alias="_total_run_time"
+    )
+
+    @classmethod
+    def _from_program(
+        cls,
+        program: "QuantumProgram",
+        *,
+        excluded_attributes: Collection[str] = (),
+        values: dict[str, Any] | None = None,
+    ) -> Self:
+        return cls.model_validate(
+            _ProgramAttributeView(program, excluded_attributes, values)
+        )
+
+
+def _to_jsonable(value: Any) -> Any:
+    """Coerce numpy scalars and arrays to their plain-Python equivalents.
+
+    :attr:`SubclassState.data` is untyped, so a subclass storing numpy — a
+    problem's ``decode_fn`` may return an array of bits, or a
+    ``{variable: numpy scalar}`` mapping — otherwise reaches the JSON
+    serialiser as a type it cannot write. Restores as plain Python.
+    """
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, dict):
+        return {key: _to_jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(item) for item in value]
+    return value
 
 
 class SubclassState(BaseModel):
@@ -36,14 +117,10 @@ class OptimizerConfig(BaseModel):
     config: dict[str, Any] = Field(default_factory=dict)
 
 
-class ProgramState(BaseModel):
-    """Pydantic model for VariationalQuantumAlgorithm state."""
+class VQACheckpoint(ProgramCheckpoint):
+    """Iterative or completed state for a variational quantum algorithm."""
 
-    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
-
-    # Metadata
-    program_type: str = Field(validation_alias="_serialized_program_type")
-    version: str = "1.0"
+    kind: Literal["iteration", "program_completion"]
     timestamp: str = Field(default_factory=lambda: datetime.now().isoformat())
 
     # Core Algorithm State (mapped to private attributes)
@@ -59,8 +136,6 @@ class ProgramState(BaseModel):
     best_probs: dict[int, dict[str, float]] = Field(
         default_factory=dict, validation_alias="_best_probs"
     )
-    total_circuit_count: int = Field(validation_alias="_total_circuit_count")
-    total_run_time: float = Field(validation_alias="_total_run_time")
     seed: int | None = Field(validation_alias="_seed")
     stop_reason: str | None = Field(
         default=None, validation_alias="_serialized_stop_reason"
@@ -79,10 +154,34 @@ class ProgramState(BaseModel):
     rng_state_bytes: bytes | None = Field(
         default=None, validation_alias="_serialized_rng_state"
     )
-    optimizer_config: OptimizerConfig = Field(
-        validation_alias="_serialized_optimizer_config"
-    )
     subclass_state: SubclassState = Field(validation_alias="_serialized_subclass_state")
+    optimizer_config: OptimizerConfig | None = Field(
+        default=None, validation_alias="_serialized_optimizer_config"
+    )
+
+    @model_validator(mode="after")
+    def _validate_kind(self) -> Self:
+        if (self.kind == "iteration") != (self.optimizer_config is not None):
+            raise ValueError(
+                "optimizer_config is required for iterative VQA checkpoints"
+            )
+        return self
+
+    @classmethod
+    def from_program(
+        cls,
+        program: "QuantumProgram",
+        *,
+        kind: Literal["iteration", "program_completion"],
+    ) -> Self:
+        excluded = (
+            ("_serialized_optimizer_config",) if kind == "program_completion" else ()
+        )
+        return cls._from_program(
+            program,
+            excluded_attributes=excluded,
+            values={"kind": kind},
+        )
 
     @field_serializer("rng_state_bytes")
     def serialize_bytes(self, v: bytes | None, _info):
@@ -99,11 +198,7 @@ class ProgramState(BaseModel):
         """Accept nested lists or per-iteration ndarray snapshots from disk or program."""
         if not v:
             return []
-        rows: list[list[list[float]]] = []
-        for item in v:
-            arr = np.asarray(item, dtype=np.float64)
-            rows.append(arr.tolist())
-        return rows
+        return [np.asarray(item, dtype=np.float64).tolist() for item in v]
 
     @field_serializer("best_params", "final_params")
     def serialize_arrays(self, v: npt.NDArray | list | None, _info):

--- a/divi/qprog/algorithms/_iterative_qaoa.py
+++ b/divi/qprog/algorithms/_iterative_qaoa.py
@@ -17,21 +17,23 @@ Three interpolation strategies are provided:
 - **CHEBYSHEV**: Chebyshev polynomial basis representation
 """
 
+import json
 from collections.abc import Callable
 from dataclasses import replace
 from enum import Enum
 from pathlib import Path
-from typing import Any, Self
+from typing import Any
 from warnings import warn
 
 import numpy as np
 import numpy.typing as npt
 from qiskit.circuit import ParameterVector
 
-from divi.backends import CircuitRunner
 from divi.qprog.checkpointing import (
+    PROGRAM_STATE_FILE,
     CheckpointConfig,
     CheckpointNotFoundError,
+    _atomic_write,
     _find_latest_checkpoint_subdir,
 )
 from divi.reporting._events import EventKind, ProgressEvent, TerminalStatus
@@ -39,6 +41,7 @@ from divi.reporting._events import EventKind, ProgressEvent, TerminalStatus
 from ._qaoa import QAOA
 
 DEPTH_SUBDIR_PREFIX = "depth_"
+TERMINAL_STATE_FILE = "iterative_terminal.json"
 
 
 def _extract_depth_from_subdir(path: Path) -> int | None:
@@ -348,14 +351,12 @@ class IterativeQAOA(QAOA):
         self._resumed_from_checkpoint = True
 
     @classmethod
-    def load_state(
+    def _resolve_checkpoint_path(
         cls,
         checkpoint_dir: Path | str,
-        backend: CircuitRunner,
         subdirectory: str | None = None,
-        **kwargs,
-    ) -> Self:
-        """Load from a checkpoint directory, resolving the deepest depth first.
+    ) -> Path:
+        """Resolve the deepest checkpointed depth before its iteration.
 
         ``run()`` writes each depth under its own ``depth_NN`` subdirectory, so
         a directory holding those is resolved to the deepest one carrying a
@@ -363,6 +364,20 @@ class IterativeQAOA(QAOA):
         """
         main_dir = Path(checkpoint_dir)
         if subdirectory is None and main_dir.is_dir():
+            terminal_file = main_dir / TERMINAL_STATE_FILE
+            if terminal_file.is_file():
+                try:
+                    terminal = json.loads(terminal_file.read_text())
+                    terminal_depth = terminal["depth"]
+                    if not isinstance(terminal_depth, int):
+                        raise ValueError
+                    terminal_dir = (
+                        main_dir / f"{DEPTH_SUBDIR_PREFIX}{terminal_depth:02d}"
+                    )
+                    _find_latest_checkpoint_subdir(terminal_dir)
+                    main_dir = terminal_dir
+                except (KeyError, OSError, TypeError, ValueError, json.JSONDecodeError):
+                    pass
             depth_dirs = sorted(
                 (
                     d
@@ -373,6 +388,8 @@ class IterativeQAOA(QAOA):
                 reverse=True,
             )
             for depth_dir in depth_dirs:
+                if main_dir != Path(checkpoint_dir):
+                    break
                 try:
                     _find_latest_checkpoint_subdir(depth_dir)
                 except CheckpointNotFoundError:
@@ -380,8 +397,36 @@ class IterativeQAOA(QAOA):
                 main_dir = depth_dir
                 break
 
-        return super().load_state(
-            main_dir, backend, subdirectory=subdirectory, **kwargs
+        return super()._resolve_checkpoint_path(main_dir, subdirectory)
+
+    def _write_terminal_checkpoint(self, checkpoint_config: CheckpointConfig) -> None:
+        """Make the sampled best-depth state the root checkpoint target."""
+        if checkpoint_config.checkpoint_dir is None:
+            return
+        root = Path(checkpoint_config.checkpoint_dir)
+        depth_dir = root / f"{DEPTH_SUBDIR_PREFIX}{self._best_depth:02d}"
+        checkpoint_path = _find_latest_checkpoint_subdir(depth_dir)
+        _, stored = type(self)._load_checkpoint_state(depth_dir)
+        current = self._make_checkpoint(checkpoint_path)
+        terminal_state = stored.model_copy(
+            update={
+                "best_loss": current.best_loss,
+                "best_probs": current.best_probs,
+                "best_params": current.best_params,
+                "final_params": current.final_params,
+                "total_circuit_count": current.total_circuit_count,
+                "total_run_time": current.total_run_time,
+                "rng_state_bytes": current.rng_state_bytes,
+                "subclass_state": current.subclass_state,
+            }
+        )
+        _atomic_write(
+            checkpoint_path / PROGRAM_STATE_FILE,
+            terminal_state.model_dump_json(indent=2),
+        )
+        _atomic_write(
+            root / TERMINAL_STATE_FILE,
+            json.dumps({"depth": self._best_depth}, indent=2),
         )
 
     @staticmethod
@@ -459,7 +504,8 @@ class IterativeQAOA(QAOA):
             checkpoint_config: Each depth is checkpointed under its own
                 ``depth_NN`` subdirectory of ``checkpoint_dir``, so depths do
                 not overwrite one another and
-                :meth:`load_state` can resume the schedule where it stopped.
+                :meth:`~divi.qprog.variational_quantum_algorithm.VariationalQuantumAlgorithm.load_state`
+                can resume the schedule where it stopped.
             **kwargs: Additional keyword arguments passed to the parent ``run()``.
 
         Returns:
@@ -472,6 +518,14 @@ class IterativeQAOA(QAOA):
                 "parameters. Use QAOA directly if you want to seed the first run.",
                 UserWarning,
                 stacklevel=2,
+            )
+
+        if (
+            checkpoint_config is not None
+            and checkpoint_config.checkpoint_dir is not None
+        ):
+            (Path(checkpoint_config.checkpoint_dir) / TERMINAL_STATE_FILE).unlink(
+                missing_ok=True
             )
 
         resuming = self._resumed_from_checkpoint
@@ -572,10 +626,13 @@ class IterativeQAOA(QAOA):
         # Restore the instance to the best depth
         self._rebuild_for_depth(self._best_depth)
         self._best_params = best_entry["best_params"]
+        self._final_params = self._best_params.copy()
         self._best_loss = best_entry["best_loss"]
 
         if perform_final_computation:
             self.sample_solution(**kwargs)
+            if checkpoint_config is not None:
+                self._write_terminal_checkpoint(checkpoint_config)
 
         return self
 

--- a/divi/qprog/algorithms/_qaoa.py
+++ b/divi/qprog/algorithms/_qaoa.py
@@ -25,6 +25,7 @@ from divi.hamiltonians._term_ops import (
 )
 from divi.pipeline import Stage
 from divi.pipeline.stages import TrotterSpecStage
+from divi.qprog._program_checkpoint import _to_jsonable
 from divi.qprog._solution_sampling_mixin import SolutionEntry, SolutionSamplingMixin
 from divi.qprog.algorithms import InitialState
 from divi.qprog.problems import QAOAProblem
@@ -187,8 +188,8 @@ class QAOA(SolutionSamplingMixin, VariationalQuantumAlgorithm):
             None if self._solution_bitstring is _UNSET else self._solution_bitstring
         )
         return {
-            "problem_metadata": self.problem_metadata,
-            "decoded_solution": decoded,
+            "problem_metadata": _to_jsonable(self.problem_metadata),
+            "decoded_solution": _to_jsonable(decoded),
             "solution_bitstring": bitstring,
             "loss_constant": self.loss_constant,
             "trotterization_strategy": pickle.dumps(

--- a/divi/qprog/algorithms/_time_evolution.py
+++ b/divi/qprog/algorithms/_time_evolution.py
@@ -3,9 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Sequence
+from pathlib import Path
 from typing import Any, Self
 
 import numpy as np
+from pydantic import Field
 from qiskit.circuit import Parameter, QuantumCircuit
 from qiskit.converters import circuit_to_dag
 from qiskit.quantum_info import SparsePauliOp
@@ -31,9 +33,14 @@ from divi.pipeline import (
 )
 from divi.pipeline.stages import ParameterBindingStage, TrotterSpecStage
 from divi.qprog import ObservableMeasuringMixin
+from divi.qprog._program_checkpoint import ProgramCheckpoint
 from divi.qprog.algorithms import InitialState, ZerosState
 from divi.qprog.quantum_program import QuantumProgram, reject_unclaimed_run_kwargs
 from divi.reporting._events import ProgressEvent, TerminalStatus
+
+
+class _TimeEvolutionCheckpoint(ProgramCheckpoint):
+    results: dict[str, float] | float | list[float] = Field(validation_alias="_results")
 
 
 class TimeEvolution(ObservableMeasuringMixin, QuantumProgram):
@@ -43,6 +50,21 @@ class TimeEvolution(ObservableMeasuringMixin, QuantumProgram):
     Trotter-Suzuki decomposition. Uses Divi's TrotterizationStrategy
     (``ExactTrotterization``, ``QDrift``) for term selection and approximation.
     """
+
+    def _make_checkpoint(
+        self,
+        checkpoint_dir: Path,
+    ) -> _TimeEvolutionCheckpoint:
+        if self._results is None:
+            raise RuntimeError("TimeEvolution has no completed results to checkpoint.")
+        return _TimeEvolutionCheckpoint._from_program(self)
+
+    def _restore_checkpoint(self, checkpoint_json: str, checkpoint_dir: Path) -> bool:
+        checkpoint = _TimeEvolutionCheckpoint.model_validate_json(checkpoint_json)
+        if checkpoint.program_type != type(self).__name__:
+            raise ValueError("Checkpoint is for a different program type.")
+        self._results = checkpoint.results
+        return True
 
     def __init__(
         self,

--- a/divi/qprog/checkpointing.py
+++ b/divi/qprog/checkpointing.py
@@ -5,6 +5,7 @@
 """Checkpointing utilities for variational quantum algorithms."""
 
 import json
+import os
 import shutil
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -215,6 +216,17 @@ class CheckpointCorruptedError(CheckpointError):
         self.details = details
 
 
+def _fsync_directory(path: Path) -> None:
+    """Persist directory-entry changes where the platform supports it."""
+    if os.name != "posix":
+        return
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
 def _atomic_write(path: Path, content: str) -> None:
     """Write content to a file atomically using a temporary file and rename.
 
@@ -232,7 +244,10 @@ def _atomic_write(path: Path, content: str) -> None:
     try:
         with open(temp_file, "w") as f:
             f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
         temp_file.replace(path)
+        _fsync_directory(path.parent)
     except Exception as e:
         if temp_file.exists():
             temp_file.unlink()

--- a/divi/qprog/ensemble.py
+++ b/divi/qprog/ensemble.py
@@ -6,11 +6,12 @@ import atexit
 import logging
 import os
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Hashable
+from collections.abc import Callable, Container, Hashable
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from contextlib import ExitStack
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, replace
 from enum import Enum
+from pathlib import Path
 from threading import Event
 from typing import Any, Self, cast
 from warnings import warn
@@ -27,7 +28,25 @@ from divi.qprog._batch_coordinator import (
     _BatchCoordinator,
     _ProxyBackend,
 )
+from divi.qprog._ensemble_checkpoint import (
+    PROGRAM_COMPLETION_FILE,
+    ROUND_COMPLETION_FILE,
+    ROUND_START_FILE,
+    ProgramRoundRecord,
+    RoundCheckpoint,
+    _encode_program_id,
+    _program_checkpoint_path,
+    _resolve_ensemble_checkpoint,
+    _round_dir,
+)
+from divi.qprog._program_checkpoint import ProgramCheckpoint
 from divi.qprog._solution_sampling_mixin import SolutionSamplingMixin
+from divi.qprog.checkpointing import (
+    CheckpointConfig,
+    CheckpointNotFoundError,
+    _atomic_write,
+    _ensure_checkpoint_dir,
+)
 from divi.qprog.quantum_program import QuantumProgram
 from divi.qprog.variational_quantum_algorithm import VariationalQuantumAlgorithm
 from divi.reporting._events import (
@@ -52,6 +71,211 @@ __all__ = [
 ]
 
 logger = logging.getLogger(__name__)
+
+
+def _qualified_type(value: Any) -> str:
+    cls = value if isinstance(value, type) else type(value)
+    return f"{cls.__module__}.{cls.__qualname__}"
+
+
+@dataclass
+class _RoundCheckpointSession:
+    checkpoint_path_by_program: dict[QuantumProgram, Path]
+    iterative_config_by_program: dict[QuantumProgram, CheckpointConfig]
+    restored_programs: set[QuantumProgram]
+    recovered_circuit_count: int = 0
+    recovered_run_time: float = 0.0
+
+    @classmethod
+    def inactive(cls) -> Self:
+        """Session for a round that is not being checkpointed."""
+        return cls({}, {}, set())
+
+    @classmethod
+    def prepare(
+        cls,
+        *,
+        checkpoint_config: CheckpointConfig,
+        round_path: Path,
+        ensemble_type: str,
+        round_index: int,
+        ensemble_state: dict[str, Any],
+        programs: list[QuantumProgram],
+        child_recovery_states: list[ProgramRoundRecord],
+        interrupted_checkpoint: RoundCheckpoint | None,
+    ) -> Self:
+        round_path.mkdir(parents=True, exist_ok=True)
+        restoring_children = interrupted_checkpoint is not None
+        if interrupted_checkpoint is None:
+            interrupted_checkpoint = RoundCheckpoint(
+                kind="round_start",
+                ensemble_type=ensemble_type,
+                round_index=round_index,
+                ensemble_state=ensemble_state,
+                programs=child_recovery_states,
+            )
+            _atomic_write(
+                round_path / ROUND_START_FILE,
+                interrupted_checkpoint.model_dump_json(indent=2, exclude_none=True),
+            )
+        else:
+            cls._validate_structure(interrupted_checkpoint, child_recovery_states)
+
+        saved_recovery_states = interrupted_checkpoint.round_start_data()
+        recovery_state_by_program = dict(zip(programs, saved_recovery_states))
+        checkpoint_path_by_program = {
+            program: _program_checkpoint_path(round_path, slot)
+            for slot, program in enumerate(programs)
+        }
+        for path in checkpoint_path_by_program.values():
+            path.mkdir(parents=True, exist_ok=True)
+
+        session = cls(
+            checkpoint_path_by_program=checkpoint_path_by_program,
+            iterative_config_by_program={
+                program: replace(
+                    checkpoint_config,
+                    checkpoint_dir=checkpoint_path_by_program[program],
+                )
+                for program in programs
+                if cls._supports_iterative(program)
+            },
+            restored_programs=set(),
+        )
+        if restoring_children:
+            session._recover(programs, recovery_state_by_program)
+        return session
+
+    @staticmethod
+    def _validate_structure(
+        persisted_checkpoint: RoundCheckpoint,
+        child_recovery_states: list[ProgramRoundRecord],
+    ) -> None:
+        def key(entry: ProgramRoundRecord) -> tuple[Any, ...]:
+            return entry.program_id, entry.program_type
+
+        persisted_states = persisted_checkpoint.round_start_data()
+        if len(persisted_states) != len(child_recovery_states) or any(
+            key(saved) != key(fresh)
+            for saved, fresh in zip(persisted_states, child_recovery_states)
+        ):
+            raise ValueError(
+                "Child recovery states do not match reconstructed programs."
+            )
+
+    @staticmethod
+    def _supports_iterative(program: QuantumProgram) -> bool:
+        return (
+            isinstance(program, VariationalQuantumAlgorithm)
+            and program.optimizer.supports_checkpointing
+            and program._early_stopping is None
+        )
+
+    def _recover(
+        self,
+        programs: list[QuantumProgram],
+        recovery_state_by_program: dict[QuantumProgram, ProgramRoundRecord],
+    ) -> None:
+        circuits = 0
+        runtime = 0.0
+        for slot, program in enumerate(programs):
+            recovery_state = recovery_state_by_program[program]
+            path = self.checkpoint_path_by_program[program]
+
+            restored = False
+            marker_path = path / PROGRAM_COMPLETION_FILE
+            if marker_path.is_file():
+                try:
+                    checkpoint_json = marker_path.read_text()
+                    metadata = ProgramCheckpoint.model_validate_json(
+                        checkpoint_json, extra="ignore"
+                    )
+                    if metadata.program_type != type(program).__name__:
+                        raise ValueError("Completed child checkpoint type changed.")
+                    recovered_circuits, recovered_runtime = self._recovered_accounting(
+                        recovery_state, metadata
+                    )
+                    if not program._restore_checkpoint(checkpoint_json, path):
+                        raise ValueError("Child does not support checkpoint restore.")
+                except Exception:
+                    logger.warning(
+                        "Could not restore completed ensemble child in slot %d; "
+                        "trying iterative recovery.",
+                        slot,
+                        exc_info=True,
+                    )
+                else:
+                    self.restored_programs.add(program)
+                    circuits += recovered_circuits
+                    runtime += recovered_runtime
+                    restored = True
+
+            if restored or program not in self.iterative_config_by_program:
+                continue
+            try:
+                vqa = cast(VariationalQuantumAlgorithm, program)
+                checkpoint_path, checkpoint = type(vqa)._load_checkpoint_state(path)
+                recovered_circuits, recovered_runtime = self._recovered_accounting(
+                    recovery_state, checkpoint
+                )
+                vqa._restore_loaded_checkpoint(checkpoint_path, checkpoint)
+            except Exception:
+                logger.warning(
+                    "Could not restore iterative ensemble child in slot %d; "
+                    "restarting it.",
+                    slot,
+                    exc_info=True,
+                )
+            else:
+                circuits += recovered_circuits
+                runtime += recovered_runtime
+
+        self.recovered_circuit_count = circuits
+        self.recovered_run_time = runtime
+
+    @staticmethod
+    def _recovered_accounting(
+        recovery_state: ProgramRoundRecord, checkpoint: ProgramCheckpoint
+    ) -> tuple[int, float]:
+        circuits = (
+            checkpoint.total_circuit_count - recovery_state.circuit_count_at_round_start
+        )
+        runtime = checkpoint.total_run_time - recovery_state.run_time_at_round_start
+        if circuits < 0 or runtime < 0:
+            raise ValueError("Recovered child accounting is negative.")
+        return circuits, runtime
+
+    def child_config(self, program: QuantumProgram) -> CheckpointConfig | None:
+        return self.iterative_config_by_program.get(program)
+
+    def was_restored(self, program: QuantumProgram) -> bool:
+        return program in self.restored_programs
+
+    def commit_completed(self, program: QuantumProgram) -> None:
+        path = self.checkpoint_path_by_program.get(program)
+        if path is None:
+            return
+        checkpoint = program._make_checkpoint(path)
+        if checkpoint is None:
+            return
+        _atomic_write(
+            path / PROGRAM_COMPLETION_FILE,
+            checkpoint.model_dump_json(indent=2),
+        )
+
+    def execute(
+        self,
+        program: QuantumProgram,
+        operation: Callable[[QuantumProgram], Any],
+        *,
+        commit_completion: bool,
+    ) -> Any:
+        if self.was_restored(program):
+            return program
+        result = operation(program)
+        if commit_completion:
+            self.commit_completed(program)
+        return result
 
 
 class ReportingLevel(str, Enum):
@@ -102,10 +326,6 @@ _BARRIER_PROGRAM_LIMIT = 256
 #: Above this many ``max_concurrent_programs``, ``run`` warns to flag a
 #: likely misuse of the knob (e.g. the user wanted ``max_batch_size``).
 _CONCURRENT_PROGRAMS_SOFT_CAP = 1024
-
-
-def _default_task_function(program: QuantumProgram):
-    return program.run()
 
 
 def _resolve_worker_count(batch_config: BatchConfig, n_programs: int) -> int:
@@ -324,6 +544,9 @@ class ProgramEnsemble(ABC):
         # Set by join() when a round is cut short by KeyboardInterrupt, so
         # run() can stop the workflow instead of starting another round.
         self._round_cancelled = False
+        self._resumed_from_checkpoint = False
+        self._interrupted_checkpoint: RoundCheckpoint | None = None
+        self._restored_checkpoint_root: Path | None = None
 
         self._progress_session: ProgressSession | None = None
         self._progress_bindings: ExitStack | None = None
@@ -441,6 +664,26 @@ class ProgramEnsemble(ABC):
         """Return the state supplied to the first workflow round."""
         return None
 
+    def _save_workflow_checkpoint_state(
+        self, state: Any, round_dir: Path, stem: str
+    ) -> dict[str, Any]:
+        """Serialize mutable workflow state for an ensemble checkpoint."""
+        if state is not None:
+            raise NotImplementedError(
+                f"{type(self).__name__} must implement workflow-state checkpointing."
+            )
+        return {}
+
+    def _load_workflow_checkpoint_state(
+        self, payload: dict[str, Any], round_dir: Path, stem: str
+    ) -> Any:
+        """Deserialize mutable workflow state from an ensemble checkpoint."""
+        if payload:
+            raise NotImplementedError(
+                f"{type(self).__name__} must implement workflow-state checkpointing."
+            )
+        return None
+
     def update_state(self, state: Any) -> Any:
         """Reduce the finished round's results into the next round's state.
 
@@ -528,6 +771,9 @@ class ProgramEnsemble(ABC):
         self._round_history.clear()
         self._round_index = 0
         self._round_context = None
+        self._resumed_from_checkpoint = False
+        self._interrupted_checkpoint = None
+        self._restored_checkpoint_root = None
 
     def reset(self):
         """
@@ -642,6 +888,7 @@ class ProgramEnsemble(ABC):
         blocking: bool = False,
         *,
         batch_config: BatchConfig = BatchConfig(),
+        _checkpoint_session: _RoundCheckpointSession | None = None,
     ):
         """
         Execute the currently materialised programs once.
@@ -693,12 +940,22 @@ class ProgramEnsemble(ABC):
                 "sampling needs training to finish first. Pass blocking=True, "
                 "or unset sampling_backend."
             )
-        dispatched = self._dispatch_round(blocking=blocking, batch_config=batch_config)
+        dispatched = self._dispatch_round(
+            blocking=blocking,
+            batch_config=batch_config,
+            checkpoint_session=_checkpoint_session,
+        )
         # Submitted — a later run() must not treat this map as pending.
         self._programs_pending = False
         return dispatched
 
-    def _dispatch_round(self, *, blocking: bool, batch_config: BatchConfig) -> Self:
+    def _dispatch_round(
+        self,
+        *,
+        blocking: bool,
+        batch_config: BatchConfig,
+        checkpoint_session: _RoundCheckpointSession | None = None,
+    ) -> Self:
         """Dispatch the currently materialised programs for one round.
 
         Without ``sampling_backend`` this is a plain dispatch. With it,
@@ -707,9 +964,22 @@ class ProgramEnsemble(ABC):
         ``sampling_backend`` — so the first dispatch is always blocking
         regardless of ``blocking``.
         """
+        session = checkpoint_session or _RoundCheckpointSession.inactive()
+
         if self._sampling_backend is None:
+
+            def task_fn(program: QuantumProgram):
+                child_config = session.child_config(program)
+
+                def operation(child: QuantumProgram):
+                    if child_config is None:
+                        return child.run()
+                    return child.run(checkpoint_config=child_config)
+
+                return session.execute(program, operation, commit_completion=True)
+
             return self._dispatch(
-                task_fn=_default_task_function,
+                task_fn=task_fn,
                 blocking=blocking,
                 batch_config=batch_config,
             )
@@ -717,22 +987,42 @@ class ProgramEnsemble(ABC):
         _validate_sampling_programs(self._programs, action="sampling_backend workflow")
 
         def _train_without_sampling(program: QuantumProgram):
-            return cast(VariationalQuantumAlgorithm, program).run(
-                perform_final_computation=False
-            )
+            child_config = session.child_config(program)
+
+            def operation(child: QuantumProgram):
+                vqa = cast(VariationalQuantumAlgorithm, child)
+                if child_config is None:
+                    return vqa.run(perform_final_computation=False)
+                return vqa.run(
+                    perform_final_computation=False,
+                    checkpoint_config=child_config,
+                )
+
+            return session.execute(program, operation, commit_completion=False)
 
         self._dispatch(
             task_fn=_train_without_sampling, blocking=True, batch_config=batch_config
         )
         if self._round_cancelled:
             return self
-        return self.sample_solution(blocking=blocking, batch_config=batch_config)
+        resolved = _resolve_sampling_params(
+            self._programs, None, suppress_strict_warning=False
+        )
+        return self._dispatch_sample_solution(
+            resolved,
+            backend=self._sampling_backend,
+            blocking=blocking,
+            batch_config=batch_config,
+            restored_programs=session.restored_programs,
+            on_sampled=session.commit_completed,
+        )
 
     def run(
         self,
         *,
         max_rounds: int | None = None,
         batch_config: BatchConfig = BatchConfig(),
+        checkpoint_config: CheckpointConfig = CheckpointConfig(),
     ) -> Self:
         """Run this ensemble's state-dependent workflow to completion.
 
@@ -750,6 +1040,9 @@ class ProgramEnsemble(ABC):
                 :meth:`is_complete` is still false. ``None`` runs until
                 convergence.
             batch_config: Forwarded to each round's dispatch.
+            checkpoint_config: Checkpoint directory and child VQA checkpoint
+                interval. The ensemble writes workflow state at every round
+                boundary.
 
         Returns:
             ProgramEnsemble: Returns self for method chaining. The terminal
@@ -769,9 +1062,34 @@ class ProgramEnsemble(ABC):
         if self._executor is not None:
             raise RuntimeError("An ensemble is already being run.")
 
-        self._reset_workflow_state()
-        state = self.initial_state()
-        self._workflow_state = state
+        interrupted_checkpoint = self._interrupted_checkpoint
+        self._interrupted_checkpoint = None
+
+        if self._resumed_from_checkpoint:
+            if (
+                checkpoint_config.checkpoint_dir is None
+                and self._restored_checkpoint_root is not None
+            ):
+                checkpoint_config = replace(
+                    checkpoint_config,
+                    checkpoint_dir=self._restored_checkpoint_root,
+                )
+            state = self._workflow_state
+            self._resumed_from_checkpoint = False
+        else:
+            if checkpoint_config.checkpoint_dir is not None:
+                try:
+                    _resolve_ensemble_checkpoint(checkpoint_config.checkpoint_dir)
+                except CheckpointNotFoundError:
+                    pass
+                else:
+                    raise RuntimeError(
+                        "Checkpoint directory already contains an ensemble "
+                        "checkpoint. Restore it or use a fresh directory."
+                    )
+            self._reset_workflow_state()
+            state = self.initial_state()
+            self._workflow_state = state
         use_caller_programs = self._programs_pending and bool(self._programs)
 
         while True:
@@ -790,13 +1108,35 @@ class ProgramEnsemble(ABC):
             self._round_context = (self._round_index, max_rounds)
             self._round_cancelled = False
             program_count = len(self._programs)
+            round_input_snapshot = None
             try:
+                if (
+                    interrupted_checkpoint is None
+                    and checkpoint_config.checkpoint_dir is not None
+                ):
+                    round_input_snapshot = self._save_round_input_state(
+                        state, checkpoint_config
+                    )
                 if not use_caller_programs:
                     self._clear_completed_round()
                     self.create_programs(state)
                 use_caller_programs = False
                 program_count = len(self._programs)
-                self.run_one_round(blocking=True, batch_config=batch_config)
+                checkpoint_session = self._prepare_checkpoint_session(
+                    state,
+                    checkpoint_config,
+                    interrupted_checkpoint,
+                    round_input_snapshot,
+                )
+                interrupted_checkpoint = None
+                self._total_circuit_count += checkpoint_session.recovered_circuit_count
+                self._total_run_time += checkpoint_session.recovered_run_time
+                self.run_one_round(
+                    blocking=True,
+                    batch_config=batch_config,
+                    _checkpoint_session=checkpoint_session,
+                )
+                self._programs_pending = False
                 if self._round_cancelled:
                     # Ctrl-C during the round: don't reduce partial results
                     # into the state, and don't start another round.
@@ -809,6 +1149,18 @@ class ProgramEnsemble(ABC):
                     )
                     break
                 state = self.update_state(state)
+                completed_record = self._round_record(
+                    program_count,
+                    circuits_before,
+                    runtime_before,
+                    status=WorkflowStatus.COMPLETE,
+                )
+                if checkpoint_config.checkpoint_dir is not None:
+                    self._save_completed_round_checkpoint(
+                        checkpoint_config,
+                        state,
+                        [*self._round_history, completed_record],
+                    )
             except KeyboardInterrupt:
                 # Ctrl-C outside the dispatch, most likely in update_state's
                 # classical reduction. Leave the state at its last complete
@@ -837,15 +1189,240 @@ class ProgramEnsemble(ABC):
                 self._round_context = None
 
             self._workflow_state = state
-            self._record_round(
-                program_count,
-                circuits_before,
-                runtime_before,
-                status=WorkflowStatus.COMPLETE,
-            )
+            self._round_history.append(completed_record)
 
         self._workflow_state = state
         return self
+
+    def _child_recovery_states(self) -> list[ProgramRoundRecord]:
+        return [
+            ProgramRoundRecord(
+                program_id=_encode_program_id(program_id),
+                program_type=_qualified_type(program),
+                circuit_count_at_round_start=program.total_circuit_count,
+                run_time_at_round_start=program.total_run_time,
+            )
+            for program_id, program in self._programs.items()
+        ]
+
+    def _prepare_checkpoint_session(
+        self,
+        state: Any,
+        checkpoint_config: CheckpointConfig,
+        interrupted_checkpoint: RoundCheckpoint | None = None,
+        round_input_snapshot: tuple[Path, dict[str, Any]] | None = None,
+    ) -> _RoundCheckpointSession:
+        if interrupted_checkpoint is None and checkpoint_config.checkpoint_dir is None:
+            return _RoundCheckpointSession.inactive()
+
+        if interrupted_checkpoint is not None:
+            checkpoint_dir = checkpoint_config.checkpoint_dir
+            if checkpoint_dir is None:
+                raise ValueError("A checkpoint directory is required.")
+            round_path = _round_dir(
+                Path(checkpoint_dir), interrupted_checkpoint.round_index
+            )
+            ensemble_state_payload = interrupted_checkpoint.ensemble_state
+        else:
+            if round_input_snapshot is None:
+                checkpoint_dir = checkpoint_config.checkpoint_dir
+                if checkpoint_dir is None:
+                    raise ValueError("A checkpoint directory is required.")
+                root = _ensure_checkpoint_dir(checkpoint_dir)
+                round_path = _round_dir(root, self._round_index)
+                # The workflow-state artifact is written here, before prepare().
+                round_path.mkdir(parents=True, exist_ok=True)
+                ensemble_state_payload = self._save_workflow_checkpoint_state(
+                    state, round_path, "input_state"
+                )
+            else:
+                round_path, ensemble_state_payload = round_input_snapshot
+
+        child_recovery_states = self._child_recovery_states()
+        return _RoundCheckpointSession.prepare(
+            checkpoint_config=checkpoint_config,
+            round_path=round_path,
+            ensemble_type=_qualified_type(self),
+            round_index=self._round_index,
+            ensemble_state=ensemble_state_payload,
+            programs=list(self._programs.values()),
+            child_recovery_states=child_recovery_states,
+            interrupted_checkpoint=interrupted_checkpoint,
+        )
+
+    def _save_round_input_state(
+        self, state: Any, checkpoint_config: CheckpointConfig
+    ) -> tuple[Path, dict[str, Any]]:
+        """Snapshot round input before program construction consumes RNG state."""
+        checkpoint_dir = checkpoint_config.checkpoint_dir
+        if checkpoint_dir is None:
+            raise ValueError("A checkpoint directory is required.")
+        root = _ensure_checkpoint_dir(checkpoint_dir)
+        round_path = _round_dir(root, self._round_index)
+        round_path.mkdir(parents=True, exist_ok=True)
+        ensemble_state_payload = self._save_workflow_checkpoint_state(
+            state, round_path, "input_state"
+        )
+        return round_path, ensemble_state_payload
+
+    @staticmethod
+    def _serialize_round_history(
+        history: list[RoundRecord],
+    ) -> list[dict[str, Any]]:
+        return [{**asdict(record), "status": record.status.value} for record in history]
+
+    def _save_completed_round_checkpoint(
+        self,
+        checkpoint_config: CheckpointConfig,
+        state: Any,
+        history: list[RoundRecord],
+    ) -> Path:
+        checkpoint_dir = checkpoint_config.checkpoint_dir
+        if checkpoint_dir is None:
+            raise ValueError("A checkpoint directory is required.")
+        root = _ensure_checkpoint_dir(checkpoint_dir)
+        round_path = _round_dir(root, self._round_index)
+        round_path.mkdir(parents=True, exist_ok=True)
+        ensemble_state_payload = self._save_workflow_checkpoint_state(
+            state, round_path, "output_state"
+        )
+        completed = RoundCheckpoint(
+            kind="round_completion",
+            ensemble_type=_qualified_type(self),
+            round_index=self._round_index,
+            ensemble_state=ensemble_state_payload,
+            round_history=self._serialize_round_history(history),
+            total_circuit_count=self.total_circuit_count,
+            total_run_time=self.total_run_time,
+        )
+        _atomic_write(
+            round_path / ROUND_COMPLETION_FILE,
+            completed.model_dump_json(indent=2, exclude_none=True),
+        )
+        return round_path
+
+    def save_state(self, checkpoint_config: CheckpointConfig) -> Path:
+        """Persist the latest successfully completed ensemble round."""
+        if self._executor is not None:
+            raise RuntimeError("Cannot save an ensemble while it is running.")
+        if (
+            not self._round_history
+            or self._round_history[-1].status is not WorkflowStatus.COMPLETE
+        ):
+            raise RuntimeError("Cannot save an ensemble before a round has completed.")
+        if checkpoint_config.checkpoint_dir is None:
+            raise ValueError(
+                "checkpoint_config.checkpoint_dir must be a non-None Path."
+            )
+        return self._save_completed_round_checkpoint(
+            checkpoint_config, self._workflow_state, list(self._round_history)
+        )
+
+    @staticmethod
+    def _deserialize_round_history(
+        history: list[dict[str, Any]],
+    ) -> list[RoundRecord]:
+        return [
+            RoundRecord(
+                number=record["number"],
+                program_count=record["program_count"],
+                circuit_count=record["circuit_count"],
+                run_time=record["run_time"],
+                status=WorkflowStatus(record["status"]),
+                error=record.get("error"),
+            )
+            for record in history
+        ]
+
+    def restore_state(
+        self,
+        checkpoint_dir: Path | str,
+        subdirectory: str | None = None,
+    ) -> Self:
+        """Restore the latest ensemble checkpoint onto this instance."""
+        if self._executor is not None:
+            raise RuntimeError("Cannot restore an ensemble while it is running.")
+        if self._programs:
+            raise RuntimeError(
+                "Cannot restore onto an ensemble with pre-materialized programs."
+            )
+        checkpoint = _resolve_ensemble_checkpoint(checkpoint_dir, subdirectory)
+        round_path = _round_dir(Path(checkpoint_dir), checkpoint.round_index)
+        expected_type = _qualified_type(self)
+        if checkpoint.ensemble_type != expected_type:
+            raise ValueError(
+                f"Checkpoint contains {checkpoint.ensemble_type}, "
+                f"not {expected_type}."
+            )
+        if checkpoint.kind == "round_completion":
+            round_history_data, total_circuit_count, total_run_time = (
+                checkpoint.round_completion_data()
+            )
+            history = self._deserialize_round_history(round_history_data)
+            round_index = checkpoint.round_index
+            interrupted_checkpoint = None
+        else:
+            interrupted_checkpoint = checkpoint
+            history = []
+            total_circuit_count = 0
+            total_run_time = 0.0
+            for candidate_index in range(interrupted_checkpoint.round_index - 1, 0, -1):
+                try:
+                    completed_checkpoint = _resolve_ensemble_checkpoint(
+                        checkpoint_dir, f"round_{candidate_index:03d}"
+                    )
+                except CheckpointNotFoundError:
+                    continue
+                if completed_checkpoint.kind == "round_completion":
+                    if completed_checkpoint.ensemble_type != expected_type:
+                        raise ValueError(
+                            "Checkpoint history contains an earlier completed round "
+                            "from a different ensemble type."
+                        )
+                    round_history_data, total_circuit_count, total_run_time = (
+                        completed_checkpoint.round_completion_data()
+                    )
+                    history = self._deserialize_round_history(round_history_data)
+                    break
+            round_index = interrupted_checkpoint.round_index - 1
+
+        stem = (
+            "output_state" if checkpoint.kind == "round_completion" else "input_state"
+        )
+        state = self._load_workflow_checkpoint_state(
+            checkpoint.ensemble_state, round_path, stem
+        )
+
+        self._workflow_state = state
+        self._round_history = history
+        self._round_index = round_index
+        self._total_circuit_count = total_circuit_count
+        self._total_run_time = total_run_time
+        self._stop_reason = None
+        self._round_context = None
+        self._programs_pending = False
+        self._interrupted_checkpoint = interrupted_checkpoint
+        self._restored_checkpoint_root = Path(checkpoint_dir)
+        self._resumed_from_checkpoint = True
+        return self
+
+    def _round_record(
+        self,
+        program_count: int,
+        circuits_before: int,
+        runtime_before: float,
+        *,
+        status: WorkflowStatus,
+        error: str | None = None,
+    ) -> RoundRecord:
+        return RoundRecord(
+            number=self._round_index,
+            program_count=program_count,
+            circuit_count=self.total_circuit_count - circuits_before,
+            run_time=self.total_run_time - runtime_before,
+            status=status,
+            error=error,
+        )
 
     def _record_round(
         self,
@@ -858,11 +1435,10 @@ class ProgramEnsemble(ABC):
     ) -> None:
         """Append a :class:`RoundRecord` for the round now in progress."""
         self._round_history.append(
-            RoundRecord(
-                number=self._round_index,
-                program_count=program_count,
-                circuit_count=self.total_circuit_count - circuits_before,
-                run_time=self.total_run_time - runtime_before,
+            self._round_record(
+                program_count,
+                circuits_before,
+                runtime_before,
                 status=status,
                 error=error,
             )
@@ -969,6 +1545,35 @@ class ProgramEnsemble(ABC):
 
         return self
 
+    def _dispatch_sample_solution(
+        self,
+        resolved: dict[Any, npt.NDArray[np.float64]],
+        *,
+        backend: CircuitRunner | None,
+        blocking: bool,
+        batch_config: BatchConfig,
+        restored_programs: Container[QuantumProgram] = frozenset(),
+        on_sampled: Callable[[QuantumProgram], None] | None = None,
+    ) -> Self:
+        program_to_id = {program: pid for pid, program in self._programs.items()}
+
+        def _sample_solution_task(program: VariationalQuantumAlgorithm):
+            if program in restored_programs:
+                return program
+            result = cast(SolutionSamplingMixin, program).sample_solution(
+                resolved[program_to_id[program]], backend=program.backend
+            )
+            if on_sampled is not None:
+                on_sampled(program)
+            return result
+
+        return self._dispatch(
+            task_fn=_sample_solution_task,
+            blocking=blocking,
+            batch_config=batch_config,
+            backend=backend,
+        )
+
     def sample_solution(
         self,
         params_per_program: dict[Any, npt.NDArray[np.float64]] | None = None,
@@ -1031,21 +1636,12 @@ class ProgramEnsemble(ABC):
             suppress_strict_warning=suppress_strict_warning,
         )
 
-        program_to_id = {program: pid for pid, program in self._programs.items()}
-
-        def _sample_solution_task(program: VariationalQuantumAlgorithm):
-            # Force the already-swapped program.backend so a program's own
-            # sampling_backend can't route around the merged-batching barrier.
-            return cast(SolutionSamplingMixin, program).sample_solution(
-                resolved[program_to_id[program]], backend=program.backend
-            )
-
         selected_backend = backend if backend is not None else self._sampling_backend
-        return self._dispatch(
-            task_fn=_sample_solution_task,
+        return self._dispatch_sample_solution(
+            resolved,
+            backend=selected_backend,
             blocking=blocking,
             batch_config=batch_config,
-            backend=selected_backend,
         )
 
     def check_all_done(self) -> bool:

--- a/divi/qprog/problems/_binary.py
+++ b/divi/qprog/problems/_binary.py
@@ -412,6 +412,10 @@ class BinaryOptimizationProblem(QAOAProblem):
 
         return sub_problems
 
+    def _has_reproducible_decomposition(self) -> bool:
+        """Whether repeated decomposition preserves program-slot meaning."""
+        return bool(getattr(self._decomposer, "_reproducible", False))
+
     def initial_solution_size(self) -> int:
         """Number of variables in the global solution vector.
 

--- a/divi/qprog/problems/_community_decomposer.py
+++ b/divi/qprog/problems/_community_decomposer.py
@@ -55,6 +55,8 @@ class CommunityDecomposer(traits.ProblemDecomposer, traits.SISO, Runnable):
         ImportError: If the ``qubo-decompose`` extra is not installed.
     """
 
+    _reproducible = True
+
     def __init__(
         self,
         *,

--- a/divi/qprog/problems/_graph_partitioning_utils.py
+++ b/divi/qprog/problems/_graph_partitioning_utils.py
@@ -263,7 +263,7 @@ def _split_graph(
             _pygraph_to_nx(graph) if isinstance(graph, rx.PyGraph) else graph
         )
         nx_results: list[tuple[nx.Graph, list]] = []
-        for part in nx.algorithms.community.kernighan_lin_bisection(nx_graph):
+        for part in nx.algorithms.community.kernighan_lin_bisection(nx_graph, seed=0):
             cluster = list(part)
             relabeled = nx.relabel_nodes(
                 nx_graph.subgraph(cluster).copy(),

--- a/divi/qprog/problems/_matching.py
+++ b/divi/qprog/problems/_matching.py
@@ -131,7 +131,7 @@ def _partition_graph_by_edges(
     graph: nx.Graph,
     max_edges: int,
     algorithm: Literal["kernighan_lin", "spectral"] = "kernighan_lin",
-    seed: int | None = None,
+    seed: int | None = 0,
 ) -> list[nx.Graph]:
     """Recursively partition a graph until each subgraph has <= *max_edges* edges.
 
@@ -160,6 +160,12 @@ def _partition_graph_by_edges(
             f"Unsupported partitioning algorithm: {algorithm!r}. "
             "Supported: 'kernighan_lin', 'spectral'."
         )
+
+    node_order = {node: index for index, node in enumerate(graph)}
+    if tuple(sorted(node_order[node] for node in part_b)) < tuple(
+        sorted(node_order[node] for node in part_a)
+    ):
+        part_a, part_b = part_b, part_a
 
     sg_a = graph.subgraph(part_a).copy()
     sg_b = graph.subgraph(part_b).copy()
@@ -199,7 +205,8 @@ def _kl_bisect(graph: nx.Graph, seed: int | None = None) -> tuple[set, set]:
 def _spectral_bisect(graph: nx.Graph) -> tuple[set, set]:
     """Fiedler-vector bisection on the graph Laplacian."""
     L = nx.laplacian_matrix(graph).astype(float)
-    _eigenvalues, eigenvectors = spla.eigsh(L, k=2, which="SM")
+    v0 = np.linspace(1.0, 2.0, graph.number_of_nodes())
+    _eigenvalues, eigenvectors = spla.eigsh(L, k=2, which="SM", v0=v0)
     fiedler = eigenvectors[:, 1]
     median = np.median(fiedler)
 
@@ -337,7 +344,7 @@ class MaxWeightMatchingProblem(QAOAProblem):
         max_edges_per_partition: int | None = None,
         partition_algorithm: Literal["kernighan_lin", "spectral"] = "kernighan_lin",
         use_classical_cleanup: bool = True,
-        seed: int | None = None,
+        seed: int | None = 0,
     ):
         self._graph = graph
         self._penalty_scale = penalty_scale

--- a/divi/qprog/quantum_program.py
+++ b/divi/qprog/quantum_program.py
@@ -5,6 +5,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Hashable, Iterator
 from contextlib import contextmanager
+from pathlib import Path
 from threading import Event
 from typing import Any, Self
 from warnings import warn
@@ -35,6 +36,7 @@ from divi.pipeline.stages import (
     PreprocessStage,
     QEMStage,
 )
+from divi.qprog._program_checkpoint import ProgramCheckpoint
 from divi.reporting._events import (
     ProgressEmitter,
     ProgressEvent,
@@ -124,6 +126,15 @@ class QuantumProgram(ABC):
         backend: The quantum circuit execution backend.
         _seed: Random seed for reproducible results.
     """
+
+    def _make_checkpoint(
+        self,
+        checkpoint_dir: Path,
+    ) -> ProgramCheckpoint | None:
+        return None
+
+    def _restore_checkpoint(self, checkpoint_json: str, checkpoint_dir: Path) -> bool:
+        return False
 
     def __init__(
         self,

--- a/divi/qprog/variational_quantum_algorithm.py
+++ b/divi/qprog/variational_quantum_algorithm.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import copy
 import logging
 import pickle
 from abc import abstractmethod
@@ -32,7 +33,11 @@ from divi.pipeline import (
 from divi.pipeline import cost_preprocessor as _default_cost_preprocessor
 from divi.pipeline.stages import ParameterBindingStage
 from divi.qprog import ObservableMeasuringMixin
-from divi.qprog._program_state import OptimizerConfig, ProgramState, SubclassState
+from divi.qprog._program_checkpoint import (
+    OptimizerConfig,
+    SubclassState,
+    VQACheckpoint,
+)
 from divi.qprog._solution_sampling_mixin import SolutionSamplingMixin
 from divi.qprog.checkpointing import (
     PROGRAM_STATE_FILE,
@@ -209,6 +214,23 @@ class VariationalQuantumAlgorithm(ObservableMeasuringMixin, QuantumProgram):
     _best_params: npt.NDArray[np.float64]
     _final_params: npt.NDArray[np.float64]
     _cost_circuit: MetaCircuit | None
+
+    def _make_checkpoint(
+        self,
+        checkpoint_dir: Path,
+    ) -> VQACheckpoint:
+        return VQACheckpoint.from_program(self, kind="program_completion")
+
+    def _restore_checkpoint(self, checkpoint_json: str, checkpoint_dir: Path) -> bool:
+        checkpoint = VQACheckpoint.model_validate_json(checkpoint_json)
+        if checkpoint.program_type != type(self).__name__:
+            raise ValueError(
+                f"Checkpoint is for {checkpoint.program_type}, not {type(self).__name__}."
+            )
+        if checkpoint.kind != "program_completion":
+            raise ValueError("Expected a completed VQA checkpoint.")
+        self._apply_checkpoint_state(checkpoint)
+        return True
 
     def __init__(
         self,
@@ -627,12 +649,104 @@ class VariationalQuantumAlgorithm(ObservableMeasuringMixin, QuantumProgram):
         self.optimizer.save_state(checkpoint_path)
 
         # 2. Save Program State (Pydantic pulls data via validation_aliases)
-        state = ProgramState.model_validate(self)
+        state = VQACheckpoint.from_program(self, kind="iteration")
 
         state_file = checkpoint_path / PROGRAM_STATE_FILE
         _atomic_write(state_file, state.model_dump_json(indent=2))
 
         return checkpoint_path
+
+    @classmethod
+    def _resolve_checkpoint_path(
+        cls,
+        checkpoint_dir: Path | str,
+        subdirectory: str | None = None,
+    ) -> Path:
+        """Resolve a program checkpoint, allowing subclasses to add nesting."""
+        return resolve_checkpoint_path(checkpoint_dir, subdirectory)
+
+    @classmethod
+    def _load_checkpoint_state(
+        cls,
+        checkpoint_dir: Path | str,
+        subdirectory: str | None = None,
+    ) -> tuple[Path, VQACheckpoint]:
+        """Read and validate the program portion of a checkpoint."""
+        checkpoint_path = cls._resolve_checkpoint_path(checkpoint_dir, subdirectory)
+        state = _load_and_validate_pydantic_model(
+            checkpoint_path / PROGRAM_STATE_FILE,
+            VQACheckpoint,
+            required_fields=["kind", "program_type", "current_iteration"],
+        )
+        if state.kind != "iteration":
+            raise ValueError("Expected an iterative VQA checkpoint.")
+        if state.program_type != cls.__name__:
+            raise ValueError(
+                f"Checkpoint contains {state.program_type}, not {cls.__name__}."
+            )
+        return checkpoint_path, state
+
+    @staticmethod
+    def _load_checkpoint_optimizer(
+        checkpoint_path: Path, state: VQACheckpoint
+    ) -> Optimizer:
+        """Reconstruct the optimizer recorded in a program checkpoint."""
+        opt_config = state.optimizer_config
+        if opt_config is None:
+            raise ValueError("Iterative checkpoint has no optimizer configuration.")
+        optimizer_class = _CHECKPOINTABLE_OPTIMIZERS.get(opt_config.type)
+        if optimizer_class is None:
+            supported = ", ".join(sorted(_CHECKPOINTABLE_OPTIMIZERS))
+            raise ValueError(
+                f"Unsupported optimizer type: {opt_config.type}. "
+                f"Checkpoints can be loaded for: {supported}."
+            )
+        return optimizer_class.load_state(checkpoint_path)
+
+    def _restore_state(
+        self,
+        checkpoint_dir: Path | str,
+        subdirectory: str | None = None,
+    ) -> Self:
+        """Restore a checkpoint onto this already-constructed program."""
+        checkpoint_path, state = type(self)._load_checkpoint_state(
+            checkpoint_dir, subdirectory
+        )
+        return self._restore_loaded_checkpoint(checkpoint_path, state)
+
+    def _restore_loaded_checkpoint(
+        self, checkpoint_path: Path, state: VQACheckpoint
+    ) -> Self:
+        """Apply an already loaded checkpoint to this program."""
+        optimizer = self._load_checkpoint_optimizer(checkpoint_path, state)
+        self._apply_checkpoint_state(state, optimizer=optimizer)
+        return self
+
+    def _apply_checkpoint_state(
+        self,
+        state: VQACheckpoint,
+        *,
+        optimizer: Optimizer | None = None,
+    ) -> None:
+        """Apply validated state atomically to this program instance."""
+        attributes = {
+            name: (
+                value.copy()
+                if isinstance(value, (dict, list, set, np.ndarray))
+                else value
+            )
+            for name, value in self.__dict__.items()
+        }
+        rng_state = copy.deepcopy(self._rng.bit_generator.state)
+        try:
+            if optimizer is not None:
+                self.optimizer = optimizer
+            state.restore(self)
+        except Exception:
+            self.__dict__.clear()
+            self.__dict__.update(attributes)
+            self._rng.bit_generator.state = rng_state
+            raise
 
     @classmethod
     def load_state(
@@ -643,33 +757,12 @@ class VariationalQuantumAlgorithm(ObservableMeasuringMixin, QuantumProgram):
         **kwargs,
     ) -> Self:
         """Load program state from a checkpoint directory."""
-        checkpoint_path = resolve_checkpoint_path(checkpoint_dir, subdirectory)
-        state_file = checkpoint_path / PROGRAM_STATE_FILE
-
-        # 1. Load Pydantic Model
-        state = _load_and_validate_pydantic_model(
-            state_file,
-            ProgramState,
-            required_fields=["program_type", "current_iteration"],
+        checkpoint_path, state = cls._load_checkpoint_state(
+            checkpoint_dir, subdirectory
         )
-
-        # 2. Reconstruct Optimizer
-        opt_config = state.optimizer_config
-        optimizer_class = _CHECKPOINTABLE_OPTIMIZERS.get(opt_config.type)
-        if optimizer_class is None:
-            supported = ", ".join(sorted(_CHECKPOINTABLE_OPTIMIZERS))
-            raise ValueError(
-                f"Unsupported optimizer type: {opt_config.type}. "
-                f"Checkpoints can be loaded for: {supported}."
-            )
-        optimizer = optimizer_class.load_state(checkpoint_path)
-
-        # 3. Create Instance
+        optimizer = cls._load_checkpoint_optimizer(checkpoint_path, state)
         program = cls(backend=backend, optimizer=optimizer, seed=state.seed, **kwargs)
-
-        # 4. Restore State
         state.restore(program)
-
         return program
 
     def get_expected_param_shape(self) -> tuple[int, int]:
@@ -1091,12 +1184,12 @@ class VariationalQuantumAlgorithm(ObservableMeasuringMixin, QuantumProgram):
         last_grad_norm: float | None = None
         last_checkpointed_iteration: int | None = None
 
-        def _flush_final_checkpoint():
+        def _flush_final_checkpoint(*, force: bool = False):
             """Checkpoint the last iteration if the interval did not already."""
             if (
                 checkpoint_config.checkpoint_dir is not None
                 and self.current_iteration > 0
-                and self.current_iteration != last_checkpointed_iteration
+                and (force or self.current_iteration != last_checkpointed_iteration)
             ):
                 self.save_state(checkpoint_config)
 
@@ -1272,10 +1365,11 @@ class VariationalQuantumAlgorithm(ObservableMeasuringMixin, QuantumProgram):
         # early-stop/cancel branches above carry a 2-D (1, n) best, so squeeze.
         self._final_params = np.atleast_1d(np.asarray(self.optimize_result.x).squeeze())
 
-        _flush_final_checkpoint()
-
         if perform_final_computation and isinstance(self, SolutionSamplingMixin):
             self.sample_solution(**kwargs)
+            _flush_final_checkpoint(force=True)
+        else:
+            _flush_final_checkpoint()
 
         self._progress_emitter(
             ProgressEvent.finish(

--- a/divi/qprog/workflows/_lassqd/_preparation.py
+++ b/divi/qprog/workflows/_lassqd/_preparation.py
@@ -4,19 +4,29 @@
 
 """Paper-faithful classical LUCJ preparation for LASSQD fragments."""
 
+import hashlib
+import os
+import tempfile
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Self, cast
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal, Self, cast
 from warnings import warn
 
 import numpy as np
+from pydantic import Field, model_validator
 from qiskit import ClassicalRegister, QuantumCircuit, transpile
 
 from divi.backends import CircuitRunner
 from divi.hamiltonians._chem import requires_chem_extra
 from divi.pipeline import sample_preprocessor
 from divi.pipeline.stages import QiskitSpecStage
+from divi.qprog._program_checkpoint import ProgramCheckpoint
 from divi.qprog._solution_sampling_mixin import _average_probabilities
-from divi.qprog.quantum_program import QuantumProgram, reject_unclaimed_run_kwargs
+from divi.qprog.checkpointing import _fsync_directory
+from divi.qprog.quantum_program import (
+    QuantumProgram,
+    reject_unclaimed_run_kwargs,
+)
 
 from ._state import FragmentSpec
 
@@ -57,6 +67,31 @@ class LUCJPreparation:
     orbital_rotation: np.ndarray
 
 
+@dataclass(frozen=True)
+class _LinearMethodResult:
+    params: np.ndarray
+    h_alpha: np.ndarray
+    h_beta: np.ndarray
+    two_body: np.ndarray
+    orbital_rotation: np.ndarray
+
+
+class _LinearMethodCheckpoint(ProgramCheckpoint):
+    state_file: Literal["completed_state.npz"]
+    state_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    best_probs: dict[int, dict[str, float]]
+
+    @model_validator(mode="after")
+    def _validate_probabilities(self) -> Self:
+        if any(
+            not np.isfinite(probability) or probability < 0
+            for probabilities in self.best_probs.values()
+            for probability in probabilities.values()
+        ):
+            raise ValueError("Completed fragment probabilities must be finite")
+        return self
+
+
 class LinearMethodFragmentProgram(QuantumProgram):
     """Classically prepare one fragment and submit only its final sample."""
 
@@ -76,6 +111,7 @@ class LinearMethodFragmentProgram(QuantumProgram):
         self.spec = spec
         self._sampling_backend = sampling_backend
         self._preparation: LUCJPreparation | None = None
+        self._terminal_result: _LinearMethodResult | None = None
         self._best_probs: dict[int, dict[str, float]] = {}
 
     def run(self, **kwargs) -> Self:
@@ -86,6 +122,13 @@ class LinearMethodFragmentProgram(QuantumProgram):
             self._input_h_beta,
             self._input_two_body,
             self.spec,
+        )
+        self._terminal_result = _LinearMethodResult(
+            params=self._preparation.params,
+            h_alpha=self._preparation.h_alpha,
+            h_beta=self._preparation.h_beta,
+            two_body=self._preparation.two_body,
+            orbital_rotation=self._preparation.orbital_rotation,
         )
         result = cast(
             "dict[int, dict[str, float] | list[dict[str, float]]]",
@@ -108,7 +151,7 @@ class LinearMethodFragmentProgram(QuantumProgram):
     @property
     def best_params(self) -> np.ndarray:
         """Optimized ffsim LUCJ parameter vector."""
-        return self._require_preparation().params
+        return self._require_terminal_result().params
 
     @property
     def best_probs(self) -> dict[int, dict[str, float]]:
@@ -118,22 +161,107 @@ class LinearMethodFragmentProgram(QuantumProgram):
     @property
     def h_alpha(self) -> np.ndarray:
         """Alpha one-body integrals in the sampled determinant basis."""
-        return self._require_preparation().h_alpha
+        return self._require_terminal_result().h_alpha
 
     @property
     def h_beta(self) -> np.ndarray:
         """Beta one-body integrals in the sampled determinant basis."""
-        return self._require_preparation().h_beta
+        return self._require_terminal_result().h_beta
 
     @property
     def two_body(self) -> np.ndarray:
         """Two-body integrals in the sampled determinant basis."""
-        return self._require_preparation().two_body
+        return self._require_terminal_result().two_body
 
     @property
     def orbital_rotation(self) -> np.ndarray:
         """Rotation from the workflow fragment basis to the sampled basis."""
-        return self._require_preparation().orbital_rotation
+        return self._require_terminal_result().orbital_rotation
+
+    def _make_checkpoint(
+        self,
+        checkpoint_dir: Path,
+    ) -> _LinearMethodCheckpoint:
+        result = self._require_terminal_result()
+        artifact = "completed_state.npz"
+        temporary_path = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                dir=checkpoint_dir, suffix=".npz", delete=False
+            ) as handle:
+                temporary_path = Path(handle.name)
+                np.savez(
+                    handle,
+                    params=result.params,
+                    h_alpha=result.h_alpha,
+                    h_beta=result.h_beta,
+                    two_body=result.two_body,
+                    orbital_rotation=result.orbital_rotation,
+                )
+                handle.flush()
+                os.fsync(handle.fileno())
+            with temporary_path.open("rb") as handle:
+                state_sha256 = hashlib.file_digest(handle, "sha256").hexdigest()
+            os.replace(temporary_path, checkpoint_dir / artifact)
+            _fsync_directory(checkpoint_dir)
+        finally:
+            if temporary_path is not None and temporary_path.exists():
+                temporary_path.unlink()
+        return _LinearMethodCheckpoint.model_validate(
+            {
+                "program_type": type(self).__name__,
+                "total_circuit_count": self.total_circuit_count,
+                "total_run_time": self.total_run_time,
+                "state_file": artifact,
+                "state_sha256": state_sha256,
+                "best_probs": self._best_probs,
+            }
+        )
+
+    def _restore_checkpoint(self, checkpoint_json: str, checkpoint_dir: Path) -> bool:
+        checkpoint = _LinearMethodCheckpoint.model_validate_json(checkpoint_json)
+        if checkpoint.program_type != type(self).__name__:
+            raise ValueError("Checkpoint is for a different program type.")
+        artifact = checkpoint_dir / checkpoint.state_file
+        with artifact.open("rb") as handle:
+            state_sha256 = hashlib.file_digest(handle, "sha256").hexdigest()
+        if state_sha256 != checkpoint.state_sha256:
+            raise ValueError("Completed fragment state digest does not match metadata")
+
+        with np.load(artifact, allow_pickle=False) as archive:
+            required = {
+                "params",
+                "h_alpha",
+                "h_beta",
+                "two_body",
+                "orbital_rotation",
+            }
+            if set(archive.files) != required:
+                raise ValueError("Completed fragment state has missing or extra arrays")
+            arrays = {name: np.asarray(archive[name]) for name in required}
+
+        expected_shapes = {
+            "h_alpha": self._input_h_alpha.shape,
+            "h_beta": self._input_h_beta.shape,
+            "two_body": self._input_two_body.shape,
+            "orbital_rotation": self._input_h_alpha.shape,
+        }
+        if arrays["params"].ndim != 1 or any(
+            arrays[name].shape != shape for name, shape in expected_shapes.items()
+        ):
+            raise ValueError("Completed fragment state has incompatible array shapes")
+        if any(
+            not np.issubdtype(array.dtype, np.number) or not np.all(np.isfinite(array))
+            for array in arrays.values()
+        ):
+            raise ValueError(
+                "Completed fragment state arrays must be finite numeric data"
+            )
+
+        result = _LinearMethodResult(**arrays)
+        self._terminal_result = result
+        self._best_probs = checkpoint.best_probs
+        return True
 
     def _spec_stage(self):
         return QiskitSpecStage()
@@ -145,6 +273,11 @@ class LinearMethodFragmentProgram(QuantumProgram):
         if self._preparation is None:
             raise RuntimeError("The fragment has not been prepared; call run() first.")
         return self._preparation
+
+    def _require_terminal_result(self) -> _LinearMethodResult:
+        if self._terminal_result is None:
+            raise RuntimeError("The fragment has not been prepared; call run() first.")
+        return self._terminal_result
 
 
 def paper_lucj_interaction_pairs(

--- a/divi/qprog/workflows/_lassqd/_workflow.py
+++ b/divi/qprog/workflows/_lassqd/_workflow.py
@@ -5,9 +5,12 @@
 """The LASSQD program ensemble: construction and per-round program creation."""
 
 import copy
+import os
+import tempfile
 import time
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
+from pathlib import Path
 from typing import Any
 from warnings import warn
 
@@ -666,7 +669,7 @@ class LASSQD(ProgramEnsemble):
     per fragment, and recovers each fragment state via sample-based quantum
     diagonalisation. By default, fragment preparation follows the reference
     implementation: ROHF and CCSD seed a one-repetition LUCJ operator, ffsim's
-    exact linear method optimizes it classically, and the backend samples only
+    exact linear method optimises it classically, and the backend samples only
     the final circuit. Backend-driven VQE preparation is available through
     ``preparation_mode='vqe'``.
 
@@ -1180,6 +1183,275 @@ ProgramEnsemble.workflow_state`: the state :meth:`update_state` produced
             # No-op on backends that cannot seed their sampler, so a run stays
             # reproducible only as far as the backend allows.
             self.backend.set_seed(self._seed)
+
+    def _save_workflow_checkpoint_state(
+        self, state: Any, round_dir: Path, stem: str
+    ) -> dict[str, Any]:
+        """Write an explicit, non-pickled snapshot of mutable LASSQD state."""
+        if not isinstance(state, LASSQDState):
+            raise TypeError(
+                f"LASSQD checkpoint state must be LASSQDState, got "
+                f"{type(state).__name__}."
+            )
+
+        arrays: dict[str, np.ndarray] = {
+            "mo_coeff": state.mo_coeff,
+            "energy": np.asarray(state.energy),
+            "previous_energy": np.asarray(state.previous_energy),
+            "orbitals_converged": np.asarray(state.orbitals_converged),
+            "energy_history": np.asarray(self._energy_history, dtype=np.float64),
+        }
+        fragments = []
+        for index, fragment in enumerate(state.fragments):
+            prefix = f"fragment_{index}"
+            arrays[f"{prefix}_rdm1"] = fragment.rdm1
+            arrays[f"{prefix}_rdm2"] = fragment.rdm2
+            params_present = fragment.params is not None
+            alpha_present = fragment.rdm1_alpha is not None
+            beta_present = fragment.rdm1_beta is not None
+            if fragment.params is not None:
+                arrays[f"{prefix}_params"] = fragment.params
+            if fragment.rdm1_alpha is not None:
+                arrays[f"{prefix}_rdm1_alpha"] = fragment.rdm1_alpha
+            if fragment.rdm1_beta is not None:
+                arrays[f"{prefix}_rdm1_beta"] = fragment.rdm1_beta
+            fragments.append(
+                {
+                    "orbitals": list(fragment.spec.orbitals),
+                    "n_alpha": fragment.spec.n_alpha,
+                    "n_beta": fragment.spec.n_beta,
+                    "params": params_present,
+                    "rdm1_alpha": alpha_present,
+                    "rdm1_beta": beta_present,
+                }
+            )
+
+        solvers = []
+        for index, solver in sorted(self._solvers.items()):
+            arrays[f"solver_{index}_occupancy"] = solver.occupancy
+            solvers.append(
+                {"index": index, "rng_state": solver._rng.bit_generator.state}
+            )
+
+        artifact = f"{stem}.npz"
+        round_dir.mkdir(parents=True, exist_ok=True)
+        temporary_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                dir=round_dir, suffix=".npz", delete=False
+            ) as handle:
+                temporary_path = Path(handle.name)
+                np.savez(handle, **arrays)  # pyrefly: ignore[bad-argument-type]
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary_path, round_dir / artifact)
+        finally:
+            if temporary_path is not None and temporary_path.exists():
+                temporary_path.unlink()
+
+        reports = []
+        for report in self._round_reports:
+            data: dict[str, Any] = asdict(report)
+            data["subspace_sizes"] = list(report.subspace_sizes)
+            reports.append(data)
+        return {
+            "artifact": artifact,
+            "fragments": fragments,
+            "rng_state": self._rng.bit_generator.state,
+            "solvers": solvers,
+            "round_reports": reports,
+        }
+
+    def _load_workflow_checkpoint_state(
+        self, payload: dict[str, Any], round_dir: Path, stem: str
+    ) -> LASSQDState:
+        """Load and validate an explicit LASSQD NPZ snapshot."""
+        artifact = payload.get("artifact")
+        if not isinstance(artifact, str):
+            raise ValueError("LASSQD checkpoint is missing its NPZ artifact.")
+        if artifact != f"{stem}.npz":
+            raise ValueError("LASSQD checkpoint references the wrong state artifact.")
+        artifact_path = round_dir / artifact
+        fragment_metadata = payload.get("fragments")
+        if not isinstance(fragment_metadata, list) or not fragment_metadata:
+            raise ValueError("LASSQD checkpoint has no fragment metadata.")
+
+        with np.load(artifact_path, allow_pickle=False) as stored:
+            required = {
+                "mo_coeff",
+                "energy",
+                "previous_energy",
+                "orbitals_converged",
+                "energy_history",
+            }
+            missing = required - set(stored.files)
+            if missing:
+                raise ValueError(
+                    f"LASSQD checkpoint artifact is missing arrays: {sorted(missing)}"
+                )
+            fragments = []
+            for index, metadata in enumerate(fragment_metadata):
+                prefix = f"fragment_{index}"
+                for suffix in ("rdm1", "rdm2"):
+                    if f"{prefix}_{suffix}" not in stored:
+                        raise ValueError(
+                            f"LASSQD checkpoint is missing {prefix}_{suffix}."
+                        )
+                spec = FragmentSpec(
+                    tuple(metadata["orbitals"]),
+                    metadata["n_alpha"],
+                    metadata["n_beta"],
+                )
+                rdm1 = stored[f"{prefix}_rdm1"].copy()
+                rdm2 = stored[f"{prefix}_rdm2"].copy()
+                expected_rdm1_shape = (spec.n_orbitals,) * 2
+                expected_rdm2_shape = (spec.n_orbitals,) * 4
+                if (
+                    rdm1.shape != expected_rdm1_shape
+                    or rdm2.shape != expected_rdm2_shape
+                ):
+                    raise ValueError(
+                        f"LASSQD checkpoint fragment {index} has invalid RDM shapes."
+                    )
+                params = (
+                    stored[f"{prefix}_params"].copy()
+                    if metadata.get("params")
+                    else None
+                )
+                rdm1_alpha = (
+                    stored[f"{prefix}_rdm1_alpha"].copy()
+                    if metadata.get("rdm1_alpha")
+                    else None
+                )
+                rdm1_beta = (
+                    stored[f"{prefix}_rdm1_beta"].copy()
+                    if metadata.get("rdm1_beta")
+                    else None
+                )
+                if params is not None and params.ndim != 1:
+                    raise ValueError(
+                        f"LASSQD checkpoint fragment {index} parameters are not 1-D."
+                    )
+                if any(
+                    spin_rdm is not None and spin_rdm.shape != expected_rdm1_shape
+                    for spin_rdm in (rdm1_alpha, rdm1_beta)
+                ):
+                    raise ValueError(
+                        f"LASSQD checkpoint fragment {index} has invalid spin RDMs."
+                    )
+                fragments.append(
+                    FragmentState(
+                        spec=spec,
+                        rdm1=rdm1,
+                        rdm2=rdm2,
+                        params=params,
+                        rdm1_alpha=rdm1_alpha,
+                        rdm1_beta=rdm1_beta,
+                    )
+                )
+            mo_coeff = stored["mo_coeff"].copy()
+            if mo_coeff.ndim != 2:
+                raise ValueError("LASSQD checkpoint MO coefficients are not 2-D.")
+            n_orbitals_total = self._mol.nao_nr()
+            if mo_coeff.shape != (n_orbitals_total, n_orbitals_total):
+                raise ValueError(
+                    "LASSQD checkpoint MO coefficients do not match the molecule."
+                )
+            specs = [fragment.spec for fragment in fragments]
+            validate_fragment_specs(specs, n_orbitals_total, self._mol.nelectron // 2)
+            explicit_specs = self._fragmentation.active_spaces
+            if explicit_specs is not None and tuple(specs) != tuple(explicit_specs):
+                raise ValueError(
+                    "LASSQD checkpoint fragment layout does not match the "
+                    "configured active_spaces."
+                )
+            for scalar_name in ("energy", "previous_energy", "orbitals_converged"):
+                if stored[scalar_name].shape != ():
+                    raise ValueError(
+                        f"LASSQD checkpoint {scalar_name} must be a scalar."
+                    )
+            if stored["energy_history"].ndim != 1:
+                raise ValueError("LASSQD checkpoint energy history is not 1-D.")
+            state = LASSQDState(
+                mo_coeff=mo_coeff,
+                fragments=tuple(fragments),
+                energy=float(stored["energy"]),
+                previous_energy=float(stored["previous_energy"]),
+                orbitals_converged=bool(stored["orbitals_converged"]),
+            )
+            energy_history = stored["energy_history"].astype(float).tolist()
+            solver_occupancies = {
+                metadata["index"]: stored[
+                    f"solver_{metadata['index']}_occupancy"
+                ].copy()
+                for metadata in payload.get("solvers", [])
+            }
+
+        rng_state = payload.get("rng_state")
+        if not isinstance(rng_state, dict):
+            raise ValueError("LASSQD checkpoint is missing RNG state.")
+        reports = []
+        for report in payload.get("round_reports", []):
+            reports.append(
+                LASSQDRoundReport(
+                    number=int(report["number"]),
+                    energy=float(report["energy"]),
+                    energy_change=(
+                        None
+                        if report["energy_change"] is None
+                        else float(report["energy_change"])
+                    ),
+                    subspace_sizes=tuple(
+                        int(size) for size in report["subspace_sizes"]
+                    ),
+                    orbital_iterations=int(report["orbital_iterations"]),
+                    orbital_evaluations=int(report["orbital_evaluations"]),
+                    orbital_gradient_norm=float(report["orbital_gradient_norm"]),
+                    orbital_converged=bool(report["orbital_converged"]),
+                    rotation_pairs=int(report["rotation_pairs"]),
+                    recovery_seconds=float(report["recovery_seconds"]),
+                    orbital_seconds=float(report["orbital_seconds"]),
+                )
+            )
+
+        solver_metadata = payload.get("solvers", [])
+        if not isinstance(solver_metadata, list):
+            raise ValueError("LASSQD checkpoint solver metadata must be a list.")
+        solver_indices = [metadata.get("index") for metadata in solver_metadata]
+        if (
+            any(not isinstance(index, int) for index in solver_indices)
+            or len(set(solver_indices)) != len(solver_indices)
+            or any(not 0 <= index < len(state.fragments) for index in solver_indices)
+        ):
+            raise ValueError("LASSQD checkpoint has invalid solver fragment indices.")
+        validation_rng = np.random.default_rng()
+        validation_rng.bit_generator.state = rng_state
+        for metadata in solver_metadata:
+            solver_rng_state = metadata.get("rng_state")
+            if not isinstance(solver_rng_state, dict):
+                raise ValueError("LASSQD checkpoint is missing solver RNG state.")
+            validation_rng.bit_generator.state = solver_rng_state
+            occupancy = solver_occupancies[metadata["index"]]
+            if occupancy.shape != (
+                2,
+                state.fragments[metadata["index"]].spec.n_orbitals,
+            ):
+                raise ValueError("LASSQD checkpoint has invalid solver occupancy.")
+
+        self._rng.bit_generator.state = rng_state
+        self._solvers.clear()
+        for metadata in solver_metadata:
+            index = metadata["index"]
+            solver = self._solver_for(index, state.fragments[index].spec)
+            solver.occupancy = solver_occupancies[index]
+            solver._rng.bit_generator.state = metadata["rng_state"]
+        self._rng.bit_generator.state = rng_state
+        self._energy_history = energy_history
+        self._round_reports = reports
+        self._state = state
+        if self._seed is not None and self.backend is not None:
+            self.backend.set_seed(self._seed)
+        return state
 
     def _solver_for(self, index: int, spec: FragmentSpec) -> SQDSolver:
         """Return this fragment's cached ``SQDSolver``, building it once.

--- a/divi/qprog/workflows/_partitioning_ensemble.py
+++ b/divi/qprog/workflows/_partitioning_ensemble.py
@@ -13,6 +13,7 @@ from divi.qprog.algorithms import PCE, QAOA, IterativeQAOA
 from divi.qprog.ensemble import ProgramEnsemble, ReportingLevel
 from divi.qprog.optimizers import Optimizer
 from divi.qprog.problems import QAOAProblem
+from divi.qprog.problems._binary import BinaryOptimizationProblem
 from divi.qprog.problems._graphs import _GraphProblemBase
 
 
@@ -124,6 +125,17 @@ class PartitioningProgramEnsemble(ProgramEnsemble):
                 problem=sub_problem,
                 **self._make_program_args(),
             )
+
+    def _child_recovery_states(self):
+        if (
+            isinstance(self._problem, BinaryOptimizationProblem)
+            and not self._problem._has_reproducible_decomposition()
+        ):
+            raise ValueError(
+                "Ensemble checkpointing requires a deterministic decomposer for "
+                "BinaryOptimizationProblem."
+            )
+        return super()._child_recovery_states()
 
     def _aggregate(self, strategy, top_n):
         def _extend_fn(current, prog_id, candidate):

--- a/docs/source/execution_workflows/program_ensembles.rst
+++ b/docs/source/execution_workflows/program_ensembles.rst
@@ -8,7 +8,9 @@ dissociation curves, problem decomposition, and algorithm comparison.
 
 An ensemble can also run over several *rounds*, choosing each round's programs
 from what the previous round measured — the basis for iterative refinement and
-other adaptive workflows. See `The Workflow Lifecycle`_.
+other adaptive workflows. Ensemble checkpointing preserves that round state and,
+where supported, the progress of individual variational programs. See
+`Checkpointing Ensemble Workflows`_.
 
 Use this page in increasing order of control:
 
@@ -415,6 +417,100 @@ results never reach it — whether the interrupt landed in the dispatch or in
    ``max_concurrent_programs`` explicitly (see :ref:`circuit-batching`) when
    later rounds may produce many more programs than the first.
 
+.. _ensemble-checkpointing:
+
+Checkpointing Ensemble Workflows
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Pass a :class:`~divi.qprog.checkpointing.CheckpointConfig` to
+:meth:`~divi.qprog.ensemble.ProgramEnsemble.run` to checkpoint an entire
+workflow, not just a single variational program:
+
+.. skip: next
+
+.. code-block:: python
+
+   from pathlib import Path
+
+   from divi.qprog.checkpointing import CheckpointConfig
+
+   checkpoint_dir = Path("checkpoints/lassqd")
+   ensemble.run(
+       max_rounds=8,
+       checkpoint_config=CheckpointConfig(
+           checkpoint_dir=checkpoint_dir,
+           checkpoint_interval=5,
+       ),
+   )
+
+At the start of each round, Divi saves the round's input workflow state and a
+manifest describing its program IDs, types, and slots. After
+``update_state()`` succeeds, it atomically records the completed round,
+including ``round_history`` and cumulative circuit/runtime counters. A crash
+therefore resolves to either the last completed round or the input of the
+interrupted round; partially reduced state is never treated as complete.
+
+To resume, construct the same ensemble configuration, restore it in place, and
+call ``run()``:
+
+.. skip: next
+
+.. code-block:: python
+
+   resumed = make_the_same_ensemble(backend)
+   resumed.restore_state(checkpoint_dir)
+   resumed.run(max_rounds=8)
+
+The resumed ``run()`` reuses the restored checkpoint directory automatically.
+Pass ``checkpoint_config`` again only to change settings such as the child
+checkpoint interval. ``max_rounds`` remains a cumulative round limit: restoring
+after round 3 and running with ``max_rounds=8`` permits rounds 4 through 8.
+
+If a round was interrupted, Divi reconstructs its complete program manifest
+before restoring any child. A structural mismatch in program order, ID, or type
+rejects the checkpoint before partial restoration can occur. Consequently,
+``create_programs(state)`` must reproduce the same ordered children for the same
+ensemble configuration and restored state. An ensemble whose program generation
+uses nondeterministic choices must save those choices in its workflow state and
+reuse them while reconstructing the interrupted round.
+
+For each child, Divi first restores a validated terminal result. If none is
+available, an eligible
+:class:`~divi.qprog.variational_quantum_algorithm.VariationalQuantumAlgorithm`
+continues from its latest complete optimizer checkpoint. Missing, damaged, or
+unsupported child state falls back to a fresh run. All paths still dispatch the
+child through the normal worker and batching lifecycle.
+
+.. important::
+
+   A fresh run refuses a directory that already contains an ensemble
+   checkpoint. Call :meth:`~divi.qprog.ensemble.ProgramEnsemble.restore_state`
+   or choose a new directory; silently mixing two workflow histories is not
+   allowed. A checkpoint directory is owned by one running process; concurrent
+   writers or restorers are not supported. Restore also requires an empty
+   program map, so do not call ``create_programs()`` first.
+
+When ``BatchMode.MERGED`` combines children into shared
+backend submissions, Divi cannot attribute backend runtime to individual
+programs. Recovered circuit accounting remains exact, but cumulative runtime
+does not include the recovered children's share of an interrupted merged
+round.
+
+One-shot ensembles use the built-in ``None`` workflow-state serialisation.
+Custom ensembles with state must override ``_save_workflow_checkpoint_state`` and
+``_load_workflow_checkpoint_state`` with an explicit, validated format. The
+built-in :class:`~divi.qprog.workflows.LASSQD` workflow does this for molecular
+orbitals, fragment RDMs, solver occupancy, reports, and RNG state without
+pickle. Its fragment programs also store terminal numerical results in a
+validated NumPy sidecar. Time-evolution trajectories, VQE hyperparameter
+sweeps, and partitioning ensembles reuse completed children. Partitioning
+combines problem-owned partition mappings with program-owned computation
+identities so restored results cannot be applied to a different subproblem.
+
+See :ref:`ensemble-checkpoint-layout` for the on-disk layout and
+:doc:`resuming_long_runs` for optimizer compatibility and single-program
+checkpoint behaviour.
+
 Inspecting what happened
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -686,6 +782,6 @@ Next Steps
 ----------
 
 - :doc:`backends` — backend configuration and performance tuning.
-- :doc:`resuming_long_runs` — checkpointing the state of supported variational
-  programs. Ensemble workflow state is not currently checkpointed as a unit.
+- :doc:`resuming_long_runs` — checkpointing and restoring individual programs
+  and complete ensemble workflows.
 - :doc:`visualization` — result visualisation, including :meth:`~divi.qprog.workflows.VQEHyperparameterSweep.visualize_results`.

--- a/docs/source/execution_workflows/resuming_long_runs.rst
+++ b/docs/source/execution_workflows/resuming_long_runs.rst
@@ -1,7 +1,12 @@
 Resuming Long-Running or Interrupted Runs
 =========================================
 
-Checkpointing saves :class:`~divi.qprog.variational_quantum_algorithm.VariationalQuantumAlgorithm` run state to disk via :class:`~divi.qprog.checkpointing.CheckpointConfig` so you can resume after interruptions, inspect intermediate progress, or raise ``max_iterations`` after a reload.
+Checkpointing saves program state to disk via
+:class:`~divi.qprog.checkpointing.CheckpointConfig` so you can resume after
+interruptions, inspect intermediate progress, or raise ``max_iterations`` after
+a reload. It covers both individual
+:class:`~divi.qprog.variational_quantum_algorithm.VariationalQuantumAlgorithm`
+runs and complete :class:`~divi.qprog.ensemble.ProgramEnsemble` workflows.
 
 Overview
 --------
@@ -12,6 +17,8 @@ On each checkpoint, Divi writes **program** state (parameters, losses, iteration
 - **Debug** — inspect intermediate parameters and losses on disk
 - **Chunk long jobs** — stop and restart without re-running from scratch
 - **Raise iteration caps** — increase ``max_iterations`` after :meth:`~divi.qprog.variational_quantum_algorithm.VariationalQuantumAlgorithm.load_state`
+- **Resume ensemble rounds** — restore workflow state, accounting, and eligible
+  child optimizers without repeating completed rounds
 
 Checkpointing is available to variational programs such as
 :class:`~divi.qprog.algorithms.VQE` and :class:`~divi.qprog.algorithms.QAOA`,
@@ -176,6 +183,36 @@ By default, ``load_state()`` loads the latest checkpoint whose files are both pr
        n_layers=2,
    )
 
+.. _resuming-ensembles:
+
+Ensemble Workflows
+------------------
+
+Ensembles use the same :class:`~divi.qprog.checkpointing.CheckpointConfig`, but
+restore onto a newly constructed ensemble instance because its constructor
+defines the workflow and problem configuration:
+
+.. skip: next
+
+.. code-block:: python
+
+   checkpoint_dir = Path("ensemble_checkpoints")
+   config = CheckpointConfig(checkpoint_dir=checkpoint_dir)
+
+   ensemble.run(max_rounds=6, checkpoint_config=config)
+
+   resumed = make_the_same_ensemble(backend)
+   resumed.restore_state(checkpoint_dir)
+   resumed.run(max_rounds=6)
+
+Completed rounds resume from their output state. Interrupted rounds resume from
+their saved input state and reconstruct the entire program manifest before any
+child state is applied. Children whose terminal results were saved are reused
+without rerunning; otherwise eligible variational children continue from their
+optimizer checkpoints, and unsupported or damaged children restart within that
+round. See :ref:`ensemble-checkpointing` for the eligibility rules, custom
+workflow-state hooks, and safety constraints.
+
 Complete Example: :class:`~divi.qprog.algorithms.QAOA` with Checkpointing
 --------------------------------------------------------------------------
 
@@ -307,6 +344,52 @@ Each checkpoint is stored in a subdirectory with the following structure:
 
 :class:`~divi.qprog.algorithms.IterativeQAOA` optimises at one depth after another and restarts its iteration count at each one, so it nests that layout one level deeper — ``depth_01/checkpoint_001``, ``depth_02/checkpoint_001``, and so on. Depths therefore never overwrite one another, and ``load_state()`` on the top-level directory resolves to the deepest depth that has a complete checkpoint. Resuming continues the depth schedule from there rather than restarting at depth 1.
 
+.. _ensemble-checkpoint-layout:
+
+Ensemble checkpoint structure
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An ensemble checkpoint is organised by workflow round:
+
+.. code-block:: text
+
+   ensemble_checkpoint_dir/
+   ├── round_001/
+   │   ├── round_start.json       # Ordered child descriptors
+   │   ├── round_completion.json  # Completed output and accounting
+   │   ├── program_000/
+   │   │   ├── checkpoint_.../       # Iterative VQA state
+   │   │   └── program_completion.json # Terminal child state
+   │   └── program_001/
+   │       └── ...
+   └── round_002/
+       ├── round_start.json
+       └── ...
+
+``round_start.json`` records the ordered program IDs and types expected when the
+interrupted round is reconstructed. The reconstructed structure must match
+before child state is restored. ``create_programs(state)`` must therefore be
+deterministic for a fixed ensemble configuration and restored state; workflows
+with nondeterministic generation must persist and reuse those choices as part of
+their workflow state.
+
+Checkpointed :class:`~divi.qprog.workflows.PartitioningProgramEnsemble` runs
+with :class:`~divi.qprog.problems.BinaryOptimizationProblem` require a
+reproducible decomposer. Divi's seeded
+:class:`~divi.qprog.problems.CommunityDecomposer` is supported; arbitrary
+``hybrid`` decomposers are rejected because they cannot guarantee that a
+reconstructed program slot represents the same subproblem.
+
+Each child writes ``program_completion.json`` only after its terminal result is
+available. That marker is preferred over iterative optimizer checkpoints, so a
+completed child is not rerun even when its optimizer itself cannot checkpoint.
+If terminal state is missing or invalid, Divi falls back to the latest complete
+iterative checkpoint and then to a fresh child. ``round_completion.json`` is
+written only after the round's state reduction succeeds, so its presence marks
+a completed round. Workflows with state may place explicitly referenced
+artifacts such as LASSQD's ``input_state.npz`` and ``output_state.npz``
+alongside these markers.
+
 The ``program_state.json`` file contains:
 
 - Current iteration number
@@ -377,11 +460,15 @@ Limitations
 - Checkpoints are **not portable** across different Python versions or library versions
 - Problem configuration must be **manually provided** when loading (not stored in checkpoint)
 - Checkpoint files can be **large** for population-based optimizers (MonteCarlo, Pymoo)
+- A child that is not eligible for mid-round restore restarts from the ensemble
+  round's saved input state
 
 Next Steps
 ----------
 
 - :doc:`core_concepts` — parameters, ``best_params`` vs ``final_params``, and warm-starting
 - :doc:`optimizers` — which optimizers support resume and how ``run()`` interacts with checkpoints
+- :doc:`program_ensembles` — ensemble round semantics, child eligibility, and
+  custom workflow-state checkpointing
 - :doc:`visualization` — trajectories using ``losses_history`` / ``param_history`` after long runs
 - :doc:`../api_reference/qprog/checkpointing` — ``CheckpointConfig``, ``list_checkpoints``, and exceptions

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -59,6 +59,7 @@ CustomVQA
 CVaR
 cvrp
 decomposer
+decomposers
 deduped
 dedupes
 deduplicated

--- a/tests/qprog/algorithms/test_iterative_qaoa.py
+++ b/tests/qprog/algorithms/test_iterative_qaoa.py
@@ -485,6 +485,52 @@ class TestIterativeQAOACheckpointing:
         # are the ones before it.
         assert [entry["depth"] for entry in loaded.depth_history] == [1, 2]
 
+    def test_restore_existing_instance_resolves_deepest_checkpoint(
+        self, default_test_simulator, tmp_path
+    ):
+        self._run_with_checkpoints(default_test_simulator, tmp_path)
+        target = IterativeQAOA(
+            MaxCutProblem(make_bull_graph()),
+            max_depth=self.MAX_DEPTH,
+            max_iterations_per_depth=self.ITERS_PER_DEPTH,
+            backend=default_test_simulator,
+            optimizer=MonteCarloOptimizer(population_size=4, n_best_sets=2),
+        )
+
+        target._restore_state(tmp_path)
+
+        assert target.n_layers == self.MAX_DEPTH
+        assert target.current_iteration == self.ITERS_PER_DEPTH
+
+    def test_terminal_checkpoint_restores_sampled_best_depth(
+        self, default_test_simulator, tmp_path
+    ):
+        program = IterativeQAOA(
+            MaxCutProblem(make_bull_graph()),
+            max_depth=self.MAX_DEPTH,
+            max_iterations_per_depth=self.ITERS_PER_DEPTH,
+            backend=default_test_simulator,
+            optimizer=MonteCarloOptimizer(population_size=4, n_best_sets=2),
+            seed=1997,
+        )
+        program.run(
+            checkpoint_config=CheckpointConfig(checkpoint_dir=tmp_path),
+            perform_final_computation=True,
+        )
+        loaded = self._load(default_test_simulator, tmp_path)
+
+        assert loaded.n_layers == program.best_depth
+        assert loaded.best_probs == program.best_probs
+        assert [entry["depth"] for entry in loaded.depth_history] == [
+            entry["depth"] for entry in program.depth_history
+        ]
+        for loaded_entry, original_entry in zip(
+            loaded.depth_history, program.depth_history
+        ):
+            np.testing.assert_allclose(
+                loaded_entry["best_params"], original_entry["best_params"]
+            )
+
     def test_resume_continues_the_depth_schedule(
         self, default_test_simulator, tmp_path
     ):

--- a/tests/qprog/algorithms/test_time_evolution.py
+++ b/tests/qprog/algorithms/test_time_evolution.py
@@ -513,6 +513,57 @@ class TestTimeEvolutionSingleItemListPreserved:
         assert len(te.results) == 1
 
 
+class TestTimeEvolutionCompletedCheckpointing:
+    @pytest.mark.parametrize(
+        ("observable", "results"),
+        [
+            (None, {"00": 0.75, "11": 0.25}),
+            (_Z0_2Q, 0.25),
+            ((_Z0_2Q, _Z1_2Q), [0.25, -0.5]),
+        ],
+        ids=["probabilities", "scalar-expval", "multiple-expvals"],
+    )
+    def test_completed_state_round_trips_without_backend_work(
+        self,
+        two_qubit_hamiltonian,
+        dummy_simulator,
+        tmp_path,
+        mocker,
+        observable,
+        results,
+    ):
+        source = TimeEvolution(
+            hamiltonian=two_qubit_hamiltonian,
+            observable=observable,
+            backend=dummy_simulator,
+        )
+        source._results = results
+        checkpoint = source._make_checkpoint(tmp_path)
+
+        target = TimeEvolution(
+            hamiltonian=two_qubit_hamiltonian,
+            observable=observable,
+            backend=dummy_simulator,
+        )
+        submit = mocker.spy(dummy_simulator, "submit_circuits")
+        target._restore_checkpoint(checkpoint.model_dump_json(), tmp_path)
+
+        assert "phase" not in checkpoint.model_dump()
+        assert target.results == results
+        submit.assert_not_called()
+
+    def test_save_rejects_a_program_without_results(
+        self, two_qubit_hamiltonian, dummy_simulator, tmp_path
+    ):
+        program = TimeEvolution(
+            hamiltonian=two_qubit_hamiltonian,
+            backend=dummy_simulator,
+        )
+
+        with pytest.raises(RuntimeError, match="no completed results"):
+            program._make_checkpoint(tmp_path)
+
+
 class TestTimeEvolutionQDrift:
     def test_qdrift_multi_sample_averages_probs(
         self, two_qubit_hamiltonian, default_test_simulator

--- a/tests/qprog/problems/test_graph_partitioning_utils.py
+++ b/tests/qprog/problems/test_graph_partitioning_utils.py
@@ -275,17 +275,19 @@ class TestGraphPartitioningConfig:
         assert len(result) == 3
         mock_split.assert_called_once_with(G, algorithm, 3)
 
-    def test_split_graph_kernighan_lin(self):
+    def test_split_graph_kernighan_lin(self, mocker):
         G = nx.path_graph(6)
         config = GraphPartitioningConfig(
             minimum_n_clusters=10, partitioning_algorithm="kernighan_lin"
         )
+        split = mocker.spy(nx.algorithms.community, "kernighan_lin_bisection")
 
         result = _split_graph(G, config)
 
         assert isinstance(result, Sequence)
         assert len(result) == 2
         assert set(result[0][1]) | set(result[1][1]) == set(G.nodes)
+        split.assert_called_once_with(G, seed=0)
 
     def test_split_graph_kernighan_lin_returns_copies(self):
         """Subgraphs returned by _split_graph are independent copies, not views."""

--- a/tests/qprog/problems/test_matching.py
+++ b/tests/qprog/problems/test_matching.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import random
+
 import networkx as nx
 import numpy as np
 import pytest
@@ -210,6 +212,34 @@ class TestPartitionGraphByEdges:
         )
         assert all(sg.size() <= 2 for sg in parts)
 
+    def test_spectral_partition_is_independent_of_global_rng(self):
+        graph = nx.cycle_graph(8)
+        random_state = np.random.get_state()
+        try:
+            np.random.seed(1)
+            first = _partition_graph_by_edges(graph, 2, algorithm="spectral")
+            np.random.seed(2)
+            second = _partition_graph_by_edges(graph, 2, algorithm="spectral")
+        finally:
+            np.random.set_state(random_state)
+
+        assert [set(part) for part in first] == [set(part) for part in second]
+
+    def test_partition_order_does_not_depend_on_bisection_order(
+        self, diamond_graph, mocker
+    ):
+        split = mocker.patch.object(
+            _matching_module,
+            "_kl_bisect",
+            side_effect=[({2, 3}, {0, 1}), ({0, 1}, {2, 3})],
+        )
+
+        first = _partition_graph_by_edges(diamond_graph, 2)
+        second = _partition_graph_by_edges(diamond_graph, 2)
+
+        assert split.call_count == 2
+        assert [set(part) for part in first] == [set(part) for part in second]
+
     def test_invalid_algorithm_raises(self, path_graph):
         with pytest.raises(ValueError, match="Unsupported"):
             _partition_graph_by_edges(path_graph, max_edges=2, algorithm="bogus")
@@ -313,6 +343,21 @@ class TestMaxWeightMatchingProblem:
         assert len(subs) > 1
         for prog_id, sub in subs.items():
             assert isinstance(sub, BinaryOptimizationProblem)
+
+    def test_default_partitioning_is_independent_of_global_rng(self):
+        graph = nx.cycle_graph(8)
+        random_state = random.getstate()
+        try:
+            random.seed(1)
+            first = MaxWeightMatchingProblem(graph, max_edges_per_partition=2)
+            first.decompose()
+            random.seed(2)
+            second = MaxWeightMatchingProblem(graph, max_edges_per_partition=2)
+            second.decompose()
+        finally:
+            random.setstate(random_state)
+
+        assert first._edge_index_maps == second._edge_index_maps
 
     def test_extend_solution(self, diamond_graph):
         p = MaxWeightMatchingProblem(diamond_graph, max_edges_per_partition=2)

--- a/tests/qprog/test_checkpointing.py
+++ b/tests/qprog/test_checkpointing.py
@@ -4,6 +4,7 @@
 
 """Tests for checkpointing utilities."""
 
+import os
 from dataclasses import FrozenInstanceError
 from datetime import datetime
 from pathlib import Path
@@ -11,6 +12,7 @@ from pathlib import Path
 import pytest
 from pydantic import BaseModel
 
+import divi.qprog.checkpointing as checkpointing_module
 from divi.qprog.checkpointing import (
     OPTIMIZER_STATE_FILE,
     PROGRAM_STATE_FILE,
@@ -562,6 +564,15 @@ class TestValidationAndAtomicWrite:
         target = tmp_path / "output.json"
         _atomic_write(target, '{"key": "value"}')
         assert target.read_text() == '{"key": "value"}'
+
+    def test_atomic_write_syncs_file_and_directory(self, tmp_path, mocker):
+        file_sync = mocker.spy(os, "fsync")
+        directory_sync = mocker.spy(checkpointing_module, "_fsync_directory")
+
+        _atomic_write(tmp_path / "output.json", "{}")
+
+        assert file_sync.call_count >= 1
+        directory_sync.assert_called_once_with(tmp_path)
 
     def test_atomic_write_cleans_up_temp_on_failure(self, tmp_path, mocker):
         """If rename fails, the temp file must be cleaned up."""

--- a/tests/qprog/test_ensemble_checkpoint.py
+++ b/tests/qprog/test_ensemble_checkpoint.py
@@ -1,0 +1,270 @@
+# SPDX-FileCopyrightText: 2025-2026 Qoro Quantum Ltd <divi@qoroquantum.de>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ensemble checkpoint state and directory resolution."""
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from divi.qprog._ensemble_checkpoint import (
+    ROUND_COMPLETION_FILE,
+    ROUND_START_FILE,
+    ProgramRoundRecord,
+    RoundCheckpoint,
+    _encode_program_id,
+    _program_checkpoint_path,
+    _resolve_ensemble_checkpoint,
+    _round_dir,
+)
+from divi.qprog._program_checkpoint import ProgramCheckpoint
+from divi.qprog.checkpointing import CheckpointNotFoundError
+
+
+def _write_json(path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload))
+
+
+def _interrupted_payload(round_index=1):
+    return {
+        "kind": "round_start",
+        "ensemble_type": "tests.SampleEnsemble",
+        "round_index": round_index,
+        "ensemble_state": {},
+        "programs": [],
+    }
+
+
+def _completed_payload(round_index=1):
+    return {
+        "kind": "round_completion",
+        "ensemble_type": "tests.SampleEnsemble",
+        "round_index": round_index,
+        "ensemble_state": {},
+        "round_history": [],
+        "total_circuit_count": 0,
+        "total_run_time": 0.0,
+    }
+
+
+class TestProgramIdEncoding:
+    def test_encodes_nested_tuple_without_losing_tuple_identity(self):
+        encoded = _encode_program_id(("ansatz", (2, None)))
+
+        assert encoded == {
+            "kind": "tuple",
+            "items": [
+                {"kind": "str", "value": "ansatz"},
+                {
+                    "kind": "tuple",
+                    "items": [
+                        {"kind": "int", "value": 2},
+                        {"kind": "none"},
+                    ],
+                },
+            ],
+        }
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), object()])
+    def test_rejects_values_without_stable_json_identity(self, value):
+        with pytest.raises(TypeError, match="checkpoint program ID"):
+            _encode_program_id(value)
+
+
+class TestStateModels:
+    def test_child_recovery_state_has_no_computation_fingerprint(self):
+        assert "identity" not in ProgramRoundRecord.model_fields
+
+    def test_round_checkpoint_uses_an_explicit_kind(self):
+        interrupted = RoundCheckpoint(
+            kind="round_start",
+            ensemble_type="tests.SampleEnsemble",
+            round_index=1,
+            ensemble_state={},
+            programs=[],
+        )
+        completed = RoundCheckpoint(
+            kind="round_completion",
+            ensemble_type="tests.SampleEnsemble",
+            round_index=1,
+            ensemble_state={},
+            round_history=[],
+            total_circuit_count=0,
+            total_run_time=0.0,
+        )
+
+        assert interrupted.kind == "round_start"
+        assert completed.kind == "round_completion"
+
+    @pytest.mark.parametrize(
+        "kind_fields",
+        [
+            {"kind": "round_start"},
+            {
+                "kind": "round_completion",
+                "programs": [],
+                "round_history": [],
+                "total_circuit_count": 0,
+                "total_run_time": 0.0,
+            },
+        ],
+    )
+    def test_round_checkpoint_rejects_an_incomplete_or_mixed_kind(self, kind_fields):
+        with pytest.raises(ValidationError):
+            RoundCheckpoint(
+                ensemble_type="tests.SampleEnsemble",
+                round_index=1,
+                ensemble_state={},
+                **kind_fields,
+            )
+
+    def test_interrupted_round_round_trips(self):
+        state = RoundCheckpoint(
+            kind="round_start",
+            ensemble_type="tests.SampleEnsemble",
+            round_index=2,
+            ensemble_state={"value": 3},
+            programs=[
+                ProgramRoundRecord(
+                    program_id=_encode_program_id(("a", 1)),
+                    program_type="tests.SampleProgram",
+                    circuit_count_at_round_start=0,
+                    run_time_at_round_start=0.0,
+                )
+            ],
+        )
+
+        assert RoundCheckpoint.model_validate_json(state.model_dump_json()) == state
+        assert state.model_dump(mode="json")["programs"] == [
+            {
+                "program_id": _encode_program_id(("a", 1)),
+                "program_type": "tests.SampleProgram",
+                "circuit_count_at_round_start": 0,
+                "run_time_at_round_start": 0.0,
+            }
+        ]
+
+    def test_completed_round_rejects_negative_counters(self):
+        with pytest.raises(ValidationError):
+            RoundCheckpoint(
+                kind="round_completion",
+                ensemble_type="tests.SampleEnsemble",
+                round_index=1,
+                ensemble_state={},
+                round_history=[],
+                total_circuit_count=-1,
+                total_run_time=0.0,
+            )
+
+    def test_completed_child_rejects_invalid_accounting(self):
+        with pytest.raises(ValidationError):
+            ProgramCheckpoint(
+                program_type="tests.SampleProgram",
+                total_circuit_count=-1,
+                total_run_time=float("inf"),
+            )
+
+    def test_interrupted_round_requires_child_accounting(self):
+        with pytest.raises(ValidationError):
+            RoundCheckpoint(
+                kind="round_start",
+                ensemble_type="tests.SampleEnsemble",
+                round_index=1,
+                ensemble_state={},
+                programs=[
+                    ProgramRoundRecord(
+                        program_id=_encode_program_id("a"),
+                        program_type="tests.SampleProgram",
+                    )
+                ],
+            )
+
+    def test_program_checkpoint_path_uses_round_local_slot(self, tmp_path):
+        assert _program_checkpoint_path(tmp_path, 2) == tmp_path / "program_002"
+
+
+class TestRoundResolution:
+    def test_round_dir_is_zero_padded(self, tmp_path):
+        assert _round_dir(tmp_path, 7) == tmp_path / "round_007"
+
+    def test_prefers_completed_marker_within_latest_round(self, tmp_path):
+        round_dir = _round_dir(tmp_path, 2)
+        _write_json(round_dir / ROUND_START_FILE, _interrupted_payload(2))
+        _write_json(round_dir / ROUND_COMPLETION_FILE, _completed_payload(2))
+
+        checkpoint = _resolve_ensemble_checkpoint(tmp_path)
+
+        assert checkpoint.round_index == 2
+        assert checkpoint.kind == "round_completion"
+
+    def test_latest_interrupted_round_wins_over_earlier_completed_round(self, tmp_path):
+        _write_json(
+            _round_dir(tmp_path, 1) / ROUND_COMPLETION_FILE,
+            _completed_payload(1),
+        )
+        _write_json(
+            _round_dir(tmp_path, 2) / ROUND_START_FILE,
+            _interrupted_payload(2),
+        )
+
+        checkpoint = _resolve_ensemble_checkpoint(tmp_path)
+
+        assert checkpoint.round_index == 2
+        assert checkpoint.kind == "round_start"
+
+    def test_skips_higher_round_with_invalid_json(self, tmp_path):
+        _write_json(
+            _round_dir(tmp_path, 1) / ROUND_COMPLETION_FILE,
+            _completed_payload(1),
+        )
+        invalid = _round_dir(tmp_path, 2) / ROUND_START_FILE
+        invalid.parent.mkdir(parents=True)
+        invalid.write_text("not-json")
+
+        resolved = _resolve_ensemble_checkpoint(tmp_path)
+
+        assert resolved.round_index == 1
+        assert resolved.kind == "round_completion"
+
+    def test_resolves_explicit_subdirectory(self, tmp_path):
+        _write_json(
+            _round_dir(tmp_path, 3) / ROUND_COMPLETION_FILE,
+            _completed_payload(3),
+        )
+
+        resolved = _resolve_ensemble_checkpoint(tmp_path, "round_003")
+
+        assert resolved.round_index == 3
+
+    def test_completed_manual_snapshot_does_not_require_open_marker(self, tmp_path):
+        _write_json(
+            _round_dir(tmp_path, 1) / ROUND_COMPLETION_FILE,
+            _completed_payload(1),
+        )
+
+        resolved = _resolve_ensemble_checkpoint(tmp_path)
+
+        assert resolved.kind == "round_completion"
+
+    def test_skips_marker_whose_state_artifact_is_missing(self, tmp_path):
+        payload = _completed_payload(2)
+        payload["ensemble_state"] = {"artifact": "output_state.npz"}
+        _write_json(
+            _round_dir(tmp_path, 2) / ROUND_COMPLETION_FILE,
+            payload,
+        )
+        _write_json(
+            _round_dir(tmp_path, 1) / ROUND_COMPLETION_FILE,
+            _completed_payload(1),
+        )
+
+        resolved = _resolve_ensemble_checkpoint(tmp_path)
+
+        assert resolved.round_index == 1
+
+    def test_no_valid_round_raises(self, tmp_path):
+        with pytest.raises(CheckpointNotFoundError, match="ensemble checkpoint"):
+            _resolve_ensemble_checkpoint(tmp_path)

--- a/tests/qprog/test_ensemble_dispatch.py
+++ b/tests/qprog/test_ensemble_dispatch.py
@@ -26,6 +26,7 @@ import divi.qprog.ensemble as ensemble_module
 from divi.backends import AsyncJobBackend, ExecutionResult
 from divi.exceptions import ExecutionCancelledError
 from divi.qprog._batch_coordinator import _BatchCoordinator, _ProxyBackend
+from divi.qprog.checkpointing import CheckpointConfig
 from divi.qprog.ensemble import (
     BatchConfig,
     BatchMode,
@@ -2023,7 +2024,7 @@ class TestEnsembleSampleSolution:
             ensemble.reset()
 
     def test_workflow_run_batches_final_sampling_on_sampling_backend(
-        self, dummy_simulator, make_dummy_simulator, mocker
+        self, dummy_simulator, make_dummy_simulator, mocker, tmp_path
     ):
         """Training completes before one merged sampling-only dispatch."""
         sampling_backend = make_dummy_simulator(100, seed=7)
@@ -2035,11 +2036,15 @@ class TestEnsembleSampleSolution:
         )
 
         try:
-            ensemble.run()
+            ensemble.run(checkpoint_config=CheckpointConfig(checkpoint_dir=tmp_path))
 
             assert primary_submit.call_count > 0
             sampling_submit.assert_called_once()
             assert all(program._best_probs for program in ensemble.programs.values())
+            markers = list(
+                (tmp_path / "round_001").glob("program_*/program_completion.json")
+            )
+            assert len(markers) == len(ensemble.programs)
         finally:
             ensemble.reset()
 

--- a/tests/qprog/test_ensemble_workflow.py
+++ b/tests/qprog/test_ensemble_workflow.py
@@ -10,9 +10,20 @@ Covers the ``initial_state`` → ``create_programs`` → dispatch → ``update_s
 mechanics live in ``test_ensemble_dispatch.py``.
 """
 
+import json
+from pathlib import Path
+from threading import Event
+
 import pytest
 
 import divi.qprog.ensemble as ensemble_module
+from divi.qprog._ensemble_checkpoint import (
+    ProgramRoundRecord,
+    RoundCheckpoint,
+    _encode_program_id,
+)
+from divi.qprog._program_checkpoint import ProgramCheckpoint
+from divi.qprog.checkpointing import CheckpointConfig
 from divi.qprog.ensemble import (
     BatchConfig,
     BatchMode,
@@ -21,6 +32,7 @@ from divi.qprog.ensemble import (
     RoundRecord,
     WorkflowStatus,
 )
+from divi.qprog.quantum_program import QuantumProgram
 from divi.reporting._events import (
     EventKind,
     ProgressEvent,
@@ -36,6 +48,88 @@ from tests.qprog._helpers import FailingTestProgram, SimpleTestProgram
 # SimpleTestProgram(10, 5.5) + SimpleTestProgram(5, 10.0).
 _CIRCUITS_PER_ROUND = 15
 _RUNTIME_PER_ROUND = 15.5
+
+
+class _TerminalTestCheckpoint(ProgramCheckpoint):
+    value: int
+
+
+class _TerminalTestProgram(QuantumProgram):
+    def __init__(self, slot, tracker, completed, *, fail, backend):
+        super().__init__(backend=backend)
+        self.slot = slot
+        self.tracker = tracker
+        self.completed = completed
+        self.fail = fail
+        self.value = None
+
+    def run(self):
+        self.tracker[self.slot] += 1
+        if self.fail:
+            assert self.completed.wait(timeout=2)
+            raise RuntimeError("planned child failure")
+        self.value = self.slot + 10
+        self._total_circuit_count = self.slot + 1
+        self._total_run_time = self.slot + 0.5
+        self.completed.set()
+        return self
+
+    def has_results(self):
+        return self.value is not None
+
+    def _make_checkpoint(self, checkpoint_dir: Path):
+        return _TerminalTestCheckpoint(
+            program_type=type(self).__name__,
+            total_circuit_count=self.total_circuit_count,
+            total_run_time=self.total_run_time,
+            value=self.value,
+        )
+
+    def _restore_checkpoint(self, checkpoint_json: str, checkpoint_dir: Path) -> bool:
+        checkpoint = _TerminalTestCheckpoint.model_validate_json(checkpoint_json)
+        self.value = checkpoint.value
+        return True
+
+
+class _TerminalTestEnsemble(ProgramEnsemble):
+    def __init__(self, backend, tracker, *, fail_second):
+        super().__init__(backend=backend)
+        self.tracker = tracker
+        self.fail_second = fail_second
+        self.completed = Event()
+
+    def initial_state(self):
+        return 0
+
+    def create_programs(self, state=None):
+        super().create_programs()
+        self.programs = {
+            "first": _TerminalTestProgram(
+                0, self.tracker, self.completed, fail=False, backend=self.backend
+            ),
+            "second": _TerminalTestProgram(
+                1,
+                self.tracker,
+                self.completed,
+                fail=self.fail_second,
+                backend=self.backend,
+            ),
+        }
+
+    def update_state(self, state):
+        return state + 1
+
+    def is_complete(self, state):
+        return state >= 1
+
+    def aggregate_results(self):
+        return self.workflow_state
+
+    def _save_workflow_checkpoint_state(self, state, round_dir, stem):
+        return {"value": state}
+
+    def _load_workflow_checkpoint_state(self, payload, round_dir, stem):
+        return payload["value"]
 
 
 class _LifecycleEnsemble(ProgramEnsemble):
@@ -104,6 +198,12 @@ class _LifecycleEnsemble(ProgramEnsemble):
 
     def aggregate_results(self):
         return self.workflow_state
+
+    def _save_workflow_checkpoint_state(self, state, round_dir, stem):
+        return {"value": state}
+
+    def _load_workflow_checkpoint_state(self, payload, round_dir, stem):
+        return payload["value"]
 
 
 class _OneShotEnsemble(ProgramEnsemble):
@@ -246,6 +346,315 @@ class TestLifecycleHookContract:
         assert ensemble.stop_reason == WorkflowStatus.COMPLETE
         assert len(ensemble.round_history) == 1
         assert ensemble.workflow_state is None
+
+
+class TestEnsembleCheckpointing:
+    def test_interrupted_round_reuses_its_child_directory(
+        self, dummy_simulator, tmp_path
+    ):
+        program = _TerminalTestProgram(
+            0, [0], Event(), fail=False, backend=dummy_simulator
+        )
+        round_path = tmp_path / "round_001"
+
+        def prepare(interrupted_checkpoint=None):
+            return ensemble_module._RoundCheckpointSession.prepare(
+                checkpoint_config=CheckpointConfig(checkpoint_dir=tmp_path),
+                round_path=round_path,
+                ensemble_type="tests.TerminalTestEnsemble",
+                round_index=1,
+                ensemble_state={"value": 0},
+                programs=[program],
+                child_recovery_states=[
+                    ProgramRoundRecord(
+                        program_id=_encode_program_id("first"),
+                        program_type="tests.TerminalTestProgram",
+                        circuit_count_at_round_start=0,
+                        run_time_at_round_start=0.0,
+                    )
+                ],
+                interrupted_checkpoint=interrupted_checkpoint,
+            )
+
+        first = prepare()
+        active = RoundCheckpoint.model_validate_json(
+            (round_path / "round_start.json").read_text()
+        )
+        second = prepare(active)
+
+        assert first.checkpoint_path_by_program[program] == round_path / "program_000"
+        assert second.checkpoint_path_by_program[program] == round_path / "program_000"
+        assert (
+            RoundCheckpoint.model_validate_json(
+                (round_path / "round_start.json").read_text()
+            )
+            == active
+        )
+
+    def test_fresh_run_rejects_a_checkpoint_root_from_an_older_run(
+        self, lifecycle_ensemble, tmp_path
+    ):
+        first = lifecycle_ensemble(n_rounds=1)
+        first.run(checkpoint_config=CheckpointConfig(checkpoint_dir=tmp_path))
+        second = lifecycle_ensemble(n_rounds=1)
+
+        with pytest.raises(
+            RuntimeError, match="already contains an ensemble checkpoint"
+        ):
+            second.run(checkpoint_config=CheckpointConfig(checkpoint_dir=tmp_path))
+
+        assert second.workflow_state is None
+        assert second.round_history == ()
+
+    def test_completed_round_restores_and_continues_cumulative_limit(
+        self, lifecycle_ensemble, tmp_path
+    ):
+        original = lifecycle_ensemble(n_rounds=3)
+        original.run(
+            max_rounds=1,
+            checkpoint_config=CheckpointConfig(checkpoint_dir=tmp_path),
+        )
+
+        restored = lifecycle_ensemble(n_rounds=3)
+        assert restored.restore_state(tmp_path) is restored
+
+        assert restored.workflow_state == 1
+        assert restored._round_index == 1
+        assert restored.round_history == original.round_history
+        assert restored.total_circuit_count == original.total_circuit_count
+        assert restored.stop_reason is None
+
+        restored.run(max_rounds=2)
+
+        assert restored.workflow_state == 2
+        assert restored.stop_reason is WorkflowStatus.MAX_ROUNDS
+        assert [record.number for record in restored.round_history] == [1, 2]
+
+    def test_one_shot_completed_checkpoint_stays_complete(
+        self, dummy_simulator, tmp_path
+    ):
+        original = _OneShotEnsemble(
+            backend=dummy_simulator, reporting_level=ReportingLevel.OFF
+        )
+        original.run(checkpoint_config=CheckpointConfig(checkpoint_dir=tmp_path))
+
+        restored = _OneShotEnsemble(
+            backend=dummy_simulator, reporting_level=ReportingLevel.FULL
+        )
+        restored.restore_state(tmp_path).run()
+
+        assert len(restored.round_history) == 1
+        assert restored.stop_reason is WorkflowStatus.COMPLETE
+        assert restored.reporting_level is ReportingLevel.FULL
+
+    def test_failed_round_restores_its_input_and_reenters_same_round(
+        self, lifecycle_ensemble, tmp_path
+    ):
+        failed = lifecycle_ensemble(n_rounds=2)
+        failed._total_circuit_count = 100
+        failed._total_run_time = 50.0
+        normal_update = failed.update_state
+
+        def fail_second_reduction(state):
+            if state == 1:
+                raise RuntimeError("reduction boom")
+            return normal_update(state)
+
+        failed.update_state = fail_second_reduction
+        with pytest.raises(RuntimeError):
+            failed.run(checkpoint_config=CheckpointConfig(checkpoint_dir=tmp_path))
+
+        resumed = lifecycle_ensemble(n_rounds=2)
+        resumed.restore_state(tmp_path)
+
+        assert resumed.workflow_state == 1
+        assert resumed._round_index == 1
+        assert resumed.total_circuit_count == 115
+        assert resumed.total_run_time == 65.5
+
+        resumed.run()
+
+        assert resumed.states_seen == [1]
+        assert resumed.workflow_state == 2
+        assert [record.number for record in resumed.round_history] == [1, 2]
+        assert (tmp_path / "round_002" / "round_completion.json").is_file()
+
+    def test_interrupted_restore_rejects_previous_round_from_another_ensemble(
+        self, lifecycle_ensemble, tmp_path
+    ):
+        failed = lifecycle_ensemble(n_rounds=2)
+        normal_update = failed.update_state
+
+        def fail_second_reduction(state):
+            if state == 1:
+                raise RuntimeError("reduction boom")
+            return normal_update(state)
+
+        failed.update_state = fail_second_reduction
+        with pytest.raises(RuntimeError, match="reduction boom"):
+            failed.run(checkpoint_config=CheckpointConfig(checkpoint_dir=tmp_path))
+
+        previous_marker = tmp_path / "round_001" / "round_completion.json"
+        previous = json.loads(previous_marker.read_text())
+        previous["ensemble_type"] = "tests.OtherEnsemble"
+        previous_marker.write_text(json.dumps(previous))
+
+        with pytest.raises(ValueError, match="earlier completed round"):
+            lifecycle_ensemble(n_rounds=2).restore_state(tmp_path)
+
+    def test_restore_rejects_pre_materialized_programs(
+        self, lifecycle_ensemble, tmp_path
+    ):
+        original = lifecycle_ensemble(n_rounds=1)
+        original.run(checkpoint_config=CheckpointConfig(checkpoint_dir=tmp_path))
+        target = lifecycle_ensemble(n_rounds=1)
+        target.create_programs(0)
+
+        with pytest.raises(RuntimeError, match="pre-materialized"):
+            target.restore_state(tmp_path)
+
+    def test_completed_marker_failure_records_failed_round(
+        self, lifecycle_ensemble, tmp_path
+    ):
+        ensemble = lifecycle_ensemble(n_rounds=1)
+        save_state = ensemble._save_workflow_checkpoint_state
+
+        def fail_output(state, round_dir, stem):
+            if stem == "output_state":
+                raise OSError("disk full")
+            return save_state(state, round_dir, stem)
+
+        ensemble._save_workflow_checkpoint_state = fail_output
+
+        with pytest.raises(OSError, match="disk full"):
+            ensemble.run(checkpoint_config=CheckpointConfig(checkpoint_dir=tmp_path))
+
+        assert ensemble.stop_reason is WorkflowStatus.FAILED
+        assert ensemble.round_history[-1].status is WorkflowStatus.FAILED
+        assert (tmp_path / "round_001" / "round_start.json").is_file()
+        assert not (tmp_path / "round_001" / "round_completion.json").exists()
+
+    def test_completed_child_is_not_reexecuted_after_round_failure(
+        self, make_dummy_simulator, tmp_path
+    ):
+        tracker = [0, 0]
+        first_backend = make_dummy_simulator(100)
+        first = _TerminalTestEnsemble(first_backend, tracker, fail_second=True)
+        config = CheckpointConfig(checkpoint_dir=tmp_path)
+
+        with pytest.raises(RuntimeError, match="Ensemble execution failed"):
+            first.run(checkpoint_config=config)
+
+        marker = json.loads(
+            (
+                tmp_path / "round_001" / "program_000" / "program_completion.json"
+            ).read_text()
+        )
+        assert "phase" not in marker
+        assert marker["value"] == 10
+        assert "payload" not in marker
+
+        replacement_backend = make_dummy_simulator(100)
+        restored = _TerminalTestEnsemble(
+            replacement_backend, tracker, fail_second=False
+        ).restore_state(tmp_path)
+        restored.run()
+
+        assert tracker == [1, 2]
+        assert restored.programs["first"].value == 10
+        assert restored.programs["second"].value == 11
+        assert restored.programs["first"].backend is replacement_backend
+        assert restored.total_circuit_count == 3
+        assert restored.total_run_time == 2.0
+
+    def test_corrupt_completed_child_restarts_from_round_input(
+        self, dummy_simulator, tmp_path
+    ):
+        tracker = [0, 0]
+        first = _TerminalTestEnsemble(dummy_simulator, tracker, fail_second=True)
+        config = CheckpointConfig(checkpoint_dir=tmp_path)
+
+        with pytest.raises(RuntimeError, match="Ensemble execution failed"):
+            first.run(checkpoint_config=config)
+
+        marker = tmp_path / "round_001" / "program_000" / "program_completion.json"
+        marker.write_text("not json")
+        restored = _TerminalTestEnsemble(
+            dummy_simulator, tracker, fail_second=False
+        ).restore_state(tmp_path)
+        restored.run()
+
+        assert tracker == [2, 2]
+        assert restored.programs["first"].value == 10
+
+    def test_completed_child_with_negative_accounting_restarts_before_mutation(
+        self, dummy_simulator, tmp_path
+    ):
+        tracker = [0, 0]
+        first = _TerminalTestEnsemble(dummy_simulator, tracker, fail_second=True)
+        config = CheckpointConfig(checkpoint_dir=tmp_path)
+
+        with pytest.raises(RuntimeError, match="Ensemble execution failed"):
+            first.run(checkpoint_config=config)
+
+        checkpoint_path = tmp_path / "round_001" / "round_start.json"
+        checkpoint = json.loads(checkpoint_path.read_text())
+        checkpoint["programs"][0]["circuit_count_at_round_start"] = 2
+        checkpoint_path.write_text(json.dumps(checkpoint))
+
+        restored = _TerminalTestEnsemble(
+            dummy_simulator, tracker, fail_second=False
+        ).restore_state(tmp_path)
+        restored.run()
+
+        assert tracker == [2, 2]
+        assert restored.programs["first"].value == 10
+
+    def test_iterative_child_accounting_is_validated_before_restore(
+        self, tmp_path, mocker
+    ):
+        program = mocker.MagicMock()
+        program.total_circuit_count = 1
+        program.total_run_time = 0.5
+        checkpoint_state = mocker.Mock(
+            total_circuit_count=1,
+            total_run_time=0.5,
+        )
+        program._load_checkpoint_state.return_value = (tmp_path, checkpoint_state)
+        child_state = ProgramRoundRecord(
+            program_id=_encode_program_id("child"),
+            program_type="tests.IterativeChild",
+            circuit_count_at_round_start=2,
+            run_time_at_round_start=1.0,
+        )
+        session = ensemble_module._RoundCheckpointSession(
+            checkpoint_path_by_program={program: tmp_path},
+            iterative_config_by_program={
+                program: CheckpointConfig(checkpoint_dir=tmp_path)
+            },
+            restored_programs=set(),
+        )
+
+        session._recover([program], {program: child_state})
+
+        program._restore_loaded_checkpoint.assert_not_called()
+        assert not session.was_restored(program)
+
+    def test_completed_child_checkpoint_failure_fails_round(
+        self, dummy_simulator, tmp_path, mocker
+    ):
+        tracker = [0, 0]
+        ensemble = _TerminalTestEnsemble(dummy_simulator, tracker, fail_second=False)
+        mocker.patch.object(
+            _TerminalTestProgram,
+            "_make_checkpoint",
+            side_effect=OSError("disk full"),
+        )
+
+        with pytest.raises(RuntimeError, match="Ensemble execution failed"):
+            ensemble.run(checkpoint_config=CheckpointConfig(checkpoint_dir=tmp_path))
+
+        assert ensemble.stop_reason is WorkflowStatus.FAILED
 
 
 class TestAdaptiveRounds:

--- a/tests/qprog/test_quantum_program.py
+++ b/tests/qprog/test_quantum_program.py
@@ -20,6 +20,7 @@ from divi.circuits import DEFAULT_PRECISION
 from divi.exceptions import ExecutionCancelledError
 from divi.pipeline import PipelineEnv
 from divi.pipeline._core import _wait_for_async_result
+from divi.qprog._program_checkpoint import ProgramCheckpoint
 from divi.qprog.quantum_program import QuantumProgram
 from divi.reporting._events import (
     EventKind,
@@ -88,7 +89,32 @@ class ConcreteQuantumProgram(QuantumProgram):
 
 
 class TestQuantumProgramBase:
+    def test_program_checkpoint_has_no_vqa_phase(self):
+        assert "phase" not in ProgramCheckpoint.model_fields
+
+        checkpoint = ProgramCheckpoint(
+            program_type="tests.ConcreteQuantumProgram",
+            total_circuit_count=3,
+            total_run_time=1.5,
+        )
+
+        assert "phase" not in checkpoint.model_dump()
+
     """Tests for QuantumProgram abstract base class contract and core functionality."""
+
+    def test_completed_checkpointing_is_unsupported_by_default(
+        self, dummy_simulator, tmp_path
+    ):
+        program = ConcreteQuantumProgram(dummy_simulator)
+
+        assert program._make_checkpoint(tmp_path) is None
+        assert program._restore_checkpoint("{}", tmp_path) is False
+        assert program.has_results() is False
+
+    def test_quantum_program_has_no_checkpoint_identity_protocol(self, dummy_simulator):
+        program = ConcreteQuantumProgram(dummy_simulator)
+
+        assert not hasattr(program, "_checkpoint_computation_identity")
 
     def test_quantum_program_uses_logging_emitter_by_default(
         self, default_test_simulator

--- a/tests/qprog/test_variational_quantum_algorithm.py
+++ b/tests/qprog/test_variational_quantum_algorithm.py
@@ -9,15 +9,17 @@ from typing import Any
 
 import numpy as np
 import pytest
+from pydantic import ValidationError
 from qiskit import QuantumCircuit
 from qiskit.circuit import Parameter
 from qiskit.quantum_info import SparsePauliOp
 from scipy.optimize import OptimizeResult
 
+import divi.qprog._program_checkpoint as program_checkpoint_module
 from divi.circuits import MetaCircuit
 from divi.exceptions import ExecutionCancelledError
 from divi.pipeline import CircuitPreprocessor
-from divi.qprog._program_state import ProgramState
+from divi.qprog._program_checkpoint import VQACheckpoint
 from divi.qprog._solution_sampling_mixin import SolutionEntry, SolutionSamplingMixin
 from divi.qprog.checkpointing import CheckpointConfig, list_checkpoints
 from divi.qprog.early_stopping import EarlyStopping, StopReason
@@ -58,6 +60,7 @@ class SampleVQAProgram(SolutionSamplingMixin, VariationalQuantumAlgorithm):
             [("X", [0], 1.0), ("Z", [1], 1.0), ("XZ", [0, 1], 1.0)], num_qubits=2
         )
         self.loss_constant = 0.0
+        self.checkpointed_value = None
 
     @property
     def n_params_per_layer(self) -> int:
@@ -94,11 +97,11 @@ class SampleVQAProgram(SolutionSamplingMixin, VariationalQuantumAlgorithm):
 
     def _save_subclass_state(self) -> dict[str, Any]:
         """Save SampleVQAProgram-specific state."""
-        return {}
+        return {"checkpointed_value": self.checkpointed_value}
 
     def _load_subclass_state(self, state: dict[str, Any]) -> None:
         """Load SampleVQAProgram-specific state."""
-        ...
+        self.checkpointed_value = state.get("checkpointed_value")
 
 
 class _BaseSampler(QuantumProgram):
@@ -985,6 +988,19 @@ class TestRunIntegration(BaseVariationalQuantumAlgorithmTest):
 
 
 class TestCheckpointing:
+    def test_vqa_checkpoint_kind_controls_optimizer_state(self, sample_program):
+        completed = program_checkpoint_module.VQACheckpoint.from_program(
+            sample_program,
+            kind="program_completion",
+        )
+        iterative = program_checkpoint_module.VQACheckpoint.from_program(
+            sample_program,
+            kind="iteration",
+        )
+
+        assert completed.optimizer_config is None
+        assert iterative.optimizer_config is not None
+
     """Tests for VariationalQuantumAlgorithm checkpointing functionality."""
 
     @pytest.fixture
@@ -1080,7 +1096,7 @@ class TestCheckpointing:
 
     def test_save_state_serializes_populated_best_probs(self, sample_program, mocker):
         # Regression: _best_probs is dict[int, dict[str, float]] (a param-set
-        # index to its bitstring distribution), so ProgramState.best_probs must
+        # index to its bitstring distribution), so VQACheckpoint.best_probs must
         # accept nested dicts rather than a flat dict[str, float].
         sample_program.optimizer.optimize = mocker.Mock(
             side_effect=self._create_mock_optimize(sample_program, n_iterations=1)
@@ -1088,7 +1104,7 @@ class TestCheckpointing:
         sample_program.run(max_iterations=1)
         sample_program._best_probs = {0: {"01": 0.5, "10": 0.5}}
 
-        state = ProgramState.model_validate(sample_program)
+        state = VQACheckpoint.from_program(sample_program, kind="iteration")
 
         assert state.best_probs == {0: {"01": 0.5, "10": 0.5}}
 
@@ -1140,10 +1156,105 @@ class TestCheckpointing:
             [[0.1, 0.2, 0.3, 0.4]],
         )
 
-    def test_program_state_restore_applies_fields_onto_fresh_program(
+    def test_restore_state_applies_checkpoint_to_existing_program(
+        self, sample_program, mock_backend, default_optimizer, tmp_path, mocker
+    ):
+        """Ensembles can restore a program they have already reconstructed."""
+        sample_program.optimizer.optimize = mocker.Mock(
+            side_effect=self._create_mock_optimize(
+                sample_program,
+                n_iterations=3,
+                result_x=np.array([[0.1, 0.2, 0.3, 0.4]]),
+                result_fun=np.array([0.123]),
+            )
+        )
+        sample_program.run(max_iterations=3, perform_final_computation=False)
+        sample_program.save_state(CheckpointConfig(checkpoint_dir=tmp_path))
+
+        fresh = SampleVQAProgram(
+            circ_count=0,
+            run_time=0.0,
+            backend=mock_backend,
+            optimizer=default_optimizer,
+        )
+
+        restored = fresh._restore_state(tmp_path)
+
+        assert restored is fresh
+        assert fresh.current_iteration == 3
+        assert fresh._best_loss == 0.123
+        assert isinstance(fresh.optimizer, MonteCarloOptimizer)
+        np.testing.assert_allclose(fresh._best_params, [0.1, 0.2, 0.3, 0.4])
+
+    def test_restore_state_rolls_back_when_subclass_restore_fails(
+        self, sample_program, mock_backend, default_optimizer, tmp_path, mocker
+    ):
+        sample_program.optimizer.optimize = mocker.Mock(
+            side_effect=self._create_mock_optimize(sample_program)
+        )
+        sample_program.run(max_iterations=1, perform_final_computation=False)
+        sample_program.save_state(CheckpointConfig(checkpoint_dir=tmp_path))
+        fresh = SampleVQAProgram(
+            circ_count=0,
+            run_time=0.0,
+            backend=mock_backend,
+            optimizer=default_optimizer,
+        )
+        original_optimizer = fresh.optimizer
+        fresh.current_iteration = 7
+        fresh.max_iterations = 11
+        fresh.checkpointed_value = "fresh"
+        fresh._preprocessor_pipeline_cache["sentinel"] = object()
+
+        def fail_after_mutation(state):
+            fresh.checkpointed_value = "mutated"
+            fresh._preprocessor_pipeline_cache.clear()
+            raise ValueError("stale subclass state")
+
+        mocker.patch.object(fresh, "_load_subclass_state", fail_after_mutation)
+
+        with pytest.raises(ValueError, match="stale subclass state"):
+            fresh._restore_state(tmp_path)
+
+        assert fresh.current_iteration == 7
+        assert fresh.max_iterations == 11
+        assert fresh.checkpointed_value == "fresh"
+        assert "sentinel" in fresh._preprocessor_pipeline_cache
+        assert fresh.optimizer is original_optimizer
+
+    def test_restore_state_rejects_a_different_program_type(
+        self, sample_program, mock_backend, default_optimizer, tmp_path, mocker
+    ):
+        """A manifest/path mix-up cannot silently mutate the wrong program."""
+        sample_program.optimizer.optimize = mocker.Mock(
+            side_effect=self._create_mock_optimize(sample_program, n_iterations=1)
+        )
+        sample_program.run(max_iterations=1, perform_final_computation=False)
+        checkpoint = sample_program.save_state(
+            CheckpointConfig(checkpoint_dir=tmp_path)
+        )
+        state_file = checkpoint / "program_state.json"
+        state = json.loads(state_file.read_text())
+        state["program_type"] = "SomeOtherProgram"
+        state_file.write_text(json.dumps(state))
+
+        fresh = SampleVQAProgram(
+            circ_count=0,
+            run_time=0.0,
+            backend=mock_backend,
+            optimizer=default_optimizer,
+        )
+
+        with pytest.raises(ValueError, match="SomeOtherProgram"):
+            fresh._restore_state(tmp_path)
+
+        assert fresh.current_iteration == 0
+        assert fresh.optimizer is default_optimizer
+
+    def test_vqa_checkpoint_restore_applies_fields_onto_fresh_program(
         self, sample_program, mock_backend, default_optimizer, mocker
     ):
-        """ProgramState.restore() writes every mapped attribute back onto a fresh
+        """VQACheckpoint.restore() writes every mapped attribute back onto a fresh
         program (in-memory, no disk): scalars, numpy-coerced params, the ndarray
         _param_history, the nested _best_probs, and the RNG bit-generator state."""
         sample_program.optimizer.optimize = mocker.Mock(
@@ -1156,7 +1267,7 @@ class TestCheckpointing:
         )
         sample_program.run(max_iterations=3)
         sample_program._best_probs = {0: {"0101": 1.0}}
-        state = ProgramState.model_validate(sample_program)
+        state = VQACheckpoint.from_program(sample_program, kind="iteration")
 
         fresh = SampleVQAProgram(
             circ_count=0,
@@ -1177,6 +1288,112 @@ class TestCheckpointing:
         assert fresh._param_history[0].dtype == np.float64
         # RNG bit-generator state round-trips so resumed runs are reproducible.
         assert fresh._rng.bit_generator.state == sample_program._rng.bit_generator.state
+
+    def test_iterative_vqa_checkpoint_requires_optimizer_config(self, sample_program):
+        payload = VQACheckpoint.from_program(
+            sample_program, kind="iteration"
+        ).model_dump()
+        payload.pop("optimizer_config")
+
+        with pytest.raises(ValidationError, match="optimizer_config"):
+            VQACheckpoint.model_validate(payload)
+
+    def test_completed_state_round_trips_without_optimizer_checkpointing(
+        self, mock_backend, tmp_path
+    ):
+        program = SampleVQAProgram(
+            circ_count=0,
+            run_time=0.0,
+            backend=mock_backend,
+            optimizer=ScipyOptimizer(method=ScipyMethod.COBYLA),
+            seed=17,
+        )
+        program.current_iteration = 2
+        program.max_iterations = 4
+        program._losses_history = [{"0": 0.5}, {"0": 0.25}]
+        program._param_history = [
+            np.array([[0.1, 0.2, 0.3, 0.4]]),
+            np.array([[0.4, 0.3, 0.2, 0.1]]),
+        ]
+        program._best_loss = 0.25
+        program._best_params = np.array([0.4, 0.3, 0.2, 0.1])
+        program._final_params = np.array([0.4, 0.3, 0.2, 0.1])
+        program._best_probs = {0: {"01": 0.75, "10": 0.25}}
+        program._stop_reason = StopReason.PATIENCE_EXCEEDED
+        program._total_circuit_count = 12
+        program._total_run_time = 1.5
+        program.checkpointed_value = "terminal"
+        program._rng.random()
+
+        checkpoint = program._make_checkpoint(tmp_path)
+        fresh = SampleVQAProgram(
+            circ_count=0,
+            run_time=0.0,
+            backend=mock_backend,
+            optimizer=ScipyOptimizer(method=ScipyMethod.COBYLA),
+            seed=17,
+        )
+        fresh._restore_checkpoint(checkpoint.model_dump_json(), tmp_path)
+
+        assert isinstance(checkpoint, VQACheckpoint)
+        assert checkpoint.kind == "program_completion"
+        assert fresh.current_iteration == 2
+        assert fresh.max_iterations == 4
+        assert fresh._losses_history == program._losses_history
+        assert fresh._best_loss == 0.25
+        assert fresh._best_probs == program._best_probs
+        assert fresh._stop_reason is StopReason.PATIENCE_EXCEEDED
+        assert fresh._total_circuit_count == 12
+        assert fresh._total_run_time == 1.5
+        assert fresh.checkpointed_value == "terminal"
+        assert fresh._rng.bit_generator.state == program._rng.bit_generator.state
+        np.testing.assert_allclose(fresh._best_params, program._best_params)
+        np.testing.assert_allclose(fresh._final_params, program._final_params)
+        assert all(isinstance(block, np.ndarray) for block in fresh._param_history)
+
+    def test_completed_restore_rejects_an_iterative_vqa_checkpoint(
+        self, sample_program, tmp_path
+    ):
+        sample_program._best_loss = 0.0
+        checkpoint = VQACheckpoint.from_program(
+            sample_program,
+            kind="iteration",
+        )
+
+        with pytest.raises(ValueError, match="completed VQA checkpoint"):
+            sample_program._restore_checkpoint(checkpoint.model_dump_json(), tmp_path)
+
+    def test_completed_state_restore_rolls_back_when_subclass_restore_fails(
+        self, sample_program, mock_backend, default_optimizer, tmp_path, mocker
+    ):
+        sample_program.checkpointed_value = "checkpoint"
+        sample_program._best_loss = 0.0
+        checkpoint = sample_program._make_checkpoint(tmp_path)
+        fresh = SampleVQAProgram(
+            circ_count=0,
+            run_time=0.0,
+            backend=mock_backend,
+            optimizer=default_optimizer,
+        )
+        fresh.current_iteration = 7
+        fresh.max_iterations = 11
+        fresh.checkpointed_value = "fresh"
+        fresh._preprocessor_pipeline_cache["sentinel"] = object()
+
+        def fail_after_mutation(state):
+            fresh.checkpointed_value = "mutated"
+            fresh._preprocessor_pipeline_cache.clear()
+            raise ValueError("stale completed state")
+
+        mocker.patch.object(fresh, "_load_subclass_state", fail_after_mutation)
+
+        with pytest.raises(ValueError, match="stale completed state"):
+            fresh._restore_checkpoint(checkpoint.model_dump_json(), tmp_path)
+
+        assert fresh.current_iteration == 7
+        assert fresh.max_iterations == 11
+        assert fresh.checkpointed_value == "fresh"
+        assert "sentinel" in fresh._preprocessor_pipeline_cache
 
     def test_grid_search_checkpoint_round_trips(self, mock_backend, tmp_path):
         """Every optimizer that reports supports_checkpointing can be loaded back."""
@@ -1211,6 +1428,7 @@ class TestCheckpointing:
         (checkpoint / "program_state.json").write_text(
             json.dumps(
                 {
+                    "kind": "iteration",
                     "program_type": "SampleVQAProgram",
                     "current_iteration": 1,
                     "max_iterations": 1,
@@ -1247,7 +1465,7 @@ class TestCheckpointing:
             backend=mock_backend,
             optimizer=default_optimizer,
         )
-        ProgramState.model_validate(sample_program).restore(fresh)
+        VQACheckpoint.from_program(sample_program, kind="iteration").restore(fresh)
 
         assert fresh.stop_reason is StopReason.PATIENCE_EXCEEDED
 
@@ -1267,7 +1485,7 @@ class TestCheckpointing:
             optimizer=default_optimizer,
         )
         fresh._stop_reason = StopReason.COST_VARIANCE_SETTLED
-        ProgramState.model_validate(sample_program).restore(fresh)
+        VQACheckpoint.from_program(sample_program, kind="iteration").restore(fresh)
 
         assert fresh.stop_reason is None
 
@@ -1380,10 +1598,36 @@ class TestCheckpointing:
         sample_program.run(
             checkpoint_config=CheckpointConfig(
                 checkpoint_dir=tmp_path / "boundary", checkpoint_interval=2
-            )
+            ),
+            perform_final_computation=False,
         )
 
         assert sample_program.save_state.call_count == 1
+
+    def test_terminal_checkpoint_includes_final_sample(
+        self, sample_program, tmp_path, mocker
+    ):
+        """The terminal save overwrites an interval save with sampled results."""
+        sample_program.optimizer.optimize = mocker.Mock(
+            side_effect=self._create_mock_optimize(sample_program, n_iterations=1)
+        )
+
+        def sample_solution(**kwargs):
+            sample_program._best_probs = {0: {"01": 1.0}}
+            return sample_program
+
+        sample_program.sample_solution = mocker.Mock(side_effect=sample_solution)
+
+        sample_program.run(
+            checkpoint_config=CheckpointConfig(
+                checkpoint_dir=tmp_path, checkpoint_interval=1
+            )
+        )
+
+        state = json.loads(
+            (tmp_path / "checkpoint_001" / "program_state.json").read_text()
+        )
+        assert state["best_probs"] == {"0": {"01": 1.0}}
 
     def test_multiple_checkpoints_and_load_latest(
         self, sample_program, tmp_path, mocker

--- a/tests/qprog/workflows/_lassqd/test_preparation.py
+++ b/tests/qprog/workflows/_lassqd/test_preparation.py
@@ -4,6 +4,7 @@
 
 """Tests for paper-faithful LASSQD fragment-circuit preparation."""
 
+import hashlib
 from types import SimpleNamespace
 
 import numpy as np
@@ -304,7 +305,7 @@ def test_fragment_ccsd_warns_and_keeps_best_unconverged_amplitudes(mocker):
 
 
 def test_linear_method_program_prepares_classically_then_samples_once(
-    dummy_simulator, mocker
+    dummy_simulator, mocker, tmp_path
 ):
     circuit = QuantumCircuit(4)
     circuit.x(0)
@@ -348,6 +349,87 @@ def test_linear_method_program_prepares_classically_then_samples_once(
     np.testing.assert_allclose(program.h_beta, preparation.h_beta)
     np.testing.assert_allclose(program.two_body, preparation.two_body)
     np.testing.assert_allclose(program.orbital_rotation, preparation.orbital_rotation)
+
+    checkpoint = program._make_checkpoint(tmp_path)
+    restored = LinearMethodFragmentProgram(
+        np.eye(2),
+        np.eye(2),
+        np.zeros((2, 2, 2, 2)),
+        spec,
+        backend=dummy_simulator,
+        seed=7,
+    )
+    prepare.reset_mock()
+    submit.reset_mock()
+
+    restored._restore_checkpoint(checkpoint.model_dump_json(), tmp_path)
+
+    assert "phase" not in checkpoint.model_dump()
+    prepare.assert_not_called()
+    submit.assert_not_called()
+    assert restored.best_probs == program.best_probs
+    np.testing.assert_allclose(restored.best_params, program.best_params)
+    np.testing.assert_allclose(restored.h_alpha, program.h_alpha)
+    np.testing.assert_allclose(restored.h_beta, program.h_beta)
+    np.testing.assert_allclose(restored.two_body, program.two_body)
+    np.testing.assert_allclose(restored.orbital_rotation, program.orbital_rotation)
+
+    mismatched = LinearMethodFragmentProgram(
+        np.eye(2),
+        np.eye(2),
+        np.zeros((2, 2, 2, 2)),
+        spec,
+        backend=dummy_simulator,
+        seed=7,
+    )
+    mismatched_checkpoint = checkpoint.model_copy(update={"state_sha256": "0" * 64})
+
+    with pytest.raises(ValueError, match="digest"):
+        mismatched._restore_checkpoint(
+            mismatched_checkpoint.model_dump_json(), tmp_path
+        )
+    assert not mismatched.has_results()
+
+
+@pytest.mark.parametrize(
+    "missing",
+    ["params", "h_alpha", "h_beta", "two_body", "orbital_rotation"],
+)
+def test_completed_linear_method_state_requires_every_array(
+    missing, dummy_simulator, tmp_path
+):
+    arrays = {
+        "params": np.array([0.1]),
+        "h_alpha": np.eye(2),
+        "h_beta": np.eye(2),
+        "two_body": np.zeros((2, 2, 2, 2)),
+        "orbital_rotation": np.eye(2),
+    }
+    arrays.pop(missing)
+    state_path = tmp_path / "completed_state.npz"
+    np.savez(state_path, **arrays)
+    with state_path.open("rb") as handle:
+        state_sha256 = hashlib.file_digest(handle, "sha256").hexdigest()
+    program = LinearMethodFragmentProgram(
+        np.eye(2),
+        np.eye(2),
+        np.zeros((2, 2, 2, 2)),
+        FragmentSpec(orbitals=(0, 1), n_alpha=1, n_beta=1),
+        backend=dummy_simulator,
+    )
+
+    with pytest.raises(ValueError, match="missing or extra arrays"):
+        checkpoint = preparation._LinearMethodCheckpoint(
+            program_type="LinearMethodFragmentProgram",
+            total_circuit_count=0,
+            total_run_time=0.0,
+            state_file="completed_state.npz",
+            state_sha256=state_sha256,
+            best_probs={0: {"0011": 1.0}},
+        )
+        program._restore_checkpoint(checkpoint.model_dump_json(), tmp_path)
+
+    assert not program.has_results()
 
 
 def test_rotates_sqd_rdms_back_to_the_workflow_fragment_basis():

--- a/tests/qprog/workflows/_lassqd/test_workflow.py
+++ b/tests/qprog/workflows/_lassqd/test_workflow.py
@@ -2043,3 +2043,84 @@ def test_two_fragment_h4_lands_on_the_product_state_energy(
 
     assert ensemble.energy > casci, "a product state cannot beat CASCI"
     assert ensemble.energy <= mean_field.e_tot + 1e-5
+
+
+def test_workflow_checkpoint_state_round_trips_npz(
+    exact_sampler_lassqd, tmp_path, mocker
+):
+    exact_sampler_lassqd, state = exact_sampler_lassqd
+    fragment = state.fragments[0]
+    state = LASSQDState(
+        mo_coeff=state.mo_coeff + 0.125,
+        fragments=(
+            FragmentState(
+                spec=fragment.spec,
+                rdm1=fragment.rdm1 + 0.1,
+                rdm2=fragment.rdm2 + 0.2,
+                params=np.arange(3, dtype=float),
+                rdm1_alpha=fragment.rdm1 / 3,
+                rdm1_beta=fragment.rdm1 * 2 / 3,
+            ),
+            state.fragments[1],
+        ),
+        energy=-1.25,
+        previous_energy=-1.0,
+        orbitals_converged=False,
+    )
+    exact_sampler_lassqd._energy_history = [-1.0, -1.25]
+    exact_sampler_lassqd._round_reports = [
+        _workflow.LASSQDRoundReport(
+            number=1,
+            energy=-1.25,
+            energy_change=-0.25,
+            subspace_sizes=(2,),
+            orbital_iterations=3,
+            orbital_evaluations=4,
+            orbital_gradient_norm=0.01,
+            orbital_converged=False,
+            rotation_pairs=5,
+            recovery_seconds=0.2,
+            orbital_seconds=0.3,
+        )
+    ]
+    solver = exact_sampler_lassqd._solver_for(0, fragment.spec)
+    solver.occupancy[:] = 0.375
+    expected_rng_state = exact_sampler_lassqd._rng.bit_generator.state
+
+    payload = exact_sampler_lassqd._save_workflow_checkpoint_state(
+        state, tmp_path, "output_state"
+    )
+    exact_sampler_lassqd._rng.random()
+    exact_sampler_lassqd._energy_history.clear()
+    exact_sampler_lassqd._solvers.clear()
+    seed_spy = mocker.spy(exact_sampler_lassqd.backend, "set_seed")
+
+    restored = exact_sampler_lassqd._load_workflow_checkpoint_state(
+        payload, tmp_path, "output_state"
+    )
+
+    np.testing.assert_array_equal(restored.mo_coeff, state.mo_coeff)
+    np.testing.assert_array_equal(restored.fragments[0].rdm2, state.fragments[0].rdm2)
+    np.testing.assert_array_equal(restored.fragments[0].params, [0.0, 1.0, 2.0])
+    assert restored.energy == -1.25
+    assert restored.previous_energy == -1.0
+    assert not restored.orbitals_converged
+    assert exact_sampler_lassqd.energy_history == (-1.0, -1.25)
+    assert exact_sampler_lassqd.round_reports[0].subspace_sizes == (2,)
+    assert exact_sampler_lassqd._rng.bit_generator.state == expected_rng_state
+    np.testing.assert_array_equal(exact_sampler_lassqd._solvers[0].occupancy, 0.375)
+    seed_spy.assert_called_once_with(exact_sampler_lassqd._seed)
+
+
+def test_workflow_checkpoint_rejects_a_different_explicit_fragment_layout(
+    exact_sampler_lassqd, dummy_expval_backend, tmp_path
+):
+    source, state = exact_sampler_lassqd
+    payload = source._save_workflow_checkpoint_state(state, tmp_path, "output_state")
+    target = _lassqd(
+        dummy_expval_backend,
+        active_spaces=[FragmentSpec(orbitals=(0, 1, 2, 3), n_alpha=2, n_beta=2)],
+    )
+
+    with pytest.raises(ValueError, match="fragment layout"):
+        target._load_workflow_checkpoint_state(payload, tmp_path, "output_state")

--- a/tests/qprog/workflows/test_partitioning_ensemble.py
+++ b/tests/qprog/workflows/test_partitioning_ensemble.py
@@ -3,13 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import networkx as nx
+import numpy as np
 import pytest
 
 from divi.qprog import QAOA, VariationalQuantumAlgorithm
 from divi.qprog._solution_sampling_mixin import SolutionEntry
 from divi.qprog.aggregation import BeamSearchStrategy, HierarchicalStrategy
+from divi.qprog.checkpointing import CheckpointConfig
 from divi.qprog.optimizers import ScipyMethod, ScipyOptimizer
 from divi.qprog.problems import (
+    BinaryOptimizationProblem,
     MaxCutProblem,
     MaxWeightMatchingProblem,
     is_valid_matching,
@@ -119,6 +122,36 @@ def _attach_program_with_candidates(ensemble, mocker, decoded_candidates):
 
 
 class TestPartitioningProgramEnsemble:
+    def test_checkpointing_rejects_arbitrary_binary_decomposer(
+        self, dummy_simulator, tmp_path
+    ):
+        hybrid = pytest.importorskip("hybrid")
+        qubo = np.ones((4, 4)) - np.eye(4)
+        problem = BinaryOptimizationProblem(
+            qubo, decomposer=hybrid.EnergyImpactDecomposer(size=2)
+        )
+        ensemble = _make_ensemble(problem, dummy_simulator)
+
+        with pytest.raises(ValueError, match="deterministic decomposer"):
+            ensemble.run(checkpoint_config=CheckpointConfig(checkpoint_dir=tmp_path))
+
+    def test_checkpointing_accepts_seeded_community_decomposer(
+        self, dummy_simulator, tmp_path
+    ):
+        decomposers = pytest.importorskip(
+            "divi.qprog.problems._community_decomposer",
+            reason="requires the 'qubo-decompose' extra",
+        )
+        qubo = np.ones((4, 4)) - np.eye(4)
+        problem = BinaryOptimizationProblem(
+            qubo, decomposer=decomposers.CommunityDecomposer(max_cluster_size=2)
+        )
+        ensemble = _make_ensemble(problem, dummy_simulator)
+
+        ensemble.run(checkpoint_config=CheckpointConfig(checkpoint_dir=tmp_path))
+
+        assert (tmp_path / "round_001" / "round_completion.json").is_file()
+
     def test_aggregate_results_calls_problem_hooks(self, mocker, dummy_simulator):
         problem = _make_stub_problem(mocker, solution_size=2)
         ensemble = _make_ensemble(problem, dummy_simulator)

--- a/tests/qprog/workflows/test_time_evolution_trajectory.py
+++ b/tests/qprog/workflows/test_time_evolution_trajectory.py
@@ -12,6 +12,7 @@ from qiskit.quantum_info import SparsePauliOp
 from divi.hamiltonians import ExactTrotterization, QDrift
 from divi.qprog import TimeEvolutionTrajectory
 from divi.qprog.algorithms import TimeEvolution
+from divi.qprog.checkpointing import CheckpointConfig
 from divi.qprog.ensemble import BatchConfig, BatchMode
 from divi.qprog.workflows import _time_evolution_trajectory as workflow
 
@@ -163,6 +164,30 @@ class TestTimeEvolutionTrajectoryCreatePrograms:
 
 
 class TestTimeEvolutionTrajectoryRun:
+    def test_checkpointing_never_passes_vqa_arguments(
+        self, two_qubit_hamiltonian, dummy_simulator, tmp_path, mocker
+    ):
+        traj = TimeEvolutionTrajectory(
+            hamiltonian=two_qubit_hamiltonian,
+            time_points=[0.5, 1.0],
+            backend=dummy_simulator,
+        )
+        run_spy = mocker.spy(TimeEvolution, "run")
+
+        traj.run(checkpoint_config=CheckpointConfig(checkpoint_dir=tmp_path))
+
+        assert run_spy.call_count == 2
+        assert all(
+            "checkpoint_config" not in call.kwargs for call in run_spy.call_args_list
+        )
+        restored = TimeEvolutionTrajectory(
+            hamiltonian=two_qubit_hamiltonian,
+            time_points=[0.5, 1.0],
+            backend=dummy_simulator,
+        )
+        restored.restore_state(tmp_path).run()
+        assert restored.stop_reason.value == "complete"
+
     def test_run_probs_mode(self, two_qubit_hamiltonian, default_test_simulator):
         traj = TimeEvolutionTrajectory(
             hamiltonian=two_qubit_hamiltonian,

--- a/tests/qprog/workflows/test_vqe_sweep.py
+++ b/tests/qprog/workflows/test_vqe_sweep.py
@@ -11,6 +11,7 @@ from qiskit.quantum_info import SparsePauliOp
 from scipy.spatial.distance import pdist, squareform
 
 from divi.qprog.algorithms import GenericLayerAnsatz, HartreeFockAnsatz, UCCSDAnsatz
+from divi.qprog.checkpointing import CheckpointConfig
 from divi.qprog.optimizers import MonteCarloOptimizer
 from divi.qprog.workflows import (
     MoleculeTransformer,
@@ -436,6 +437,26 @@ def vqe_sweep_hamiltonian(
 
 
 class TestVQEHyperparameterSweep:
+    def test_child_checkpoints_use_distinct_derived_directories(
+        self, vqe_sweep_hamiltonian, tmp_path
+    ):
+        vqe_sweep_hamiltonian.create_programs()
+        vqe_sweep_hamiltonian._round_index = 1
+        original = CheckpointConfig(checkpoint_dir=tmp_path, checkpoint_interval=2)
+
+        session = vqe_sweep_hamiltonian._prepare_checkpoint_session(None, original)
+        configs = session.iterative_config_by_program
+
+        assert set(configs) == set(vqe_sweep_hamiltonian.programs.values())
+        paths = [config.checkpoint_dir for config in configs.values()]
+        assert len(set(paths)) == len(paths)
+        assert {path.name for path in paths} == {
+            f"program_{slot:03d}" for slot in range(len(paths))
+        }
+        assert {path.parent.name for path in paths} == {"round_001"}
+        assert all(config.checkpoint_interval == 2 for config in configs.values())
+        assert original.checkpoint_dir == tmp_path
+
     """A test class to group all tests for the VQEHyperparameterSweep."""
 
     def test_sampling_backend_is_owned_by_ensemble(

--- a/tutorials/advanced/checkpointing.py
+++ b/tutorials/advanced/checkpointing.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Demonstrates checkpointing functionality for variational quantum algorithms.
+"""Demonstrates checkpointing for quantum programs and program ensembles.
 
 This example shows how to:
 - Save checkpoints during optimization
@@ -10,6 +10,7 @@ This example shows how to:
 - Adjust iteration targets after loading
 - List and inspect checkpoints
 - Sample directly from a checkpoint's parameters via ``sample_solution``
+- Restore a completed ensemble without rerunning its children
 """
 
 import shutil
@@ -18,7 +19,12 @@ from pathlib import Path
 import numpy as np
 import pennylane as qp
 
-from divi.qprog import VQE, HartreeFockAnsatz
+from divi.qprog import (
+    VQE,
+    HartreeFockAnsatz,
+    MoleculeTransformer,
+    VQEHyperparameterSweep,
+)
 from divi.qprog.checkpointing import (
     CheckpointConfig,
     get_checkpoint_info,
@@ -32,6 +38,7 @@ if __name__ == "__main__":
     # Set up checkpoint directories
     checkpoint_dir = Path("checkpoint_demo")
     checkpoint_dir_interval = Path("checkpoint_demo_interval")
+    ensemble_checkpoint_dir = Path("checkpoint_demo_ensemble")
 
     try:
         # Create molecule
@@ -147,11 +154,42 @@ if __name__ == "__main__":
         print(f"Circuits used (measurement only): {vqe4.total_circuit_count}")
 
         print("\n" + "=" * 60)
+        print("Step 6: Restore a completed program ensemble")
+        print("=" * 60)
+
+        transformer = MoleculeTransformer(base_molecule=mol, bond_modifiers=[0.0])
+        sweep = VQEHyperparameterSweep(
+            molecule_transformer=transformer,
+            ansatze=[HartreeFockAnsatz()],
+            optimizer=MonteCarloOptimizer(population_size=10),
+            max_iterations=1,
+            backend=get_backend(),
+        )
+        sweep.run(
+            checkpoint_config=CheckpointConfig(checkpoint_dir=ensemble_checkpoint_dir)
+        )
+
+        restored_sweep = VQEHyperparameterSweep(
+            molecule_transformer=transformer,
+            ansatze=[HartreeFockAnsatz()],
+            optimizer=MonteCarloOptimizer(population_size=10),
+            max_iterations=1,
+            backend=get_backend(),
+        ).restore_state(ensemble_checkpoint_dir)
+        restored_sweep.run()
+        print(f"Restored rounds: {len(restored_sweep.round_history)}")
+        print(f"Restored circuits: {restored_sweep.total_circuit_count}")
+
+        print("\n" + "=" * 60)
         print("Checkpointing demo complete!")
         print("=" * 60)
     finally:
         # Clean up checkpoint directories
-        for dir_path in [checkpoint_dir, checkpoint_dir_interval]:
+        for dir_path in [
+            checkpoint_dir,
+            checkpoint_dir_interval,
+            ensemble_checkpoint_dir,
+        ]:
             if dir_path.exists():
                 shutil.rmtree(dir_path)
                 print(f"Cleaned up: {dir_path}")


### PR DESCRIPTION
`ProgramEnsemble` now saves a checkpoint at every round boundary and restores onto an equivalently constructed instance, so an interrupted run resumes instead of starting over.

Within an interrupted round it reruns only work that no valid child artifact represents:

- programs own their terminal state via `_make_checkpoint` / `_restore_checkpoint`
- a per-run `_RoundCheckpointSession` owns manifests, child directories, recovery precedence and represented accounting
- recovery order is completed marker, then iterative VQA checkpoint, then fresh execution

Partition children became eligible for reuse by making every built-in decomposition reproducible rather than by fingerprinting content: `kernighan_lin` and max-weight-matching bisection are seeded, the spectral start vector is fixed, partition ordering is canonicalised, and non-reproducible binary decomposers are rejected before dispatch.

Checkpoint writes now `fsync` the file and its directory, so "marker written last" survives a crash rather than only a process exit.

## Verification

- full suite: 4755 passed, 33 skipped, no warnings summary
- `pyrefly`: 0 errors, suppressions unchanged at 76
- docs build + 202 snippet tests pass; tutorials dry-run passes
- `make spelling`: 2 pre-existing misspellings remain in files this branch does not touch (`nonterminal` in `_characterization.py`, `sqd` in a generated autosummary signature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)